### PR TITLE
Update Legacy Banner URLs to Point to Old Site

### DIFF
--- a/components/LegacyCommentBanner.tsx
+++ b/components/LegacyCommentBanner.tsx
@@ -16,7 +16,9 @@ interface LegacyCommentBannerProps {
  */
 export const LegacyCommentBanner = ({ contentType, onClose }: LegacyCommentBannerProps) => {
   // Determine the correct URL based on environment
-  const baseUrl = isProduction() ? 'https://researchhub.com' : 'https://staging.researchhub.com';
+  const baseUrl = isProduction()
+    ? 'https://old.researchhub.com'
+    : 'https://old.staging.researchhub.com';
 
   const { slug, id } = useParams();
 

--- a/components/LegacyNoteBanner.tsx
+++ b/components/LegacyNoteBanner.tsx
@@ -12,7 +12,9 @@ interface LegacyNoteBannerProps {
  */
 export const LegacyNoteBanner = ({ orgSlug, noteId }: LegacyNoteBannerProps) => {
   // Determine the correct URL based on environment
-  const baseUrl = isProduction() ? 'https://researchhub.com' : 'https://staging.researchhub.com';
+  const baseUrl = isProduction()
+    ? 'https://old.researchhub.com'
+    : 'https://old.staging.researchhub.com';
 
   const legacyNoteUrl = `${baseUrl}/${orgSlug}/notebook/${noteId}`;
 


### PR DESCRIPTION
## What?
- This PR fixes the URLs in legacy banners to correctly point to the old ResearchHub site. Previously, the URLs were missing the **'old'** prefix, causing them to redirect to the new V2 site instead of the legacy system.

## How?
- Updated base URLs in `LegacyNoteBanner.tsx` to use:
  - Production: `https://old.researchhub.com`
  - Staging: `https://old.staging.researchhub.com`
- Updated base URLs in `LegacyCommentBanner.tsx` to use the same prefixes
