### PR TITLE
Stop sending content-type header for GET requests

### DIFF
--- a/services/client.ts
+++ b/services/client.ts
@@ -51,11 +51,14 @@ export class ApiClient {
     }
   }
 
-  private static async getHeaders() {
+  private static async getHeaders(method: string) {
     const headers: Record<string, string> = {
-      'Content-Type': 'application/json',
       Accept: 'application/json',
     };
+
+    if (method !== 'GET') {
+      headers['Content-Type'] = 'application/json';
+    }
 
     const authToken = await this.getAuthToken();
     if (authToken) {
@@ -97,7 +100,7 @@ export class ApiClient {
 
   static async get<T>(path: string): Promise<T> {
     try {
-      const headers = await this.getHeaders();
+      const headers = await this.getHeaders('GET');
       const response = await fetch(`${this.baseURL}${path}`, this.getFetchOptions('GET', headers));
 
       if (!response.ok) {
@@ -125,8 +128,7 @@ export class ApiClient {
    */
   static async getBlob(path: string): Promise<Blob> {
     try {
-      const headers = await this.getHeaders();
-      delete headers['Content-Type']; // Remove Content-Type for blob response
+      const headers = await this.getHeaders('GET');
       delete headers['Accept']; // Remove Accept header to allow blob response
 
       const response = await fetch(`${this.baseURL}${path}`, {
@@ -146,7 +148,7 @@ export class ApiClient {
   }
 
   static async post<T>(path: string, body?: any): Promise<T> {
-    const headers = await this.getHeaders();
+    const headers = await this.getHeaders('POST');
     const response = await fetch(
       `${this.baseURL}${path}`,
       this.getFetchOptions('POST', headers, body)
@@ -167,7 +169,7 @@ export class ApiClient {
   }
 
   static async patch<T>(path: string, body?: any): Promise<T> {
-    const headers = await this.getHeaders();
+    const headers = await this.getHeaders('PATCH');
     const response = await fetch(
       `${this.baseURL}${path}`,
       this.getFetchOptions('PATCH', headers, body)
@@ -182,7 +184,7 @@ export class ApiClient {
 
   static async delete<T>(path: string, body?: any): Promise<T> {
     try {
-      const headers = await this.getHeaders();
+      const headers = await this.getHeaders('DELETE');
       const response = await fetch(
         `${this.baseURL}${path}`,
         this.getFetchOptions('DELETE', headers, body)


### PR DESCRIPTION
The current API client attaches a `content-type` header to every request, even `GET` request that don't have any content (payload). The `content-type` header with the value `application/json` is considered "unsafe" and therefore triggered a CORS preflight request on every API call (see screenshot below).

This change removes the `content-type` header for all `GET` requests.

<img width="1393" alt="image" src="https://github.com/user-attachments/assets/0e25bb4f-30a5-485a-a8f5-b3f31a3199d6" />
