### PR TITLE
Render Legacy Figure Elements in the Tiptap Editor

### DIFF
--- a/components/Editor/extensions/ReadOnlyFigure/index.ts
+++ b/components/Editor/extensions/ReadOnlyFigure/index.ts
@@ -1,0 +1,1 @@
+export * from './read-only-figure';

--- a/components/Editor/extensions/ReadOnlyFigure/read-only-figure.ts
+++ b/components/Editor/extensions/ReadOnlyFigure/read-only-figure.ts
@@ -1,0 +1,101 @@
+import { Node, mergeAttributes } from '@tiptap/core';
+import { Plugin, PluginKey } from '@tiptap/pm/state';
+import { Decoration, DecorationSet } from '@tiptap/pm/view';
+
+export const ReadOnlyFigure = Node.create({
+  name: 'figure',
+
+  group: 'block',
+
+  content: 'block*',
+
+  parseHTML() {
+    return [
+      {
+        tag: 'figure',
+        preserveWhitespace: 'full',
+        getAttrs: (element) => {
+          const htmlElement = element as HTMLElement;
+          return {
+            originalContent: htmlElement.innerHTML,
+            class: htmlElement.getAttribute('class') || '',
+          };
+        },
+      },
+    ];
+  },
+
+  addAttributes() {
+    return {
+      originalContent: {
+        default: '',
+        parseHTML: (element) => element.innerHTML,
+        renderHTML: (attrs) => ({
+          'data-original-content': attrs.originalContent,
+        }),
+      },
+      class: {
+        default: '',
+      },
+    };
+  },
+
+  renderHTML({ node, HTMLAttributes }) {
+    // Create a temporary div to parse the HTML string into DOM elements
+    const tempDiv = document.createElement('div');
+    tempDiv.innerHTML = node.attrs.originalContent || '';
+
+    return [
+      'figure',
+      mergeAttributes(HTMLAttributes, {
+        class: node.attrs.class,
+      }),
+      // Spread the child nodes from the parsed content
+      ...Array.from(tempDiv.childNodes),
+    ];
+  },
+
+  addProseMirrorPlugins() {
+    const plugin = new Plugin({
+      key: new PluginKey('readOnlyFigure'),
+      props: {
+        handleClick: (view, pos) => {
+          const node = view.state.doc.nodeAt(pos);
+          if (node?.type.name === 'figure') {
+            return true;
+          }
+          return false;
+        },
+        handleKeyDown: (view, event) => {
+          const { selection } = view.state;
+          const node = view.state.doc.nodeAt(selection.from);
+
+          if (node?.type.name === 'figure') {
+            if (event.key === 'Backspace' || event.key === 'Delete' || event.key === 'Enter') {
+              return true;
+            }
+          }
+          return false;
+        },
+        decorations: (state) => {
+          const { doc } = state;
+          const decorations: Decoration[] = [];
+
+          doc.descendants((node, pos) => {
+            if (node.type.name === 'figure') {
+              decorations.push(
+                Decoration.node(pos, pos + node.nodeSize, {
+                  class: 'readonly-node',
+                })
+              );
+            }
+          });
+
+          return DecorationSet.create(doc, decorations);
+        },
+      },
+    });
+
+    return [plugin];
+  },
+});

--- a/components/Editor/extensions/extension-kit.ts
+++ b/components/Editor/extensions/extension-kit.ts
@@ -55,6 +55,7 @@ import { isChangeOrigin } from '@tiptap/extension-collaboration';
 import { AnyExtension } from '@tiptap/core';
 import { PlaceholderOptions } from '@tiptap/extension-placeholder';
 import { Youtube } from './Youtube';
+import { ReadOnlyFigure } from './ReadOnlyFigure';
 
 interface ExtensionKitProps {
   provider?: HocuspocusProvider | null;
@@ -173,6 +174,7 @@ export const ExtensionKit = ({
     class: 'ProseMirror-dropcursor border-black',
   }),
   Youtube,
+  ReadOnlyFigure,
 ];
 
 export default ExtensionKit;

--- a/components/Editor/styles/index.css
+++ b/components/Editor/styles/index.css
@@ -44,3 +44,4 @@
 @import './partials/placeholder.css';
 @import './partials/table.css';
 @import './partials/typography.css';
+@import './partials/readonly.css';

--- a/components/Editor/styles/partials/readonly.css
+++ b/components/Editor/styles/partials/readonly.css
@@ -1,0 +1,10 @@
+.readonly-node {
+  position: relative;
+  pointer-events: none; /* Prevents interaction with the content */
+}
+
+/* Allow interaction with iframes/videos inside readonly nodes */
+.readonly-node iframe,
+.readonly-node video {
+  pointer-events: all;
+}


### PR DESCRIPTION
## What?
- Created `ReadOnlyFigure` extension to render legacy HTML content (e.g., YouTube embeds from Quill editor)
- hide the heading from the Post body

## What to test
- [ ] Legacy figure elements (like YouTube embeds, or videos) render correctly
- [ ] Interactive elements within figures (like video controls) remain functional
