### PR TITLE
Funding/copy changes

### DIFF
--- a/app/layouts/PublishMenu.tsx
+++ b/app/layouts/PublishMenu.tsx
@@ -157,7 +157,7 @@ export const PublishMenu: React.FC<PublishMenuProps> = ({ children, forceMinimiz
                   </div>
                   <div className="flex-1">
                     <div className="text-sm font-medium tracking-[0.02em] text-gray-900">
-                      Give research funding
+                      Sponsor new research
                     </div>
                     <div className="text-xs text-gray-600 mt-0.5">
                       Fund specific research you care about
@@ -292,7 +292,7 @@ export const PublishMenu: React.FC<PublishMenuProps> = ({ children, forceMinimiz
                   </div>
                   <div className="flex-1">
                     <div className="text-sm font-medium tracking-[0.02em] text-gray-900">
-                      Give research funding
+                      Sponsor new research
                     </div>
                     <div className="text-xs text-gray-600 mt-0.5">
                       Fund specific research you care about

--- a/components/Fund/GrantRightSidebar.tsx
+++ b/components/Fund/GrantRightSidebar.tsx
@@ -46,39 +46,7 @@ export const GrantRightSidebar = () => {
           </Button>
         </div>
 
-        <CollapsibleSection title="85% of funding is wasted">
-          <CollapsibleItem
-            title="Studies go unreported"
-            icon={<ShieldAlert className="w-4 h-4" strokeWidth={2.5} />}
-            isOpen={openSections.includes('unreported-studies')}
-            onToggle={() => toggleSection('unreported-studies')}
-          >
-            Less than half of study outcomes are ever reported. Negative results rarely get
-            published, creating massive blind spots in scientific knowledge.
-          </CollapsibleItem>
-
-          <CollapsibleItem
-            title="Results can't be replicated"
-            icon={<ShieldAlert className="w-4 h-4" strokeWidth={2.5} />}
-            isOpen={openSections.includes('replication-crisis')}
-            onToggle={() => toggleSection('replication-crisis')}
-          >
-            Less than half of published biomedical research can be independently replicated, making
-            much of the scientific record unreliable.
-          </CollapsibleItem>
-
-          <CollapsibleItem
-            title="$200B+ wasted annually"
-            icon={<ShieldAlert className="w-4 h-4" strokeWidth={2.5} />}
-            isOpen={openSections.includes('billions-wasted')}
-            onToggle={() => toggleSection('billions-wasted')}
-          >
-            The Lancet found that traditional grant systems waste hundreds of billions annually
-            through poor incentives and opaque processes.
-          </CollapsibleItem>
-        </CollapsibleSection>
-
-        <CollapsibleSection title="Preregistration solves this">
+        <CollapsibleSection title="Preregistration = better science">
           <CollapsibleItem
             title="Prevents p-hacking"
             icon={<Check className="w-4 h-4" strokeWidth={2.5} />}

--- a/components/ui/CurrencyBadge.tsx
+++ b/components/ui/CurrencyBadge.tsx
@@ -110,16 +110,7 @@ export const CurrencyBadge: FC<CurrencyBadgeProps> = ({
     md: isUSD ? 16 : 18,
   };
 
-  const formatNumber = (num: number, useShorten: boolean | undefined) => {
-    if (useShorten) {
-      // Assuming formatRSC can handle generic number shortening.
-      // If formatRSC specifically adds "RSC" text, this needs adjustment.
-      return formatRSC({ amount: num, shorten: true });
-    }
-    return Math.round(num).toLocaleString();
-  };
-
-  const displayAmount = formatNumber(amount, shorten);
+  const displayAmount = formatRSC({ amount, shorten, round: !shorten });
   const currencyText = isUSD ? 'USD' : 'RSC';
 
   // Create tooltip content
@@ -138,7 +129,7 @@ export const CurrencyBadge: FC<CurrencyBadgeProps> = ({
         <div className="p-1">
           <div className="font-semibold text-orange-700 mb-0.5 flex items-center gap-1">
             <ResearchCoinIcon size={14} color={colors.iconColor} />
-            <span>≈ {Math.round(rscEquivalent).toLocaleString()} RSC</span>
+            <span>≈ {formatRSC({ amount: rscEquivalent, round: true })} RSC</span>
           </div>
         </div>
       );
@@ -149,9 +140,11 @@ export const CurrencyBadge: FC<CurrencyBadgeProps> = ({
         <div className="p-1">
           <div className="font-semibold text-orange-700 mb-0.5 flex items-center gap-1">
             <ResearchCoinIcon size={14} color={colors.iconColor} />
-            <span>{Math.round(amount).toLocaleString()} RSC</span>
+            <span>{formatRSC({ amount, round: true })} RSC</span>
           </div>
-          <div className="text-gray-700 text-xs">≈ ${formatNumber(usdEquivalent, shorten)} USD</div>
+          <div className="text-gray-700 text-xs">
+            ≈ ${formatRSC({ amount: usdEquivalent, decimalPlaces: 2 })} USD
+          </div>
         </div>
       );
     }

--- a/components/ui/RSCBadge.tsx
+++ b/components/ui/RSCBadge.tsx
@@ -111,16 +111,7 @@ export const CurrencyBadge: FC<CurrencyBadgeProps> = ({
     md: isUSD ? 16 : 18,
   };
 
-  const formatNumber = (num: number, useShorten: boolean | undefined) => {
-    if (useShorten) {
-      // Assuming formatRSC can handle generic number shortening.
-      // If formatRSC specifically adds "RSC" text, this needs adjustment.
-      return formatRSC({ amount: num, shorten: true });
-    }
-    return Math.round(num).toLocaleString();
-  };
-
-  const displayAmount = formatNumber(amount, shorten);
+  const displayAmount = formatRSC({ amount, shorten, round: !shorten });
   const currencyText = isUSD ? 'USD' : 'RSC';
 
   // Create tooltip content
@@ -139,7 +130,7 @@ export const CurrencyBadge: FC<CurrencyBadgeProps> = ({
         <div className="p-1">
           <div className="font-semibold text-orange-700 mb-0.5 flex items-center gap-1">
             <ResearchCoinIcon size={14} color={colors.iconColor} />
-            <span>≈ {Math.round(rscEquivalent).toLocaleString()} RSC</span>
+            <span>≈ {formatRSC({ amount: rscEquivalent, round: true })} RSC</span>
           </div>
         </div>
       );
@@ -150,9 +141,11 @@ export const CurrencyBadge: FC<CurrencyBadgeProps> = ({
         <div className="p-1">
           <div className="font-semibold text-orange-700 mb-0.5 flex items-center gap-1">
             <ResearchCoinIcon size={14} color={colors.iconColor} />
-            <span>{Math.round(amount).toLocaleString()} RSC</span>
+            <span>{formatRSC({ amount, round: true })} RSC</span>
           </div>
-          <div className="text-gray-700 text-xs">≈ ${usdEquivalent.toFixed(2)} USD</div>
+          <div className="text-gray-700 text-xs">
+            ≈ ${formatRSC({ amount: usdEquivalent, decimalPlaces: 2 })} USD
+          </div>
         </div>
       );
     }

--- a/components/work/GrantApplications.tsx
+++ b/components/work/GrantApplications.tsx
@@ -94,7 +94,7 @@ export const GrantApplications: FC<GrantApplicationsProps> = ({ grantId }) => {
             className="flex items-center gap-1"
             onClick={() => setIsApplyModalOpen(true)}
           >
-            <Plus className="h-4 w-4" /> Submit Application
+            <Plus className="h-4 w-4" /> Submit application
           </Button>
         </div>
 
@@ -155,7 +155,7 @@ export const GrantApplications: FC<GrantApplicationsProps> = ({ grantId }) => {
             className="flex items-center gap-1"
             onClick={() => setIsApplyModalOpen(true)}
           >
-            <Plus className="h-4 w-4" /> Submit Application
+            <Plus className="h-4 w-4" /> Submit application
           </Button>
         </div>
 
@@ -217,7 +217,7 @@ export const GrantApplications: FC<GrantApplicationsProps> = ({ grantId }) => {
             setIsApplyModalOpen(true);
           }}
         >
-          <Plus className="h-4 w-4" /> Submit Application
+          <Plus className="h-4 w-4" /> Submit application
         </Button>
       </div>
 

--- a/components/work/components/GrantAmountSection.tsx
+++ b/components/work/components/GrantAmountSection.tsx
@@ -9,6 +9,7 @@ import { Button } from '@/components/ui/Button';
 import { ApplyToGrantModal } from '@/components/modals/ApplyToGrantModal';
 import { PreregistrationForModal } from '@/services/post.service';
 import { Work } from '@/types/work';
+import { Plus } from 'lucide-react';
 
 interface GrantAmountSectionProps {
   work: Work;
@@ -74,10 +75,10 @@ export const GrantAmountSection = ({ work }: GrantAmountSectionProps) => {
           onClick={() => {
             setIsApplyModalOpen(true);
           }}
-          className="w-full mt-3"
+          className="w-full mt-3 flex items-center justify-center gap-1"
           size="lg"
         >
-          Apply for Grant
+          <Plus className="h-4 w-4" /> Submit application
         </Button>
       </div>
 

--- a/utils/number.ts
+++ b/utils/number.ts
@@ -13,6 +13,11 @@ interface FormatRSCOptions {
    * @default false
    */
   round?: boolean;
+  /**
+   * The number of decimal places to format to.
+   * This is ignored if `shorten` is true.
+   */
+  decimalPlaces?: number;
 }
 
 /**
@@ -26,8 +31,14 @@ interface FormatRSCOptions {
  * formatRSC({ amount: 433 }) // "433"
  * formatRSC({ amount: 1234 }) // "1,234"
  * formatRSC({ amount: 1234.567, round: true }) // "1,235"
+ * formatRSC({ amount: 65.102, decimalPlaces: 2 }) // "65.10"
  */
-export function formatRSC({ amount, shorten = false, round = false }: FormatRSCOptions): string {
+export function formatRSC({
+  amount,
+  shorten = false,
+  round = false,
+  decimalPlaces,
+}: FormatRSCOptions): string {
   // Round the amount if requested
   const valueToFormat = round ? Math.round(amount) : amount;
 
@@ -52,10 +63,17 @@ export function formatRSC({ amount, shorten = false, round = false }: FormatRSCO
       // For values less than 1,000
       return valueToFormat.toString();
     }
-  } else {
-    // shorten is false
-    return valueToFormat.toLocaleString();
   }
+
+  if (decimalPlaces !== undefined) {
+    return valueToFormat.toLocaleString('en-US', {
+      minimumFractionDigits: decimalPlaces,
+      maximumFractionDigits: decimalPlaces,
+    });
+  }
+
+  // shorten is false
+  return valueToFormat.toLocaleString();
 }
 
 /**


### PR DESCRIPTION
Notes from the call:

- [X] Think deeply about copy of grant/RFP/funding. Receive funding / Give funding / Request for proposals
- [X] RFP Page: Copy on the right sidebar should be more direct. ONLY TALK ABOUT SOLUTION, NOT PROBLEM. PREREGISTRATIONS = better research. 
- [X] Use same copy for primary button on Submit Application and Apply for Grant
- [X] Add a comma to the hover state USD value over RSC