### PR TITLE
fix: USD amounts are missing decimal separators

### DIFF
--- a/components/ui/CurrencyBadge.tsx
+++ b/components/ui/CurrencyBadge.tsx
@@ -6,7 +6,6 @@ import { ResearchCoinIcon } from '@/components/ui/icons/ResearchCoinIcon';
 import { Badge } from './Badge';
 import { Tooltip } from './Tooltip';
 import { useExchangeRate } from '@/contexts/ExchangeRateContext';
-import { InfoIcon } from 'lucide-react';
 import { formatRSC } from '@/utils/number';
 
 interface CurrencyBadgeProps {


### PR DESCRIPTION
This change adds decimal separators to the approximate USD amount shown in RSC tooltips.
Example: Instead of _1000000 USD_ => _1,000,000 USD_ will be displayed.

<img width="794" alt="image" src="https://github.com/user-attachments/assets/a7350daf-c697-4af3-a06d-ff7a7e959864" />

Fixes https://github.com/ResearchHub/issues/issues/267