### PR TITLE
Add missing contacts field to PublishingForm default values

### DIFF
--- a/app/notebook/components/PublishingForm/index.tsx
+++ b/app/notebook/components/PublishingForm/index.tsx
@@ -263,8 +263,6 @@ export function PublishingForm({ bountyAmount, onBountyClick }: PublishingFormPr
   }, [articleType, clearErrors]);
 
   const handlePublishClick = async () => {
-    console.log('handlePublishClick');
-    console.log(methods.getValues());
     const result = await methods.trigger();
 
     if (!result) {


### PR DESCRIPTION
## What?
- When attempting to publish updates to existing content in the Notebook, users were encountering a validation error showing only a "required flag" at the top of the page instead of the normal confirmation checkboxes. This occurred because the `contacts` field was missing from the form's default values, causing validation to fail silently.
Slack thread: https://researchhubfoundation.slack.com/archives/C0897LR58B1/p1749218805828829

## How?
- Added `contacts: []` to the default values in the PublishingForm component to ensure proper validation when publishing updates to existing content.
