### PR TITLE
Strip HTML from abstracts in feed

### DIFF
--- a/types/contribution.ts
+++ b/types/contribution.ts
@@ -5,6 +5,7 @@ import { transformTopic } from './topic';
 import { transformBounty } from './bounty';
 import { Work } from './work';
 import { ContributionType } from '@/services/contribution.service';
+import { stripHtml } from '@/utils/stringUtils';
 
 export interface Hub {
   id: ID;
@@ -106,7 +107,7 @@ const transformUnifiedDocumentToWork = ({ raw, hubs }: { raw: any; hubs: Hub[] }
     slug: relatedUnifiedDocument?.slug,
     createdDate: raw.created_date,
     authors: [],
-    abstract: relatedUnifiedDocument?.renderable_text,
+    abstract: stripHtml(relatedUnifiedDocument?.renderable_text || ''),
     topics: hubs.map((hub) => transformTopic(hub)),
     formats: [], // TODO we need formats here
     figures: [], // TODO we need figures here
@@ -243,7 +244,7 @@ export const transformContributionToFeedEntry = ({
         id: item.id,
         contentType: 'PAPER',
         createdDate: created_date,
-        textPreview: item.abstract || '',
+        textPreview: stripHtml(item.abstract || ''),
         slug: item.slug,
         title: item.title,
         authors: [transformAuthorProfile(created_by.author_profile)],

--- a/types/contributionTransformer.ts
+++ b/types/contributionTransformer.ts
@@ -1,3 +1,4 @@
+import { stripHtml } from '@/utils/stringUtils';
 import { ID } from './root';
 
 export type UnifiedDocument = {
@@ -169,7 +170,7 @@ const parseUnifiedDocument = (raw: any): UnifiedDocument => {
     parsed.document = {
       ...parsed.document,
       paperTitle: unparsedInnerDoc.paper_title,
-      abstract: unparsedInnerDoc.abstract,
+      abstract: stripHtml(unparsedInnerDoc.abstract || ''),
     };
   }
 
@@ -273,7 +274,7 @@ const parsePaperContributionItem = (raw: any): PaperContributionItem => {
     createdBy: raw.created_by || raw.uploaded_by || raw.item.created_by || raw.item.uploaded_by,
     unifiedDocument: parseUnifiedDocument(raw.item.unified_document),
     createdDate: raw.created_date,
-    abstract: raw.item.abstract,
+    abstract: stripHtml(raw.item.abstract || ''),
   };
 };
 

--- a/types/feed.ts
+++ b/types/feed.ts
@@ -395,7 +395,7 @@ export const transformFeedEntry = (feedEntry: RawApiFeedEntry): FeedEntry => {
           id: content_object.id,
           contentType: 'PAPER',
           createdDate: content_object.created_date,
-          textPreview: content_object.abstract || '',
+          textPreview: stripHtml(content_object.abstract || ''),
           slug: content_object.slug || '',
           title: stripHtml(content_object.title || ''),
           authors:

--- a/types/publication.ts
+++ b/types/publication.ts
@@ -1,3 +1,4 @@
+import { stripHtml } from '@/utils/stringUtils';
 import { FeedEntry } from './feed';
 import { createTransformer } from './transformer';
 
@@ -158,7 +159,7 @@ export const transformPublicationToFeedEntry = (
       id: documents.id,
       contentType: 'PAPER',
       createdDate: created_date,
-      textPreview: documents.abstract || '',
+      textPreview: stripHtml(documents.abstract || ''),
       slug: documents.slug,
       title: documents.title,
       authors: documents.authors.map((author) => ({

--- a/types/root.ts
+++ b/types/root.ts
@@ -1,3 +1,5 @@
+import { stripHtml } from '@/utils/stringUtils';
+
 export type ID = string | number | null | undefined;
 
 export type Currency = 'RSC' | 'USD';
@@ -57,7 +59,7 @@ export const transformUnifiedDocument = (
     document: {
       id: documentData?.id,
       title: documentData?.title,
-      abstract: documentData?.abstract,
+      abstract: stripHtml(documentData?.abstract || ''),
       slug: documentData?.slug,
       authors: documentData?.authors,
     },


### PR DESCRIPTION
## What?
- Convert all abstract content from HTML to plain text to prevent HTML tags from displaying as visible text in the feed and other components.
