### PR TITLE
 Add authorURL to FeedItemPaper

### DIFF
--- a/app/layouts/RightSidebar.tsx
+++ b/app/layouts/RightSidebar.tsx
@@ -102,7 +102,7 @@ const JournalSpotlight = () => {
     { name: 'Seong Won Nho' },
     { name: 'Hossam Abdelhamed' },
     { name: 'Mark Lawrence' },
-    { name: 'Attila Karsi' },
+    { name: 'Attila Karsi', authorUrl: '/author/984218' },
   ];
 
   // The specific paper URL from the request

--- a/app/layouts/RightSidebar.tsx
+++ b/app/layouts/RightSidebar.tsx
@@ -194,7 +194,7 @@ const FundingSpotlight = () => {
         authors.push({
           name: author.fullName || `${author.firstName || ''} ${author.lastName || ''}`.trim(),
           verified: author.user?.isVerified,
-          profileUrl: author.profileUrl,
+          authorUrl: author.profileUrl,
         });
       }
     });

--- a/components/Feed/items/FeedItemFundraise.tsx
+++ b/components/Feed/items/FeedItemFundraise.tsx
@@ -73,7 +73,7 @@ export const FeedItemFundraise: FC<FeedItemFundraiseProps> = ({
     post.authors?.map((author) => ({
       name: author.fullName,
       verified: author.user?.isVerified,
-      profileUrl: author.profileUrl,
+      authorUrl: author.profileUrl,
     })) || [];
 
   // Use provided href or create default funding page URL

--- a/components/Feed/items/FeedItemPaper.tsx
+++ b/components/Feed/items/FeedItemPaper.tsx
@@ -103,6 +103,7 @@ export const FeedItemPaper: FC<FeedItemPaperProps> = ({
                     name: author.fullName,
                     verified: author.user?.isVerified,
                     profileUrl: author.profileUrl,
+                    authorUrl: `/author/${author.id}`,
                   }))}
                   size="sm"
                   className="text-gray-500 font-normal"

--- a/components/Feed/items/FeedItemPaper.tsx
+++ b/components/Feed/items/FeedItemPaper.tsx
@@ -102,8 +102,7 @@ export const FeedItemPaper: FC<FeedItemPaperProps> = ({
                   authors={paper.authors.map((author) => ({
                     name: author.fullName,
                     verified: author.user?.isVerified,
-                    profileUrl: author.profileUrl,
-                    authorUrl: `/author/${author.id}`,
+                    authorUrl: author.profileUrl,
                   }))}
                   size="sm"
                   className="text-gray-500 font-normal"

--- a/components/Feed/items/FeedItemPost.tsx
+++ b/components/Feed/items/FeedItemPost.tsx
@@ -44,7 +44,7 @@ export const FeedItemPost: FC<FeedItemPostProps> = ({
     post.authors?.map((author) => ({
       name: author.fullName,
       verified: author.user?.isVerified,
-      profileUrl: author.profileUrl,
+      authorUrl: author.profileUrl,
     })) || [];
 
   // Use provided href or create default post page URL


### PR DESCRIPTION
These author links were not working, they just redirected to the paper page.
<img width="891" height="521" alt="Screenshot 2025-07-22 at 8 29 48 AM" src="https://github.com/user-attachments/assets/07cc6203-c8b6-48d4-bb29-8b629ec84e68" />
