### PR TITLE
Bug: "New" button is centered for desktop

### DIFF
--- a/app/layouts/PublishMenu.tsx
+++ b/app/layouts/PublishMenu.tsx
@@ -55,7 +55,7 @@ export const PublishMenu: React.FC<PublishMenuProps> = ({ children, forceMinimiz
   );
 
   return (
-    <div className="relative flex justify-center">
+    <div className={`relative ${forceMinimize ? 'flex justify-center' : ''}`}>
       {/* Standard Menu */}
       <BaseMenu
         trigger={standardTrigger}


### PR DESCRIPTION
## What?
- "New" button is centered for desktop. it should only be centered when nav is collapsed

## How?
- we need to take into account `forceMinimize` property when we align the button