### PR TITLE
fix: A user's verification status is not reflected

### DIFF
--- a/app/author/[id]/components/AuthorProfile.tsx
+++ b/app/author/[id]/components/AuthorProfile.tsx
@@ -121,7 +121,7 @@ const AuthorProfile: React.FC<AuthorProfileProps> = ({ author, refetchAuthorInfo
             <div className="flex flex-col items-start">
               <div className="flex items-center gap-2">
                 <h1 className="text-2xl font-bold text-gray-900">{fullName}</h1>
-                {author.user?.isVerified && <VerifiedBadge />}
+                {author.isVerified && <VerifiedBadge />}
               </div>
               {author.headline && (
                 <div className="text-gray-600 font-sm text-left">

--- a/components/Comment/lib/commentOptimisticUtils.ts
+++ b/components/Comment/lib/commentOptimisticUtils.ts
@@ -52,6 +52,7 @@ export const createOptimisticComment = (
         headline: '',
         profileUrl: `/profile/${authorId}`,
         isClaimed: true,
+        isVerified: false,
       },
     },
     score: 0,

--- a/services/feed.service.ts
+++ b/services/feed.service.ts
@@ -157,6 +157,7 @@ export class FeedService {
             moderator: false,
           },
           isClaimed: !!safeAuthor.user,
+          isVerified: safeAuthor.user?.is_verified || false,
         },
       };
     }

--- a/types/authorProfile.ts
+++ b/types/authorProfile.ts
@@ -41,6 +41,7 @@ export interface AuthorProfile {
   googleScholar?: string | null;
   orcidId?: string | null;
   isClaimed: boolean;
+  isVerified: boolean;
   hIndex?: number;
   i10Index?: number;
   userId?: number;
@@ -60,6 +61,7 @@ export const transformAuthorProfile = createTransformer<any, AuthorProfile>((raw
       headline: '',
       profileUrl: '/profile/0',
       isClaimed: false,
+      isVerified: false,
     };
   }
 
@@ -100,6 +102,7 @@ export const transformAuthorProfile = createTransformer<any, AuthorProfile>((raw
     i10Index: raw.i10_index || undefined,
     userId: raw.user_id || undefined,
     editorOfHubs: editorOfHubs,
+    isVerified: raw.is_verified_v2 || false,
   };
 });
 

--- a/types/feed.ts
+++ b/types/feed.ts
@@ -44,6 +44,7 @@ const transformNestedParentComment = (rawParent: any): ParentCommentPreview | un
           headline: '',
           profileUrl: '/profile/0',
           isClaimed: false,
+          isVerified: false,
         };
 
     return {
@@ -438,6 +439,7 @@ export const transformFeedEntry = (feedEntry: RawApiFeedEntry): FeedEntry => {
                     headline: '',
                     profileUrl: '/profile/0',
                     isClaimed: false,
+                    isVerified: false,
                   }
                 : {
                     id: 0,
@@ -448,6 +450,7 @@ export const transformFeedEntry = (feedEntry: RawApiFeedEntry): FeedEntry => {
                     headline: '',
                     profileUrl: '/profile/0',
                     isClaimed: false,
+                    isVerified: false,
                   },
           journal: content_object.journal || {
             id: 0,

--- a/types/publication.ts
+++ b/types/publication.ts
@@ -169,6 +169,7 @@ export const transformPublicationToFeedEntry = (
         fullName: `${author.first_name} ${author.last_name}`,
         profileUrl: '',
         isClaimed: false,
+        isVerified: false,
       })),
       topics: (
         hubs.map((hub: any) => ({
@@ -187,6 +188,7 @@ export const transformPublicationToFeedEntry = (
           `${documents.authors[0]?.first_name || ''} ${documents.authors[0]?.last_name || ''}`.trim(),
         profileUrl: '',
         isClaimed: false,
+        isVerified: false,
       },
       journal: {
         id: 0,

--- a/types/user.ts
+++ b/types/user.ts
@@ -60,7 +60,7 @@ const baseTransformUser = (raw: any): User => {
     firstName: raw.first_name || '',
     lastName: raw.last_name || '',
     fullName: (raw.first_name || '') + (raw.last_name ? ' ' + raw.last_name : '') || 'Unknown User',
-    isVerified: raw.is_verified || false,
+    isVerified: raw.is_verified_v2 || false,
     authorProfile: undefined,
     balance: raw.balance || 0,
     hasCompletedOnboarding: raw.has_completed_onboarding || false,


### PR DESCRIPTION
Get verification status from `is_verified_v2` attribute.

<img width="721" alt="image" src="https://github.com/user-attachments/assets/4c79867d-33f5-43e0-b283-9077bfa37439" />

<img width="273" alt="image" src="https://github.com/user-attachments/assets/0c4c0eaf-0676-4808-a56d-58443d9d7b27" />


Fixes https://github.com/ResearchHub/issues/issues/274