### PR TITLE
Various small UI fixes

### DIFF
--- a/components/Editor/components/menus/LinkMenu/LinkMenu.tsx
+++ b/components/Editor/components/menus/LinkMenu/LinkMenu.tsx
@@ -46,7 +46,7 @@ export const LinkMenu = ({ editor, appendTo }: MenuProps): JSX.Element => {
   return (
     <BaseBubbleMenu
       editor={editor}
-      pluginKey="textMenu"
+      pluginKey="linkMenu"
       shouldShow={shouldShow}
       updateDelay={0}
       tippyOptions={{

--- a/components/Editor/components/menus/TextMenu/TextMenu.tsx
+++ b/components/Editor/components/menus/TextMenu/TextMenu.tsx
@@ -46,18 +46,18 @@ export const TextMenu = ({ editor }: TextMenuProps) => {
             },
             {
               name: 'flip',
-              options: {
-                fallbackPlacements: ['bottom-start', 'top-end', 'bottom-end'],
-              },
+              enabled: false,
             },
           ],
+          strategy: 'fixed',
         },
         maxWidth: 'calc(100vw - 16px)',
+        interactive: true,
       }}
       editor={editor}
       pluginKey="textMenu"
       shouldShow={states.shouldShow}
-      updateDelay={100}
+      updateDelay={200}
     >
       <Toolbar.Wrapper>
         {/* <AIDropdown

--- a/components/Notification/NotificationItem.tsx
+++ b/components/Notification/NotificationItem.tsx
@@ -15,12 +15,14 @@ import { TopicAndJournalBadge } from '@/components/ui/TopicAndJournalBadge';
 import { ChevronRight } from 'lucide-react';
 import { CurrencyBadge } from '@/components/ui/CurrencyBadge';
 import { useExchangeRate } from '@/contexts/ExchangeRateContext';
+import { useRouter } from 'next/navigation';
 
 interface NotificationItemProps {
   notification: Notification;
 }
 
 export function NotificationItem({ notification }: NotificationItemProps) {
+  const router = useRouter();
   const notificationInfo = getNotificationInfo(notification);
   const { exchangeRate } = useExchangeRate();
   const message = formatNotificationMessage(notification, exchangeRate);
@@ -124,7 +126,7 @@ export function NotificationItem({ notification }: NotificationItemProps) {
         )}
         onClick={() => {
           if (hasNavigationUrl && formattedNavigationUrl) {
-            window.open(formattedNavigationUrl, '_blank', 'noopener,noreferrer');
+            router.push(formattedNavigationUrl);
           }
         }}
       >

--- a/components/Notification/lib/formatNotification.ts
+++ b/components/Notification/lib/formatNotification.ts
@@ -172,6 +172,13 @@ export function getRSCAmountFromNotification(notification: Notification): number
  * - Adds /bounties suffix specifically for BOUNTY_FOR_YOU notifications
  */
 export function formatNavigationUrl(notification: Notification): string | undefined {
+  if (notification.type === 'PREREGISTRATION_UPDATE' && notification.work) {
+    const { id, slug } = notification.work;
+    if (id && slug) {
+      return `/fund/${id}/${slug}/updates`;
+    }
+  }
+
   const url = notification.navigationUrl;
 
   // Handle null/empty URL when we have document data

--- a/components/ui/CurrencyBadge.tsx
+++ b/components/ui/CurrencyBadge.tsx
@@ -2,7 +2,7 @@
 
 import { FC } from 'react';
 import { cn } from '@/utils/styles';
-
+import { ResearchCoinIcon } from './icons/ResearchCoinIcon';
 import { Badge } from './Badge';
 import { Tooltip } from './Tooltip';
 import { useExchangeRate } from '@/contexts/ExchangeRateContext';
@@ -153,7 +153,7 @@ export const CurrencyBadge: FC<CurrencyBadgeProps> = ({
       return (
         <div className="p-1">
           <div className="font-semibold text-orange-700 mb-0.5 flex items-center gap-1">
-            <Icon name="gold2" size={14} color={colors.iconColor} />
+            <ResearchCoinIcon size={14} />
             <span>{Math.round(amount).toLocaleString()} RSC</span>
           </div>
           <div className="text-gray-700 text-xs">≈ ${formatNumber(displayValue, shorten)} USD</div>
@@ -165,7 +165,7 @@ export const CurrencyBadge: FC<CurrencyBadgeProps> = ({
       return (
         <div className="p-1">
           <div className="font-semibold text-orange-700 mb-0.5 flex items-center gap-1">
-            <Icon name="gold2" size={14} />
+            <ResearchCoinIcon size={14} />
             <span>{Math.round(amount).toLocaleString()} RSC</span>
           </div>
           <div className="text-gray-700 text-xs">≈ ${formatNumber(usdEquivalent, shorten)} USD</div>
@@ -222,7 +222,7 @@ export const CurrencyBadge: FC<CurrencyBadgeProps> = ({
               $
             </span>
           ) : (
-            <Icon name="gold2" size={effectiveIconSize} className="mr-1" />
+            <ResearchCoinIcon size={effectiveIconSize} className="mr-1" />
           ))}
         {inverted ? (
           <div className="flex items-center">
@@ -310,18 +310,10 @@ export const CurrencyBadge: FC<CurrencyBadgeProps> = ({
             $
           </span>
         ) : (
-          <Icon
-            name="gold2"
+          <ResearchCoinIcon
             size={effectiveIconSize}
-            color={
-              variant === 'award'
-                ? colors.awardIconColor
-                : variant === 'received'
-                  ? '#16A34A'
-                  : variant === 'disabled'
-                    ? colors.disabledIconColor
-                    : undefined
-            }
+            variant={variant === 'received' ? 'green' : variant === 'disabled' ? 'solid' : 'orange'}
+            color={variant === 'disabled' ? colors.disabledIconColor : undefined}
           />
         ))}
       {variant === 'award' ? (

--- a/components/ui/icons/ResearchCoinIcon.tsx
+++ b/components/ui/icons/ResearchCoinIcon.tsx
@@ -128,10 +128,9 @@ export function ResearchCoinIcon({
     );
   }
 
-  // Define gradient IDs based on variant
-  const gradientId = variant === 'green' ? 'greenCoinGradient' : 'coinGradient';
-  // Determine fill based on variant
-  const coinFill = variant === 'solid' ? color : `url(#${gradientId})`;
+  // Simple approach: just use solid green for green variant, keep everything else the same
+  const coinFill =
+    variant === 'solid' ? color : variant === 'green' ? '#22C55E' : 'url(#coinGradient)';
 
   return (
     <svg width={size} height={size} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 14 14">
@@ -139,10 +138,6 @@ export function ResearchCoinIcon({
         <linearGradient id="coinGradient" x1="0%" y1="0%" x2="100%" y2="100%">
           <stop offset="0%" stopColor="#F97316" />
           <stop offset="100%" stopColor="#EA580C" />
-        </linearGradient>
-        <linearGradient id="greenCoinGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-          <stop offset="0%" stopColor="#16A34A" />
-          <stop offset="100%" stopColor="#15803D" />
         </linearGradient>
         <filter id="softShadow" x="-10%" y="-10%" width="120%" height="120%">
           <feGaussianBlur stdDeviation="0.3" />


### PR DESCRIPTION
### Issue 1. Broken fill on Notifications
(Before fix)
<img width="855" alt="Screenshot 2025-07-09 at 6 02 40 PM" src="https://github.com/user-attachments/assets/021af882-4574-4157-9749-7a7650305b7a" />
(After FIX)
<img width="872" alt="Screenshot 2025-07-09 at 6 02 43 PM" src="https://github.com/user-attachments/assets/c0772240-23ab-4b25-9ee8-64b43eb4d577" />

### Issue 2. Notifications redirect to a new tab 
Rationale: We don't need to direct them to a new tab because now we have a back button that will prevent their session from forking/ending.
New behavior: Clicking a notification redirects within the open tab.

### Issue 3. Notifications on funding updates should don't navigate to the updates tab of the fund page
Rationale: Notifications should navigate to the most direct location of the interaction
New behavior: Clicking funding update notifications (`notification.type === 'PREREGISTRATION_UPDATE'`) now redirects to (`/fund/${id}/${slug}/updates`)

### Issue 4. TextMenu in Notebook moves/disappers when user clicks Font Size or Font Type
Context: https://github.com/ResearchHub/issues/issues/373
New behavior: Working as intended.
<img width="605" alt="Screenshot 2025-07-09 at 8 30 50 PM" src="https://github.com/user-attachments/assets/e31f9d6e-1d19-499e-839c-63f2aa8e3032" />
