### PR TITLE
Update Footer with Support Button

### DIFF
--- a/components/FooterLinks.tsx
+++ b/components/FooterLinks.tsx
@@ -55,6 +55,9 @@ export const FooterLinks: React.FC = () => (
       <a href="https://docs.researchhub.com/" className="hover:text-gray-700">
         Docs
       </a>
+      <a href="https://airtable.com/appuhMJaf1kb3ic8e/pagYeh6cB9sgiTIgx/form" className="hover:text-gray-700" target="_blank" rel="noopener noreferrer">
+        Support
+      </a>
       <a href="https://researchhub.foundation/" className="hover:text-gray-700">
         Foundation
       </a>


### PR DESCRIPTION
Updating the bottom left footer with a "Support" button linking to the airtable form. It will be placed to the left of the "Foundation" button on the same row. 

<img width="283" alt="image" src="https://github.com/user-attachments/assets/d6a6838e-775a-40de-899c-bdcc0087a209" />
