### PR TITLE
fix: Add `self` for camera access

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -8,7 +8,7 @@ const nextConfig = {
         {
           key: 'Permissions-Policy',
           value:
-            'camera=("https://*.withpersona.com/"), geolocation=(), gyroscope=(), microphone=()',
+            'camera=(self "https://*.withpersona.com/"), geolocation=(), gyroscope=(), microphone=()',
         },
         {
           key: 'Referrer-Policy',


### PR DESCRIPTION
The `Permissions-Policy` header must also allow `self` for camera access.