### PR TITLE
Fix Image Display in Post Detail Page

### DIFF
--- a/components/Editor/extensions/ImageBlock/ImageBlock.ts
+++ b/components/Editor/extensions/ImageBlock/ImageBlock.ts
@@ -60,7 +60,7 @@ export const ImageBlock = Image.extend({
   parseHTML() {
     return [
       {
-        tag: 'img[src*="tiptap.dev"]:not([src^="data:"]), img[src*="windows.net"]:not([src^="data:"])',
+        tag: 'img:not([src^="data:"])',
       },
     ];
   },

--- a/hooks/useNote.ts
+++ b/hooks/useNote.ts
@@ -219,8 +219,8 @@ export const useUpdateNote = (noteId: ID, options: UpdateNoteOptions = {}): UseU
   const [error, setError] = useState<Error | null>(null);
   const titleRef = useRef<string>('');
 
-  const debouncedUpdate = useRef<DebouncedFunc<(editor: Editor) => Promise<void>>>(
-    debounce(async (editor: Editor) => {
+  const debouncedUpdate = useRef<DebouncedFunc<(editor: Editor, noteId: ID) => Promise<void>>>(
+    debounce(async (editor: Editor, noteId: ID) => {
       if (!editor || !noteId) {
         console.error('Editor or noteId is undefined in debouncedUpdate', { editor, noteId });
         return;
@@ -277,7 +277,7 @@ export const useUpdateNote = (noteId: ID, options: UpdateNoteOptions = {}): UseU
         console.error('Editor is undefined in updateNote');
         return;
       }
-      debouncedUpdate.current(editor);
+      debouncedUpdate.current(editor, noteId);
     },
     [noteId]
   );


### PR DESCRIPTION
## What?
- On the most recent pre-registration, in the new app, I noticed the images are no longer being rendered. I'm using google chrome and checked both when I'm logged in and in cognito as well. [Slack thread](https://researchhubfoundation.slack.com/archives/C0897LR58B1/p1744748397064509)
- This was due to overly restrictive image parsing rules that only allowed images from specific domains (`tiptap.dev` and `windows.net`).

## How?
- Modified the `ImageBlock` extension to accept images from any valid URL while maintaining security by excluding data URLs. This allows the BlockEditor to properly render all images in post content.
