### PR TITLE
Add Github workflow for mirroring `main` branch

### DIFF
--- a/.github/workflows/mirror-main.yml
+++ b/.github/workflows/mirror-main.yml
@@ -1,0 +1,27 @@
+name: Mirror Master Branch
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  mirror:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Git
+        run: |
+          git config --global user.email "github-actions[bot]@users.no-reply.github.com"
+          git config --global user.name "github-actions[bot]"
+
+      - name: Mirror master
+        env:
+          GITHUB_TOKEN: ${{ secrets.PAT }}
+        run: |
+          git fetch origin main
+          git update-ref refs/heads/main-mirror refs/remotes/origin/main
+          git push --force origin main-mirror


### PR DESCRIPTION
This is needed to have a static DNS entry (e.g., `v2.staging.researchhub.com`) pointing always pointing to the `main` branch in staging.