### PR TITLE
Add native browser navigation support to feed items

### DIFF
--- a/components/Feed/FeedItemActions.tsx
+++ b/components/Feed/FeedItemActions.tsx
@@ -271,7 +271,11 @@ export const FeedItemActions: FC<FeedItemActionsProps> = ({
   // Use the flag modal hook
   const { isOpen, contentToFlag, openFlagModal, closeFlagModal } = useFlagModal();
 
-  const handleVote = () => {
+  const handleVote = (e?: React.MouseEvent) => {
+    if (e) {
+      e.preventDefault();
+      e.stopPropagation();
+    }
     executeAuthenticatedAction(() => {
       // Toggle vote: if already upvoted, neutralize, otherwise upvote
       const newVoteType: UserVoteType = localUserVote === 'UPVOTE' ? 'NEUTRAL' : 'UPVOTE';
@@ -280,7 +284,10 @@ export const FeedItemActions: FC<FeedItemActionsProps> = ({
   };
 
   const handleComment = (e?: React.MouseEvent) => {
-    if (e) e.stopPropagation();
+    if (e) {
+      e.preventDefault();
+      e.stopPropagation();
+    }
     if (href) {
       router.push(`${href}/conversation`);
     } else if (onComment) {
@@ -289,14 +296,20 @@ export const FeedItemActions: FC<FeedItemActionsProps> = ({
   };
 
   const handleReviewClick = (e?: React.MouseEvent) => {
-    if (e) e.stopPropagation();
+    if (e) {
+      e.preventDefault();
+      e.stopPropagation();
+    }
     if (href) {
       router.push(`${href}/reviews`);
     }
   };
 
   const handleBountyClick = (e?: React.MouseEvent) => {
-    if (e) e.stopPropagation();
+    if (e) {
+      e.preventDefault();
+      e.stopPropagation();
+    }
     if (href) {
       router.push(`${href}/bounties`);
     }
@@ -304,7 +317,10 @@ export const FeedItemActions: FC<FeedItemActionsProps> = ({
 
   // Handle opening the tip modal
   const handleOpenTipModal = (e?: React.MouseEvent) => {
-    if (e) e.stopPropagation();
+    if (e) {
+      e.preventDefault();
+      e.stopPropagation();
+    }
     executeAuthenticatedAction(() => {
       setTipModalState({ isOpen: true, contentId: votableEntityId });
     });
@@ -334,7 +350,11 @@ export const FeedItemActions: FC<FeedItemActionsProps> = ({
     setTipModalState({ isOpen: false });
   };
 
-  const handleReport = () => {
+  const handleReport = (e?: React.MouseEvent) => {
+    if (e) {
+      e.preventDefault();
+      e.stopPropagation();
+    }
     executeAuthenticatedAction(() => {
       // Map feedContentType to ContentType
       let contentType: ContentType;

--- a/components/Feed/items/CardWrapper.tsx
+++ b/components/Feed/items/CardWrapper.tsx
@@ -1,0 +1,33 @@
+import Link from 'next/link';
+import { cn } from '@/utils/styles';
+
+interface CardWrapperProps {
+  href?: string;
+  children: React.ReactNode;
+  className?: string;
+  isClickable?: boolean;
+}
+
+const defaultClassName =
+  'block w-full bg-white rounded-lg shadow-sm border border-gray-200 overflow-hidden';
+const defaultHoverClassName =
+  'group hover:shadow-md hover:border-indigo-100 transition-all duration-200 cursor-pointer';
+
+export const CardWrapper = ({
+  href,
+  children,
+  className,
+  isClickable = true,
+}: CardWrapperProps) => {
+  const wrapperClassName = cn(defaultClassName, isClickable && defaultHoverClassName, className);
+
+  if (href) {
+    return (
+      <Link href={href} className={wrapperClassName}>
+        {children}
+      </Link>
+    );
+  }
+
+  return <div className={wrapperClassName}>{children}</div>;
+};

--- a/components/Feed/items/FeedItemBounty.tsx
+++ b/components/Feed/items/FeedItemBounty.tsx
@@ -28,6 +28,8 @@ import { ResearchCoinIcon } from '@/components/ui/icons/ResearchCoinIcon';
 import { ContributeBountyModal } from '@/components/modals/ContributeBountyModal';
 import { Icon } from '@/components/ui/icons/Icon';
 import { buildWorkUrl } from '@/utils/url';
+import Link from 'next/link';
+import { CardWrapper } from './CardWrapper';
 /**
  * Internal component for rendering bounty details
  */
@@ -246,16 +248,10 @@ export const FeedItemBounty: FC<FeedItemBountyProps> = ({
   // Determine if card should have clickable styles
   const isClickable = !!href;
 
-  // Handle click on the card (simplified since bountyPageUrl was removed)
-  const handleCardClick = () => {
-    if (href) {
-      window.location.href = href;
-    }
-  };
-
   // Handle opening the contribute modal
   const handleOpenContributeModal = (e: React.MouseEvent | undefined) => {
     if (e) {
+      e.preventDefault();
       e.stopPropagation();
     }
     setIsContributeModalOpen(true);
@@ -263,6 +259,7 @@ export const FeedItemBounty: FC<FeedItemBountyProps> = ({
 
   // Handle CTA button click (Add Review/Add Solution)
   const handleSolution = (e: React.MouseEvent) => {
+    e.preventDefault();
     e.stopPropagation(); // Prevent card click navigation
 
     // Attempt to derive the work details from the feed entry first
@@ -311,6 +308,7 @@ export const FeedItemBounty: FC<FeedItemBountyProps> = ({
   // Handle awarding the bounty
   const handleAwardBounty = (e: React.MouseEvent | undefined) => {
     if (e) {
+      e.preventDefault();
       e.stopPropagation();
     }
     if (onAward) {
@@ -328,6 +326,7 @@ export const FeedItemBounty: FC<FeedItemBountyProps> = ({
       label: 'Edit',
       onClick: (e?: React.MouseEvent) => {
         e?.stopPropagation();
+        e?.preventDefault();
         onEdit();
       },
     });
@@ -353,6 +352,7 @@ export const FeedItemBounty: FC<FeedItemBountyProps> = ({
       icon: Users,
       label: 'View Contributors',
       onClick: (e?: React.MouseEvent) => {
+        e?.preventDefault();
         e?.stopPropagation();
         handleOpenContributeModal(e);
       },
@@ -384,15 +384,7 @@ export const FeedItemBounty: FC<FeedItemBountyProps> = ({
         work={entry.relatedWork}
       />
 
-      {/* Main Content Card - Restoring border and styles */}
-      <div
-        className={cn(
-          'w-full bg-white rounded-lg shadow-sm border border-gray-200 overflow-hidden', // Restored card styles
-          isClickable &&
-            'group hover:shadow-md hover:border-indigo-100 transition-all duration-200 cursor-pointer' // Restored hover styles
-        )}
-        onClick={handleCardClick}
-      >
+      <CardWrapper href={href} isClickable={isClickable}>
         <div className="p-4">
           {' '}
           {/* Added padding back */}
@@ -407,7 +399,13 @@ export const FeedItemBounty: FC<FeedItemBountyProps> = ({
           />
           {/* Container for Support and CTA buttons */}
           {showSupportAndCTAButtons && (
-            <div className="mt-4 flex items-center gap-2" onClick={(e) => e.stopPropagation()}>
+            <div
+              className="mt-4 flex items-center gap-2"
+              onClick={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+              }}
+            >
               {/* Contribute Button - Conditionally shown */}
               {isActive && showContributeButton && !isAuthor && (
                 <Button variant="contribute" size="sm" onClick={handleOpenContributeModal}>
@@ -435,28 +433,31 @@ export const FeedItemBounty: FC<FeedItemBountyProps> = ({
           )}
           {/* Action Buttons - Full width - Moved inside the padded div */}
           {showFooter && !shouldHideActions && (
-            <div className="mt-4 pt-3 border-t border-gray-200">
-              <div onClick={(e) => e.stopPropagation()}>
-                {/* Standard Feed Item Actions */}
-                <FeedItemActions
-                  metrics={entry.metrics}
-                  feedContentType="BOUNTY"
-                  votableEntityId={bountyEntry.comment.id}
-                  relatedDocumentId={bountyEntry.relatedDocumentId}
-                  relatedDocumentContentType={bountyEntry.relatedDocumentContentType}
-                  userVote={entry.userVote}
-                  tips={entry.tips}
-                  showTooltips={showTooltips}
-                  actionLabels={actionLabels}
-                  menuItems={menuItems}
-                  bounties={[bountyEntry.bounty]}
-                  onComment={onReply}
-                />
-              </div>
+            <div
+              className="mt-4 pt-3 border-t border-gray-200"
+              onClick={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+              }}
+            >
+              <FeedItemActions
+                metrics={entry.metrics}
+                feedContentType="BOUNTY"
+                votableEntityId={bountyEntry.comment.id}
+                relatedDocumentId={bountyEntry.relatedDocumentId}
+                relatedDocumentContentType={bountyEntry.relatedDocumentContentType}
+                userVote={entry.userVote}
+                tips={entry.tips}
+                showTooltips={showTooltips}
+                actionLabels={actionLabels}
+                menuItems={menuItems}
+                bounties={[bountyEntry.bounty]}
+                onComment={onReply}
+              />
             </div>
           )}
         </div>
-      </div>
+      </CardWrapper>
 
       {/* Contribute Bounty Modal */}
       <ContributeBountyModal

--- a/components/Feed/items/FeedItemComment.tsx
+++ b/components/Feed/items/FeedItemComment.tsx
@@ -17,6 +17,8 @@ import { Avatar } from '@/components/ui/Avatar';
 import { LegacyCommentBanner } from '@/components/LegacyCommentBanner';
 import { formatTimeAgo } from '@/utils/date';
 import { Tooltip } from '@/components/ui/Tooltip';
+import Link from 'next/link';
+import { CardWrapper } from './CardWrapper';
 
 // Define the recursive rendering component for parent comments
 const RenderParentComment: FC<{ comment: ParentCommentPreview; level: number }> = ({
@@ -185,13 +187,6 @@ export const FeedItemComment: FC<FeedItemCommentProps> = ({
   // Use provided href or create default comment page URL
   const commentPageUrl = href || `/comment/${comment.thread?.objectId}/${comment.id}`;
 
-  // Handle click on the card (navigate to comment page) - only if href is provided
-  const handleCardClick = () => {
-    if (href) {
-      router.push(commentPageUrl);
-    }
-  };
-
   // Create menu items for edit and delete actions
   const menuItems = [];
 
@@ -242,14 +237,7 @@ export const FeedItemComment: FC<FeedItemCommentProps> = ({
         />
       )}
       {/* Main Content Card - Using onClick instead of wrapping with Link */}
-      <div
-        onClick={handleCardClick}
-        className={cn(
-          'bg-white rounded-lg shadow-sm border border-gray-200 overflow-hidden',
-          isClickable &&
-            'group hover:shadow-md hover:border-indigo-100 transition-all duration-200 cursor-pointer'
-        )}
-      >
+      <CardWrapper href={commentPageUrl} isClickable={isClickable}>
         <div className="p-4">
           {/* Review Badge and Rating - Only show for reviews */}
           {isReview && (
@@ -275,7 +263,12 @@ export const FeedItemComment: FC<FeedItemCommentProps> = ({
           {/* Action Buttons - Full width */}
           {!hideActions && (
             <div className="pt-3 border-t border-gray-200">
-              <div onClick={(e) => e.stopPropagation()}>
+              <div
+                onClick={(e) => {
+                  e.preventDefault();
+                  e.stopPropagation();
+                }}
+              >
                 {/* Standard Feed Item Actions with Reply functionality */}
                 <FeedItemActions
                   metrics={entry.metrics}
@@ -295,7 +288,7 @@ export const FeedItemComment: FC<FeedItemCommentProps> = ({
             </div>
           )}
         </div>
-      </div>
+      </CardWrapper>
     </div>
   );
 };

--- a/components/Feed/items/FeedItemFundraise.tsx
+++ b/components/Feed/items/FeedItemFundraise.tsx
@@ -15,6 +15,8 @@ import Image from 'next/image';
 import { TopicAndJournalBadge } from '@/components/ui/TopicAndJournalBadge';
 import { formatRSC } from '@/utils/number';
 import { TaxDeductibleBadge } from '@/components/ui/TaxDeductibleBadge';
+import Link from 'next/link';
+import { CardWrapper } from './CardWrapper';
 
 interface FeedItemFundraiseProps {
   entry: FeedEntry;
@@ -173,13 +175,6 @@ export const FeedItemFundraise: FC<FeedItemFundraiseProps> = ({
   // Use provided href or create default funding page URL
   const fundingPageUrl = href || `/fund/${post.id}/${post.slug}`;
 
-  // Handle click on the card (navigate to funding page) - only if href is provided
-  const handleCardClick = () => {
-    if (href) {
-      router.push(fundingPageUrl);
-    }
-  };
-
   // Determine if card should have clickable styles
   const isClickable = !!href;
 
@@ -214,14 +209,7 @@ export const FeedItemFundraise: FC<FeedItemFundraiseProps> = ({
       />
 
       {/* Main Content Card - Using onClick instead of wrapping with Link */}
-      <div
-        onClick={handleCardClick}
-        className={cn(
-          'bg-white rounded-lg shadow-sm border border-gray-200 overflow-hidden',
-          isClickable &&
-            'group hover:shadow-md hover:border-indigo-100 transition-all duration-200 cursor-pointer'
-        )}
-      >
+      <CardWrapper href={fundingPageUrl} isClickable={isClickable}>
         <div className="p-4">
           {/* Body Content with desktop image integrated */}
           <FeedItemFundraiseBody
@@ -247,7 +235,12 @@ export const FeedItemFundraise: FC<FeedItemFundraiseProps> = ({
           {/* Action Buttons - Full width */}
           {showActions && (
             <div className="mt-4 pt-3 border-t border-gray-200">
-              <div onClick={(e) => e.stopPropagation()}>
+              <div
+                onClick={(e) => {
+                  e.preventDefault();
+                  e.stopPropagation();
+                }}
+              >
                 {/* Standard Feed Item Actions */}
                 <FeedItemActions
                   metrics={entry.metrics}
@@ -263,7 +256,7 @@ export const FeedItemFundraise: FC<FeedItemFundraiseProps> = ({
             </div>
           )}
         </div>
-      </div>
+      </CardWrapper>
     </div>
   );
 };

--- a/components/Feed/items/FeedItemGrant.tsx
+++ b/components/Feed/items/FeedItemGrant.tsx
@@ -17,6 +17,8 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faUserTie } from '@fortawesome/free-solid-svg-icons';
 import { truncateText } from '@/utils/stringUtils';
 import Image from 'next/image';
+import Link from 'next/link';
+import { CardWrapper } from './CardWrapper';
 
 // Grant-specific content type that extends the feed entry structure
 export interface FeedGrantContent {
@@ -107,6 +109,7 @@ const FeedItemGrantBody: FC<{
 
   // Handle apply button click
   const handleApplyClick = (e: React.MouseEvent) => {
+    e.preventDefault();
     e.stopPropagation();
     // Navigate to grant application page
     router.push(`/grant/${grant.id}/${grant.slug}`);
@@ -116,7 +119,13 @@ const FeedItemGrantBody: FC<{
     <div>
       {/* Header with badges and status */}
       <div className="flex items-start justify-between mb-3">
-        <div className="flex flex-wrap gap-2" onClick={(e) => e.stopPropagation()}>
+        <div
+          className="flex flex-wrap gap-2"
+          onClick={(e) => {
+            e.preventDefault();
+            e.stopPropagation();
+          }}
+        >
           <ContentTypeBadge type="grant" />
           {topics.map((topic, index) => (
             <TopicAndJournalBadge
@@ -203,7 +212,13 @@ const FeedItemGrantBody: FC<{
 
           {/* Applicants section */}
           {applicants.length > 0 && (
-            <div className="flex items-center gap-3 mb-4" onClick={(e) => e.stopPropagation()}>
+            <div
+              className="flex items-center gap-3 mb-4"
+              onClick={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+              }}
+            >
               <FontAwesomeIcon icon={faUserTie} className="w-4 h-4 text-gray-500 flex-shrink-0" />
               <div className="flex items-center gap-2">
                 <span className="text-sm text-gray-500 font-normal">
@@ -275,20 +290,12 @@ export const FeedItemGrant: FC<FeedItemGrantProps> = ({
 }) => {
   // Extract the grant from the entry's content
   const grant = entry.content as FeedGrantContent;
-  const router = useRouter();
 
   // Get the author from the grant
   const author = grant.createdBy;
 
   // Use provided href or create default grant page URL
   const grantPageUrl = href || `/grant/${grant.id}/${grant.slug}`;
-
-  // Handle click on the card (navigate to grant page) - only if href is provided
-  const handleCardClick = () => {
-    if (href) {
-      router.push(grantPageUrl);
-    }
-  };
 
   // Determine if card should have clickable styles
   const isClickable = !!href;
@@ -327,14 +334,7 @@ export const FeedItemGrant: FC<FeedItemGrantProps> = ({
       )}
 
       {/* Main Content Card */}
-      <div
-        onClick={handleCardClick}
-        className={cn(
-          'bg-white rounded-lg shadow-sm border border-gray-200 overflow-hidden',
-          isClickable &&
-            'group hover:shadow-md hover:border-indigo-100 transition-all duration-200 cursor-pointer'
-        )}
-      >
+      <CardWrapper href={grantPageUrl} isClickable={isClickable}>
         <div className="p-4">
           {/* Mobile image (shown only on small screens) */}
           <MobileImage />
@@ -345,7 +345,12 @@ export const FeedItemGrant: FC<FeedItemGrantProps> = ({
           {/* Action Buttons */}
           {showActions && (
             <div className="mt-4 pt-3 border-t border-gray-200">
-              <div onClick={(e) => e.stopPropagation()}>
+              <div
+                onClick={(e) => {
+                  e.preventDefault();
+                  e.stopPropagation();
+                }}
+              >
                 <FeedItemActions
                   metrics={entry.metrics}
                   feedContentType="GRANT"
@@ -360,7 +365,7 @@ export const FeedItemGrant: FC<FeedItemGrantProps> = ({
             </div>
           )}
         </div>
-      </div>
+      </CardWrapper>
     </div>
   );
 };

--- a/components/Feed/items/FeedItemPaper.tsx
+++ b/components/Feed/items/FeedItemPaper.tsx
@@ -12,6 +12,8 @@ import { useRouter } from 'next/navigation';
 import { cn } from '@/utils/styles';
 import { JournalStatusBadge } from '@/components/ui/JournalStatusBadge';
 import { Users, BookText } from 'lucide-react';
+import Link from 'next/link';
+import { CardWrapper } from './CardWrapper';
 
 interface FeedItemPaperProps {
   entry: FeedEntry;
@@ -128,13 +130,6 @@ export const FeedItemPaper: FC<FeedItemPaperProps> = ({
   // Use provided href or create default paper page URL
   const paperPageUrl = href || `/paper/${paper.id}/${paper.slug}`;
 
-  // Handle click on the card (navigate to paper page) - only if href is provided
-  const handleCardClick = () => {
-    if (href) {
-      router.push(paperPageUrl);
-    }
-  };
-
   // Determine if card should have clickable styles
   const isClickable = !!href;
 
@@ -147,15 +142,7 @@ export const FeedItemPaper: FC<FeedItemPaperProps> = ({
       {/* Header */}
       <FeedItemHeader timestamp={paper.createdDate} author={author} actionText={actionText} />
 
-      {/* Main Content Card - Using onClick instead of wrapping with Link */}
-      <div
-        onClick={handleCardClick}
-        className={cn(
-          'bg-white rounded-lg shadow-sm border border-gray-200 overflow-hidden',
-          isClickable &&
-            'group hover:shadow-md hover:border-indigo-100 transition-all duration-200 cursor-pointer'
-        )}
-      >
+      <CardWrapper href={paperPageUrl} isClickable={isClickable}>
         <div className="p-4">
           {/* Content area with image */}
           <div className="flex mb-4">
@@ -181,7 +168,13 @@ export const FeedItemPaper: FC<FeedItemPaperProps> = ({
           {/* Action Buttons - Full width */}
           {showActions && (
             <div className="mt-4 pt-3 border-t border-gray-200 flex items-center justify-between">
-              <div className="w-full" onClick={(e) => e.stopPropagation()}>
+              <div
+                className="w-full"
+                onClick={(e) => {
+                  e.preventDefault();
+                  e.stopPropagation();
+                }}
+              >
                 {/* Standard Feed Item Actions */}
                 <FeedItemActions
                   metrics={entry.metrics}
@@ -197,7 +190,7 @@ export const FeedItemPaper: FC<FeedItemPaperProps> = ({
             </div>
           )}
         </div>
-      </div>
+      </CardWrapper>
     </div>
   );
 };

--- a/components/Feed/items/FeedItemPost.tsx
+++ b/components/Feed/items/FeedItemPost.tsx
@@ -11,6 +11,8 @@ import { FeedItemActions } from '@/components/Feed/FeedItemActions';
 import { useRouter } from 'next/navigation';
 import Image from 'next/image';
 import { Users } from 'lucide-react';
+import Link from 'next/link';
+import { CardWrapper } from './CardWrapper';
 
 interface FeedItemPostProps {
   entry: FeedEntry;
@@ -113,20 +115,12 @@ export const FeedItemPost: FC<FeedItemPostProps> = ({
 }) => {
   // Extract the post from the entry's content
   const post = entry.content as FeedPostContent;
-  const router = useRouter();
 
   // Get the author from the post
   const author = post.createdBy;
 
   // Use provided href or create default post page URL
   const postPageUrl = href || `/post/${post.id}/${post.slug}`;
-
-  // Handle click on the card (navigate to post page) - only if href is provided
-  const handleCardClick = () => {
-    if (href) {
-      router.push(postPageUrl);
-    }
-  };
 
   // Determine if card should have clickable styles
   const isClickable = !!href;
@@ -163,14 +157,7 @@ export const FeedItemPost: FC<FeedItemPostProps> = ({
       />
 
       {/* Main Content Card - Using onClick instead of wrapping with Link */}
-      <div
-        onClick={handleCardClick}
-        className={cn(
-          'bg-white rounded-lg shadow-sm border border-gray-200 overflow-hidden',
-          isClickable &&
-            'group hover:shadow-md hover:border-indigo-100 transition-all duration-200 cursor-pointer'
-        )}
-      >
+      <CardWrapper href={postPageUrl} isClickable={isClickable}>
         <div className="p-4">
           {/* Mobile image (shown only on small screens) */}
           <MobileImage />
@@ -181,7 +168,12 @@ export const FeedItemPost: FC<FeedItemPostProps> = ({
           {/* Action Buttons - Full width */}
           {showActions && (
             <div className="mt-4 pt-3 border-t border-gray-200">
-              <div onClick={(e) => e.stopPropagation()}>
+              <div
+                onClick={(e) => {
+                  e.preventDefault();
+                  e.stopPropagation();
+                }}
+              >
                 {/* Standard Feed Item Actions */}
                 <FeedItemActions
                   metrics={entry.metrics}
@@ -197,7 +189,7 @@ export const FeedItemPost: FC<FeedItemPostProps> = ({
             </div>
           )}
         </div>
-      </div>
+      </CardWrapper>
     </div>
   );
 };

--- a/components/Paper/RelatedWorkCard.tsx
+++ b/components/Paper/RelatedWorkCard.tsx
@@ -41,7 +41,10 @@ export const RelatedWorkCard = ({
     })) || [];
 
   // Handle click on the paper card
-  const handleClick = () => {
+  const handleClick = (e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+
     if (onClick) {
       onClick();
     } else if (work.id && work.slug) {

--- a/components/ui/AuthorList.tsx
+++ b/components/ui/AuthorList.tsx
@@ -160,6 +160,7 @@ export const AuthorList = ({
           {showAll && filteredAuthors.length > 3 && (
             <button
               onClick={(e) => {
+                e.preventDefault();
                 e.stopPropagation();
                 setShowAll(false);
               }}
@@ -181,6 +182,7 @@ export const AuthorList = ({
         <AuthorItem author={filteredAuthors[1]} showDot={false} size={size} className={className} />
         <button
           onClick={(e) => {
+            e.preventDefault();
             e.stopPropagation();
             setShowAll(true);
           }}


### PR DESCRIPTION
Issue: https://github.com/ResearchHub/issues/issues/196

## What?
- Replace custom click handlers with Next.js `Link` component to support native browser behaviors:
  - Command+click (Mac) / Ctrl+click (Windows) to open in new tab
  - Right-click context menu
  - Middle-click to open in new tab

## How?
- Create reusable `CardWrapper` component:
  - Conditionally renders `Link` or `div` based on `href` prop
  - Centralizes common card styles and hover effects
  - Reduces code duplication across feed items

> [!IMPORTANT]
> All interactive elements inside `Link` components need `preventDefault` and `stopPropagation` (Upvote, Tip, show all etc)