### PR TITLE
Profile image not showing up in search results

### DIFF
--- a/components/Search/SearchSuggestions.tsx
+++ b/components/Search/SearchSuggestions.tsx
@@ -5,6 +5,7 @@ import { cn } from '@/utils/styles';
 import { SearchSuggestion } from '@/types/search';
 import type { EntityType } from '@/types/search';
 import { FollowTopicButton } from '@/components/ui/FollowTopicButton';
+import { Avatar } from '@/components/ui/Avatar';
 
 interface SearchSuggestionsProps {
   query: string;
@@ -129,14 +130,26 @@ export function SearchSuggestions({
       // Get the smaller icon variant for dropdown mode
       const getSmallIcon = () => {
         if (suggestion.isRecent)
-          return <History className="h-5 w-5 text-gray-400 mt-0.5 flex-shrink-0" />;
+          return <History className="h-5 w-8 text-gray-400 mt-0.5 flex-shrink-0" />;
         if (isPaperSuggestion)
-          return <FileText className="h-5 w-5 text-gray-500 mt-0.5 flex-shrink-0" />;
-        if (isUserSuggestion)
-          return <User className="h-5 w-5 text-gray-500 mt-0.5 flex-shrink-0" />;
+          return <FileText className="h-5 w-8 text-gray-500 mt-0.5 flex-shrink-0" />;
+        if (isUserSuggestion) {
+          const authorProfile = suggestion.authorProfile;
+          return authorProfile?.profileImage ? (
+            <Avatar
+              src={authorProfile.profileImage}
+              alt={suggestion.displayName}
+              size="sm"
+              className="mt-0.5 flex-shrink-0"
+              authorId={authorProfile.id}
+            />
+          ) : (
+            <User className="h-5 w-8 text-gray-500 mt-0.5 flex-shrink-0" />
+          );
+        }
         if (isTopicSuggestion)
-          return <Hash className="h-5 w-5 text-gray-500 mt-0.5 flex-shrink-0" />;
-        return <HelpCircle className="h-5 w-5 text-gray-500 mt-0.5 flex-shrink-0" />; // Default
+          return <Hash className="h-5 w-8 text-gray-500 mt-0.5 flex-shrink-0" />;
+        return <HelpCircle className="h-5 w-8 text-gray-500 mt-0.5 flex-shrink-0" />; // Default
       };
 
       if (displayMode === 'inline') {

--- a/types/search.ts
+++ b/types/search.ts
@@ -122,7 +122,11 @@ export const transformSearchSuggestion = createTransformer<any, SearchSuggestion
           isVerified: raw.is_verified || false,
           url: raw.author_profile ? buildAuthorUrl(raw.author_profile.id) : undefined,
           authorProfile: raw.author_profile
-            ? { ...raw.author_profile, userId: raw.id }
+            ? {
+                ...raw.author_profile,
+                userId: raw.id,
+                profileImage: raw.author_profile.profile_image || '',
+              }
             : {
                 id: raw.id,
                 headline: userHeadline,


### PR DESCRIPTION
Issue: https://github.com/ResearchHub/issues/issues/346
## What? 
- In the search suggestions component, user suggestions were displaying a generic `User` icon instead of the user's profile avatar. The issue was in the `transformSearchSuggestion` function where the `profileImage` field was not being properly set in the `authorProfile` object.

## How
- update `transformSearchSuggestion`. Ensured `profileImage` is properly extracted and set in the `authorProfile`.
- Updated the `SearchSuggestions` component to use the `Avatar` component instead of the `User` icon for user suggestions



comment
<img width="661" height="460" alt="image" src="https://github.com/user-attachments/assets/d531845b-f33c-47e2-9a46-3b36ee0dc7f5" />
search
<img width="767" height="283" alt="image" src="https://github.com/user-attachments/assets/0e02f816-fa84-4517-b290-071739041583" />
