### PR TITLE
Remove url redirect on comments

### DIFF
--- a/components/Feed/items/FeedItemComment.tsx
+++ b/components/Feed/items/FeedItemComment.tsx
@@ -185,8 +185,8 @@ export const FeedItemComment: FC<FeedItemCommentProps> = ({
   // Determine the content type for the comment
   const contentType: ContentType = comment.thread?.threadType === 'PAPER' ? 'paper' : 'post';
 
-  // Use provided href or create default comment page URL
-  const commentPageUrl = href || `/comment/${comment.thread?.objectId}/${comment.id}`;
+  // Only use href if explicitly provided, don't create default URLs
+  const commentPageUrl = href; // Remove the default URL generation
 
   // Create menu items for edit and delete actions
   const menuItems = [];

--- a/components/Feed/items/FeedItemComment.tsx
+++ b/components/Feed/items/FeedItemComment.tsx
@@ -185,8 +185,8 @@ export const FeedItemComment: FC<FeedItemCommentProps> = ({
   // Determine the content type for the comment
   const contentType: ContentType = comment.thread?.threadType === 'PAPER' ? 'paper' : 'post';
 
-  // Only use href if explicitly provided, don't create default URLs
-  const commentPageUrl = href; // Remove the default URL generation
+  // Only use href if explicitly provided
+  const commentPageUrl = href;
 
   // Create menu items for edit and delete actions
   const menuItems = [];


### PR DESCRIPTION
## Bug:
 Clicking on comments (Peer reviews, conversation) on pages like Papers, and Preregistrations resulted in an unwanted URL redirect to a non-existent comment page (404 error). 

## Solution:
Removed URL redirect unless explicitly provided