### PR TITLE
Add title tag to pages

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -54,6 +54,9 @@ export default async function RootLayout({
 
   return (
     <html lang="en">
+      <head>
+        <title>ResearchHub | Open Science Community</title>
+      </head>
       <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
         <ClickProvider>
           <OnchainProvider>


### PR DESCRIPTION
Without a title, the hostname gets displayed as the page title:

<img width="661" alt="image" src="https://github.com/user-attachments/assets/ee82a61c-de41-4a34-a271-8ead4a793638" />
