### PR TITLE
Fix tab state synchronization and fundraise routing issues

### DIFF
--- a/app/post/[id]/[slug]/bounties/page.tsx
+++ b/app/post/[id]/[slug]/bounties/page.tsx
@@ -8,6 +8,7 @@ import { PageLayout } from '@/app/layouts/PageLayout';
 import { PostDocument } from '@/components/work/PostDocument';
 import { WorkRightSidebar } from '@/components/work/WorkRightSidebar';
 import { SearchHistoryTracker } from '@/components/work/SearchHistoryTracker';
+import { handleFundraiseRedirect } from '@/utils/navigation';
 
 interface Props {
   params: Promise<{
@@ -51,6 +52,10 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 export default async function PostBountiesPage({ params }: Props) {
   const resolvedParams = await params;
   const post = await getPost(resolvedParams.id);
+
+  // Handle fundraise redirection
+  handleFundraiseRedirect(post, resolvedParams.id, resolvedParams.slug);
+
   const metadata = await MetadataService.get(post.unifiedDocumentId?.toString() || '');
   const content = await getPostContent(post);
 

--- a/app/post/[id]/[slug]/conversation/page.tsx
+++ b/app/post/[id]/[slug]/conversation/page.tsx
@@ -8,6 +8,7 @@ import { PageLayout } from '@/app/layouts/PageLayout';
 import { PostDocument } from '@/components/work/PostDocument';
 import { WorkRightSidebar } from '@/components/work/WorkRightSidebar';
 import { SearchHistoryTracker } from '@/components/work/SearchHistoryTracker';
+import { handleFundraiseRedirect } from '@/utils/navigation';
 
 interface Props {
   params: Promise<{
@@ -51,6 +52,10 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 export default async function PostConversationPage({ params }: Props) {
   const resolvedParams = await params;
   const post = await getPost(resolvedParams.id);
+
+  // Handle fundraise redirection
+  handleFundraiseRedirect(post, resolvedParams.id, resolvedParams.slug);
+
   const metadata = await MetadataService.get(post.unifiedDocumentId?.toString() || '');
   const content = await getPostContent(post);
 

--- a/app/post/[id]/[slug]/page.tsx
+++ b/app/post/[id]/[slug]/page.tsx
@@ -9,6 +9,7 @@ import { WorkDocument } from '@/components/work/WorkDocument';
 import { WorkRightSidebar } from '@/components/work/WorkRightSidebar';
 import { SearchHistoryTracker } from '@/components/work/SearchHistoryTracker';
 import { PostDocument } from '@/components/work/PostDocument';
+import { handleFundraiseRedirect } from '@/utils/navigation';
 
 interface Props {
   params: Promise<{
@@ -55,6 +56,9 @@ export default async function PostPage({ params }: Props) {
 
   // First fetch the post
   const post = await getPost(id);
+
+  // Handle fundraise redirection
+  handleFundraiseRedirect(post, resolvedParams.id, resolvedParams.slug);
 
   // Then fetch metadata using unifiedDocumentId
   const metadata = await MetadataService.get(post.unifiedDocumentId?.toString() || '');

--- a/app/post/[id]/[slug]/reviews/page.tsx
+++ b/app/post/[id]/[slug]/reviews/page.tsx
@@ -8,6 +8,7 @@ import { PageLayout } from '@/app/layouts/PageLayout';
 import { PostDocument } from '@/components/work/PostDocument';
 import { WorkRightSidebar } from '@/components/work/WorkRightSidebar';
 import { SearchHistoryTracker } from '@/components/work/SearchHistoryTracker';
+import { handleFundraiseRedirect } from '@/utils/navigation';
 
 interface Props {
   params: Promise<{
@@ -51,6 +52,10 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 export default async function PostReviewsPage({ params }: Props) {
   const resolvedParams = await params;
   const post = await getPost(resolvedParams.id);
+
+  // Handle fundraise redirection
+  handleFundraiseRedirect(post, resolvedParams.id, resolvedParams.slug);
+
   const metadata = await MetadataService.get(post.unifiedDocumentId?.toString() || '');
   const content = await getPostContent(post);
 

--- a/components/work/WorkTabs.tsx
+++ b/components/work/WorkTabs.tsx
@@ -49,13 +49,7 @@ export const WorkTabs = ({
   };
 
   // Initialize activeTab from URL or props
-  const [activeTab, setActiveTab] = useState<TabType>(() => {
-    // Check if URL contains a tab indicator
-    if (typeof window !== 'undefined') {
-      return getActiveTabFromPath(window.location.pathname);
-    }
-    return defaultTab;
-  });
+  const [activeTab, setActiveTab] = useState<TabType>(() => defaultTab);
 
   // Update active tab when pathname changes
   useEffect(() => {

--- a/utils/navigation.ts
+++ b/utils/navigation.ts
@@ -1,3 +1,6 @@
+import { redirect } from 'next/navigation';
+import { Work } from '@/types/work';
+
 /**
  * Opens an author profile using the appropriate routing mechanism
  * @param authorId The ID of the author to navigate to
@@ -17,3 +20,15 @@ export const navigateToAuthorProfile = (authorId: number | string | undefined, n
     window.location.href = url;
   }
 };
+
+/**
+ * Handles redirection for fundraise posts
+ * @param work The work object to check for fundraise
+ * @param id The post ID
+ * @param slug The post slug
+ */
+export function handleFundraiseRedirect(work: Work, id: string, slug: string) {
+  if (work.note?.post?.fundraise) {
+    redirect(`/fund/${id}/${slug}`);
+  }
+}


### PR DESCRIPTION
## What?
1. **Tab state bug**: Browser back/forward navigation shows correct active tab but displays cached content from different tab
2. **Fix routing**: redirect pages from `/post/id/slug` -> `/fund/id/slug` if the post is a fundraise.

## How?
- `WorkTabs.tsx` initialized `activeTab` from pathname, preventing `useEffect` from calling `onTabChange()`
- **Tab state**: Changed `WorkTabs.tsx` initialization from pathname-based to `defaultTab`
- **Routing**: Added server-side redirect from `/post/id/slug` to `/fund/id/slug` (`utils/navigation.ts`)


