### PR TITLE
Change Earn tab wording

### DIFF
--- a/app/layouts/Navigation.tsx
+++ b/app/layouts/Navigation.tsx
@@ -90,7 +90,7 @@ export const Navigation: React.FC<NavigationProps> = ({
       label: 'Earn',
       href: '/earn',
       iconKey: 'earn',
-      description: 'Find opportunities to earn RSC',
+      description: 'Earn RSC for completing peer reviews',
     },
     {
       label: 'Fund',

--- a/app/layouts/TopBar.tsx
+++ b/app/layouts/TopBar.tsx
@@ -100,7 +100,7 @@ const getPageInfo = (pathname: string): PageInfo | null => {
   if (pathname.startsWith('/bounties')) {
     return {
       title: 'Bounties',
-      subtitle: 'Find opportunities to earn ResearchCoin',
+      subtitle: 'Earn RSC for completing peer reviews',
       icon: <Icon name="earn1" size={20} className="text-primary-600" />,
     };
   }
@@ -108,7 +108,7 @@ const getPageInfo = (pathname: string): PageInfo | null => {
   if (pathname.startsWith('/earn')) {
     return {
       title: 'Earn',
-      subtitle: 'Find opportunities to earn ResearchCoin',
+      subtitle: 'Earn RSC for completing peer reviews',
       icon: <Icon name="earn1" size={20} className="text-primary-600" />,
     };
   }


### PR DESCRIPTION
Changed Earn tab wording in subtitle to include the word "peer review"

Old
<img width="340" height="68" alt="image" src="https://github.com/user-attachments/assets/5b12ab8f-6b37-4594-9c88-ab503b99165d" />

New
<img width="340" height="68" alt="image" src="https://github.com/user-attachments/assets/0d152b40-de3b-4d14-a3c3-f5d04e167127" />
