### PR TITLE
fix: Use correct storage hostname as fallback

### DIFF
--- a/services/file.service.ts
+++ b/services/file.service.ts
@@ -61,7 +61,8 @@ export class FileService {
 
       // Extract the absolute URL from the presigned URL
       const path = presigned_url.split('?')[0].split('.com/')[1];
-      const storageDomain = process.env.NEXT_PUBLIC_STORAGE_DOMAIN || 'storage.researchhub.com';
+      const storageDomain =
+        process.env.NEXT_PUBLIC_STORAGE_DOMAIN || 'storage.prod.researchhub.com';
       const absoluteUrl = `https://${storageDomain}/${path}`;
 
       return {


### PR DESCRIPTION
The fallback value for the storage hostname is incorrect. It should read `storage.prod.researchhub.com`.