### PR TITLE
Fix Menu Closing Issue with VerificationBanner

### DIFF
--- a/components/banners/VerificationBanner.tsx
+++ b/components/banners/VerificationBanner.tsx
@@ -5,9 +5,19 @@ import { X, BadgeCheck, ChevronRight } from 'lucide-react';
 interface VerificationBannerProps {
   onClose: () => void;
   onLearnMore?: () => void;
+  onMenuClose?: () => void;
 }
 
-export default function VerificationBanner({ onClose, onLearnMore }: VerificationBannerProps) {
+export default function VerificationBanner({
+  onClose,
+  onLearnMore,
+  onMenuClose,
+}: VerificationBannerProps) {
+  const handleLearnMoreClick = (e: React.MouseEvent) => {
+    onMenuClose?.();
+    onLearnMore?.();
+  };
+
   return (
     <div className="bg-indigo-50 p-3 rounded-lg">
       <div className="flex justify-between items-start">
@@ -31,7 +41,7 @@ export default function VerificationBanner({ onClose, onLearnMore }: Verificatio
             </li>
           </ul>
           <button
-            onClick={onLearnMore}
+            onClick={handleLearnMoreClick}
             className="text-xs text-indigo-600 hover:text-indigo-700 font-medium flex items-center"
           >
             Learn more

--- a/components/menus/UserMenu.tsx
+++ b/components/menus/UserMenu.tsx
@@ -30,6 +30,7 @@ export default function UserMenu({ user, onViewProfile, onVerifyAccount }: UserM
   const { address, isConnected } = useAccount();
   const [isWalletModalOpen, setIsWalletModalOpen] = useState(false);
   const [isVerifyModalOpen, setIsVerifyModalOpen] = useState(false);
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
 
   const handleLearnMore = () => {
     setIsVerifyModalOpen(true);
@@ -52,6 +53,10 @@ export default function UserMenu({ user, onViewProfile, onVerifyAccount }: UserM
     setIsVerifyModalOpen(false);
   };
 
+  const handleCloseMenu = () => {
+    setIsMenuOpen(false);
+  };
+
   const trigger = (
     <button className="hover:ring-2 hover:ring-gray-200 rounded-full p-1 relative">
       <Avatar src={user.authorProfile?.profileImage} alt={user.fullName} size={34} />
@@ -72,6 +77,8 @@ export default function UserMenu({ user, onViewProfile, onVerifyAccount }: UserM
         className="w-64 p-0"
         withOverlay={true}
         animate
+        open={isMenuOpen}
+        onOpenChange={setIsMenuOpen}
       >
         {/* User info section */}
         <div className="px-4 py-3 border-b border-gray-200">
@@ -176,6 +183,7 @@ export default function UserMenu({ user, onViewProfile, onVerifyAccount }: UserM
             <VerificationBanner
               onClose={() => setShowVerificationBanner(false)}
               onLearnMore={handleLearnMore}
+              onMenuClose={handleCloseMenu}
             />
           </div>
         )}

--- a/components/ui/form/BaseMenu.tsx
+++ b/components/ui/form/BaseMenu.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { FC, ReactNode, useState } from 'react';
+import { FC, ReactNode, useState, useEffect } from 'react';
 import * as DropdownMenu from '@radix-ui/react-dropdown-menu';
 import * as Portal from '@radix-ui/react-portal';
 import { Transition } from '@headlessui/react';
@@ -17,6 +17,7 @@ interface BaseMenuProps {
   onOpenChange?: (open: boolean) => void;
   disabled?: boolean;
   sameWidth?: boolean;
+  open?: boolean;
 }
 
 export const BaseMenu: FC<BaseMenuProps> = ({
@@ -30,8 +31,26 @@ export const BaseMenu: FC<BaseMenuProps> = ({
   onOpenChange,
   disabled = false,
   sameWidth = false,
+  open,
 }) => {
-  const [isOpen, setIsOpen] = useState(false);
+  const [isOpenInternal, setIsOpenInternal] = useState(false);
+
+  const isOpen = open !== undefined ? open : isOpenInternal;
+
+  useEffect(() => {
+    if (open !== undefined) {
+      setIsOpenInternal(open);
+    }
+  }, [open]);
+
+  const handleOpenChange = (newOpen: boolean) => {
+    if (!disabled) {
+      if (open === undefined) {
+        setIsOpenInternal(newOpen);
+      }
+      onOpenChange?.(newOpen);
+    }
+  };
 
   return (
     <>
@@ -49,19 +68,12 @@ export const BaseMenu: FC<BaseMenuProps> = ({
             <div
               className="fixed inset-0 bg-black/[0.15]"
               style={{ zIndex: 99999 }}
-              onClick={() => setIsOpen(false)}
+              onClick={() => handleOpenChange(false)}
             />
           </Transition>
         </Portal.Root>
       )}
-      <DropdownMenu.Root
-        onOpenChange={(open) => {
-          if (!disabled) {
-            setIsOpen(open);
-            onOpenChange?.(open);
-          }
-        }}
-      >
+      <DropdownMenu.Root open={isOpen} onOpenChange={handleOpenChange}>
         <DropdownMenu.Trigger disabled={disabled} asChild>
           {trigger}
         </DropdownMenu.Trigger>


### PR DESCRIPTION
What?
=====
- **Bug**🐛🐛🐛 When a user clicks the "Learn More" link in the `VerificationBanner` component within the `UserMenu` dropdown, the modal opens correctly but the dropdown menu remains open, creating a confusing UI where both elements are visible simultaneously. Due to the higher z-index of the `BaseMenu`, the modal becomes inaccessible to users, preventing interaction with the verification flow 😥

How?
=====
- Implemented external state management for the `BaseMenu` component to allow proper control of its open/closed state from parent components. This pattern enables the `UserMenu` component to programmatically close the dropdown when the _"Learn More"_ link is clicked, ensuring the modal is fully accessible.