### PR TITLE
Fix nonprofit render in Notebook

### DIFF
--- a/app/notebook/components/PublishingForm/components/FundingSection.tsx
+++ b/app/notebook/components/PublishingForm/components/FundingSection.tsx
@@ -112,19 +112,21 @@ export function FundingSection({ note }: FundingSectionProps) {
       {fundraise ? (
         <>
           <FundraiseSection fundraise={fundraise} />
-          {(isLoadingNonprofit || nonprofit || isEditingNonprofit) && (
-            <div className="pt-4 border-t border-gray-200">
-              {isEditingNonprofit || !nonprofit ? (
-                <NonprofitSearchSection />
-              ) : (
-                <NonprofitSearchSection
-                  readOnly={false}
-                  allowClear={true}
-                  onClear={() => setIsEditingNonprofit(true)}
-                />
-              )}
-            </div>
-          )}
+          <div className="pt-4 border-t border-gray-200">
+            {isLoadingNonprofit ? (
+              <p className="text-sm text-gray-500 px-1">Loading nonprofit information...</p>
+            ) : isEditingNonprofit || !nonprofit ? (
+              <NonprofitSearchSection />
+            ) : (
+              <NonprofitSearchSection
+                readOnly={false}
+                allowClear={true}
+                onClear={() => {
+                  setIsEditingNonprofit(true);
+                }}
+              />
+            )}
+          </div>
         </>
       ) : (
         <>


### PR DESCRIPTION
**Problem**:
Preregistrations published without a nonprofit were unable to add a nonprofit to republish. 

**Solution**:
Changed the conditional to display the NonprofitSearchSection when the note is already published but doesn't have a nonprofit attached.

<img width="1502" alt="Screenshot 2025-05-09 at 11 25 58 AM" src="https://github.com/user-attachments/assets/572c294f-4810-4a13-abee-41817ff72e44" />

