### PR TITLE
fix: Voting on bounty comments fails

### DIFF
--- a/components/Feed/FeedItemActions.tsx
+++ b/components/Feed/FeedItemActions.tsx
@@ -256,6 +256,7 @@ export const FeedItemActions: FC<FeedItemActionsProps> = ({
     votableEntityId,
     feedContentType,
     relatedDocumentId,
+    relatedDocumentContentType,
     onVoteSuccess: (response, voteType) => {
       // Update local state based on vote type
       if (voteType === 'UPVOTE' && localUserVote !== 'UPVOTE') {

--- a/hooks/useVote.ts
+++ b/hooks/useVote.ts
@@ -3,7 +3,7 @@ import { ContentType } from '@/types/work';
 import { toast } from 'react-hot-toast';
 import { useSession } from 'next-auth/react';
 import { ApiError } from '@/services/types';
-import { ReactionService } from '@/services/reaction.service';
+import { ReactionService, DocumentType } from '@/services/reaction.service';
 import { UserVoteType, VotableContentType } from '@/types/reaction';
 import { FeedContentType } from '@/types/feed';
 
@@ -11,6 +11,7 @@ interface UseVoteOptions {
   votableEntityId: number;
   feedContentType?: FeedContentType;
   relatedDocumentId?: number;
+  relatedDocumentContentType?: ContentType;
   onVoteSuccess?: (updatedItem: any, voteType: UserVoteType) => void;
   onVoteError?: (error: any) => void;
 }
@@ -43,6 +44,7 @@ export function useVote({
   votableEntityId,
   feedContentType,
   relatedDocumentId,
+  relatedDocumentContentType,
   onVoteSuccess,
   onVoteError,
 }: UseVoteOptions) {
@@ -69,7 +71,16 @@ export function useVote({
 
         let response;
         const votableContentType = mapFeedContentTypeToVotable(feedContentType);
-        const documentType = votableContentType === 'paper' ? 'paper' : 'researchhubpost';
+
+        // Determine document type
+        let documentType: DocumentType;
+        if (relatedDocumentContentType) {
+          // Use the related document content type when available (e.g., `paper`)
+          documentType = relatedDocumentContentType === 'paper' ? 'paper' : 'researchhubpost';
+        } else {
+          // Fallback to votable content type (e.g., `comment`)
+          documentType = votableContentType === 'paper' ? 'paper' : 'researchhubpost';
+        }
 
         // Use the appropriate service method based on feed content type
         if (feedContentType === 'COMMENT' || feedContentType === 'BOUNTY') {
@@ -126,6 +137,7 @@ export function useVote({
       votableEntityId,
       feedContentType,
       relatedDocumentId,
+      relatedDocumentContentType,
       isVoting,
       session,
       onVoteSuccess,


### PR DESCRIPTION
Voting on bounty comments was failing due to the API path to the voting endpoint containing an incorrect path element (in the case of bounties, it was always set to `researchhubpost` although the bounty was on a paper.

This change updates the `useVote` hook to determine the correct API path element based on a new argument `relatedDocumentContentType` (a `relatedDocumentId` parameter already existed).