### PR TITLE
Make `unifiedDocumentId` Required in `CommentFeed`

### DIFF
--- a/components/Comment/CommentFeed.tsx
+++ b/components/Comment/CommentFeed.tsx
@@ -30,7 +30,7 @@ interface CommentFeedProps {
   renderCommentActions?: boolean;
   hideEditor?: boolean;
   debug?: boolean;
-  unifiedDocumentId?: number | null;
+  unifiedDocumentId: number | null;
   work?: Work;
 }
 

--- a/components/work/FundDocument.tsx
+++ b/components/work/FundDocument.tsx
@@ -56,6 +56,7 @@ export const FundDocument = ({
         return (
           <div className="space-y-6" key="reviews-tab">
             <CommentFeed
+              unifiedDocumentId={work.unifiedDocumentId || null}
               documentId={work.id}
               contentType={work.contentType}
               commentType="REVIEW"
@@ -73,6 +74,7 @@ export const FundDocument = ({
         return (
           <div className="space-y-6" key="bounties-tab">
             <CommentFeed
+              unifiedDocumentId={work.unifiedDocumentId || null}
               documentId={work.id}
               contentType={work.contentType}
               commentType="BOUNTY"
@@ -89,6 +91,7 @@ export const FundDocument = ({
         return (
           <div className="space-y-6" key="conversation-tab">
             <CommentFeed
+              unifiedDocumentId={work.unifiedDocumentId || null}
               documentId={work.id}
               contentType={work.contentType}
               commentType="GENERIC_COMMENT"

--- a/components/work/GrantDocument.tsx
+++ b/components/work/GrantDocument.tsx
@@ -63,6 +63,7 @@ export const GrantDocument = ({
         return (
           <div className="space-y-6" key="conversation-tab">
             <CommentFeed
+              unifiedDocumentId={work.unifiedDocumentId || null}
               documentId={work.id}
               contentType={work.contentType}
               commentType="GENERIC_COMMENT"

--- a/components/work/PostDocument.tsx
+++ b/components/work/PostDocument.tsx
@@ -52,6 +52,7 @@ export const PostDocument = ({
         return (
           <div className="space-y-6" key="reviews-tab">
             <CommentFeed
+              unifiedDocumentId={work.unifiedDocumentId || null}
               documentId={work.id}
               contentType={work.contentType}
               commentType="REVIEW"
@@ -68,6 +69,7 @@ export const PostDocument = ({
         return (
           <div className="space-y-6" key="bounties-tab">
             <CommentFeed
+              unifiedDocumentId={work.unifiedDocumentId || null}
               documentId={work.id}
               contentType={work.contentType}
               commentType="BOUNTY"
@@ -81,6 +83,7 @@ export const PostDocument = ({
         return (
           <div className="space-y-6" key="conversation-tab">
             <CommentFeed
+              unifiedDocumentId={work.unifiedDocumentId || null}
               documentId={work.id}
               contentType={work.contentType}
               commentType="GENERIC_COMMENT"

--- a/components/work/WorkDocument.tsx
+++ b/components/work/WorkDocument.tsx
@@ -169,7 +169,7 @@ export const WorkDocument = ({ work, metadata, defaultTab = 'paper' }: WorkDocum
           <div className="space-y-6" key="reviews-tab">
             <CommentFeed
               documentId={work.id}
-              unifiedDocumentId={work.unifiedDocumentId}
+              unifiedDocumentId={work.unifiedDocumentId || null}
               contentType={work.contentType}
               commentType="REVIEW"
               editorProps={{
@@ -188,7 +188,7 @@ export const WorkDocument = ({ work, metadata, defaultTab = 'paper' }: WorkDocum
           <div className="space-y-6" key="bounties-tab">
             <CommentFeed
               documentId={work.id}
-              unifiedDocumentId={work.unifiedDocumentId}
+              unifiedDocumentId={work.unifiedDocumentId || null}
               contentType={work.contentType}
               commentType="BOUNTY"
               renderCommentActions={false}
@@ -203,7 +203,7 @@ export const WorkDocument = ({ work, metadata, defaultTab = 'paper' }: WorkDocum
           <div className="space-y-6" key="comments-tab">
             <CommentFeed
               documentId={work.id}
-              unifiedDocumentId={work.unifiedDocumentId}
+              unifiedDocumentId={work.unifiedDocumentId || null}
               contentType={work.contentType}
               commentType="GENERIC_COMMENT"
               key={`comment-feed-${work.id}`}


### PR DESCRIPTION
## Problem
The `unifiedDocumentId` property in `CommentFeed` component is currently optional, which led to missing IDs in `PostDocument`, `FundDocument`, and other components that use `CommentFeed`. This caused issues with comment functionality.

## Solution
- Make `unifiedDocumentId` a required prop with type `number | null`
- This ensures all parent components must explicitly pass the ID
- TypeScript will now catch any missing implementations at compile time
- `null` is still allowed as a fallback, though it should never occur in practice
