### PR TITLE
Read `file` field for PDF URLs

### DIFF
--- a/types/work.ts
+++ b/types/work.ts
@@ -196,10 +196,12 @@ export const transformWork = createTransformer<any, Work>((raw) => {
         : [],
     formats: raw.pdf_url
       ? [...(raw.formats || []), { type: 'PDF', url: ProxyService.generateProxyUrl(raw.pdf_url) }]
-      : (raw.formats || []).map((format: FormatType) => ({
-          ...format,
-          url: format.type === 'PDF' ? ProxyService.generateProxyUrl(format.url) : format.url,
-        })),
+      : raw.file
+        ? [...(raw.formats || []), { type: 'PDF', url: ProxyService.generateProxyUrl(raw.file) }]
+        : (raw.formats || []).map((format: FormatType) => ({
+            ...format,
+            url: format.type === 'PDF' ? ProxyService.generateProxyUrl(format.url) : format.url,
+          })),
     license: raw.pdf_license,
     pdfCopyrightAllowsDisplay: raw.pdf_copyright_allows_display,
     figures: raw.first_preview


### PR DESCRIPTION
When determining a paper's source, the current implementation only considers the `pdf_url` field. This change includes the `file` field for evaluating a document URL (which is used by 4M papers in our database).