### PR TITLE
Change FeedItemPaper action text

### DIFF
--- a/components/Feed/items/FeedItemPaper.tsx
+++ b/components/Feed/items/FeedItemPaper.tsx
@@ -129,14 +129,14 @@ export const FeedItemPaper: FC<FeedItemPaperProps> = ({ entry, href, showTooltip
   // Determine if card should have clickable styles
   const isClickable = !!href;
 
+  // Construct the dynamic action text
+  const journalName = paper.journal?.name;
+  const actionText = journalName ? `published in ${journalName}` : 'published in a journal';
+
   return (
     <div className="space-y-3">
       {/* Header */}
-      <FeedItemHeader
-        timestamp={paper.createdDate}
-        author={author}
-        actionText="published a paper"
-      />
+      <FeedItemHeader timestamp={paper.createdDate} author={author} actionText={actionText} />
 
       {/* Main Content Card - Using onClick instead of wrapping with Link */}
       <div


### PR DESCRIPTION
"{Author} published a paper" was misleading --> "{Author} published in {journal.name}"
- Fallback to "in a journal"
<img width="820" alt="Screenshot 2025-05-08 at 3 10 25 PM" src="https://github.com/user-attachments/assets/97a7cf6a-411f-4613-a6b7-adf6b55831dc" />
