### PR TITLE
Disable auto-capitalization of login email address

### DIFF
--- a/components/Auth/screens/Login.tsx
+++ b/components/Auth/screens/Login.tsx
@@ -74,6 +74,7 @@ export default function Login({
           type="email"
           value={email}
           autoCapitalize="none"
+          autoComplete="email"
           className="w-full p-3 border rounded mb-4 bg-gray-50"
           disabled
         />

--- a/components/Auth/screens/SelectProvider.tsx
+++ b/components/Auth/screens/SelectProvider.tsx
@@ -77,6 +77,7 @@ export default function SelectProvider({
           onChange={(e) => setEmail(e.target.value)}
           placeholder="Email"
           autoCapitalize="none"
+          autoComplete="email"
           className="w-full p-3 border rounded mb-4"
           autoFocus
         />


### PR DESCRIPTION
- On mobile, disable auto-capitalization of email address in login field.
- Allow auto-completion of email address in login field.

See: https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/autocapitalize
See: https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/autocomplete