### PR TITLE
Allow microphone access for Persona verification

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -8,7 +8,7 @@ const nextConfig = {
         {
           key: 'Permissions-Policy',
           value:
-            'camera=(self "https://*.withpersona.com/"), geolocation=(), gyroscope=(), microphone=()',
+            'camera=(self "https://*.withpersona.com/"), geolocation=(), gyroscope=(), microphone=(self "https://*.withpersona.com/")',
         },
         {
           key: 'Referrer-Policy',


### PR DESCRIPTION
The Persona integration will log errors if microphone access is not permitted.