### PR TITLE
Update bounty fee calculation

### DIFF
--- a/components/Bounty/BountyForm.tsx
+++ b/components/Bounty/BountyForm.tsx
@@ -436,7 +436,7 @@ export function BountyForm({ workId, onSubmitSuccess, className }: BountyFormPro
   const platformFee = Math.floor(rscAmount * 0.09);
   const daoFee = Math.floor(rscAmount * 0.02);
   const incFee = Math.floor(rscAmount * 0.07);
-  const baseAmount = rscAmount - platformFee;
+  const baseAmount = rscAmount + platformFee;
   const insufficientBalance = userBalance < rscAmount;
   const hasAdditionalInfo = !!(
     editorContent &&


### PR DESCRIPTION
`baseAmount` for the bounty should be calculated as `rscAmount + platformFee`. The user's total cost for the bounty is the amount of the bounty + the platform fee.