### PR TITLE
Add Homepage Experiment Tracking

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,14 +1,20 @@
 import { getServerSession } from 'next-auth/next';
 import { handleTrendingRedirect } from '@/utils/navigation';
 import { LandingPage } from '@/components/landing/LandingPage';
+import { headers } from 'next/headers';
+import { ExperimentVariant } from '@/utils/experiment';
 
 // This can be a server component
 export default async function Home() {
   // Get session on the server
   const session = await getServerSession();
 
+  // Get experiment variant from middleware
+  const headersList = await headers();
+  const experimentVariant = headersList.get('x-homepage-experiment');
+
   // If user is logged in, redirect to trending page
-  handleTrendingRedirect(!!session?.user);
+  handleTrendingRedirect(!!session?.user, experimentVariant as ExperimentVariant | null);
 
   // If no user is logged in, show the landing page
   return <LandingPage />;

--- a/components/Feed/items/FeedItemGrant.tsx
+++ b/components/Feed/items/FeedItemGrant.tsx
@@ -190,7 +190,7 @@ export const FeedItemGrant: FC<FeedItemGrantRefactoredProps> = ({
             {/* Organization */}
             {(grant.organization || grant.grant?.organization) && (
               <MetadataSection>
-                <div className="mb-3 flex items-center gap-1.5 text-sm text-gray-500">
+                <div className="flex items-center gap-1.5 text-sm mb-3 text-gray-500">
                   <Building className="w-4 h-4" />
                   <span>{grant.organization || grant.grant?.organization}</span>
                 </div>
@@ -200,7 +200,7 @@ export const FeedItemGrant: FC<FeedItemGrantRefactoredProps> = ({
             {/* Deadline */}
             {deadline && isOpen && (
               <MetadataSection>
-                <div className="flex items-center gap-2 mb-4">
+                <div className="flex items-center gap-1.5 text-sm mb-3">
                   <Calendar className="w-4 h-4 text-gray-500 flex-shrink-0" />
                   <span className={isExpiringSoon ? 'text-amber-600' : 'text-gray-500'}>
                     Apply by: {format(new Date(deadline), 'MMM d, yyyy')}
@@ -212,7 +212,7 @@ export const FeedItemGrant: FC<FeedItemGrantRefactoredProps> = ({
             {/* Applicants */}
             {applicants.length > 0 && (
               <MetadataSection>
-                <div className="flex items-center gap-2 mb-4">
+                <div className="flex items-center gap-1.5 text-sm mb-3">
                   <Icon name="createBounty" size={16} color="#6b7280" className="flex-shrink-0" />
                   <div className="flex items-center gap-2">
                     <span className="text-sm text-gray-500 font-normal">

--- a/components/Onboarding/OnboardingModal.tsx
+++ b/components/Onboarding/OnboardingModal.tsx
@@ -15,6 +15,8 @@ import { useRouter, useSearchParams } from 'next/navigation';
 import { InterestSelector } from '../InterestSelector/InterestSelector';
 import { OnboardingAccordionSkeleton } from './OnboardingAccordionSkeleton';
 import AnalyticsService, { LogEvent } from '@/services/analytics.service';
+import { useSession } from 'next-auth/react';
+import { Experiment, ExperimentVariant, isExperimentEnabled } from '@/utils/experiment';
 
 type OnboardingStep = 'PERSONAL_INFORMATION' | 'ADDITIONAL_INFORMATION' | 'TOPICS';
 
@@ -97,7 +99,12 @@ export function OnboardingModal() {
       user.hasCompletedOnboarding === false &&
       !onboardingEventFired.current
     ) {
-      AnalyticsService.logEvent(LogEvent.ONBOARDING_VIEWED);
+      AnalyticsService.logEvent(LogEvent.ONBOARDING_VIEWED, {
+        homepageExperiment: isExperimentEnabled(Experiment.HomepageExperiment)
+          ? ExperimentVariant.B
+          : ExperimentVariant.A,
+        authProvider: user.authProvider,
+      });
       onboardingEventFired.current = true;
     }
 

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,11 +1,56 @@
-import { withAuth } from 'next-auth/middleware';
+import { NextRequestWithAuth, withAuth } from 'next-auth/middleware';
+import { NextRequest, NextResponse } from 'next/server';
+import { Experiment, ExperimentVariant } from './utils/experiment';
 
-export default withAuth({
-  callbacks: {
-    authorized: ({ token }) => !!token,
-  },
-});
+function getExperimentVariant(request: NextRequest): string {
+  // Check if user already has an experiment assignment
+  const existingVariant = request.cookies.get(Experiment.HomepageExperiment);
+
+  if (existingVariant?.value) {
+    return existingVariant.value;
+  }
+
+  // Assign new variant (50/50 split)
+  const variant = Math.random() < 0.5 ? ExperimentVariant.A : ExperimentVariant.B;
+
+  return variant;
+}
+
+function setExperimentCookie(response: NextResponse, variant: string): void {
+  const expirationDate = new Date(Date.now() + 1 * 24 * 60 * 60 * 1000); // 1 day in milliseconds
+
+  response.cookies.set(Experiment.HomepageExperiment, variant, {
+    expires: expirationDate,
+    secure: process.env.NEXT_PUBLIC_VERCEL_ENV !== undefined,
+    sameSite: 'lax',
+    path: '/',
+  });
+}
+
+// Main middleware function
+export function middleware(request: NextRequest) {
+  // Only apply A/B testing to the homepage for logged-out users
+  if (request.nextUrl.pathname === '/') {
+    const variant = getExperimentVariant(request);
+    const response = NextResponse.next();
+
+    // Set experiment cookie
+    setExperimentCookie(response, variant);
+
+    // Add experiment variant to headers for client-side access
+    response.headers.set('x-homepage-experiment', variant);
+
+    return response;
+  }
+
+  // For protected routes, use auth middleware
+  return withAuth(request as NextRequestWithAuth, {
+    callbacks: {
+      authorized: ({ token }) => !!token,
+    },
+  });
+}
 
 export const config = {
-  matcher: ['/notebook/:path*', '/notebook/api/:path*'],
+  matcher: ['/', '/notebook/:path*', '/notebook/api/:path*'],
 };

--- a/types/user.ts
+++ b/types/user.ts
@@ -18,6 +18,7 @@ export interface User {
   moderator: boolean;
   editorOfHubs?: Hub[];
   isModerator?: boolean;
+  authProvider?: 'google' | 'credentials';
 }
 
 export type TransformedUser = User & BaseTransformed;
@@ -39,6 +40,7 @@ const baseTransformUser = (raw: any): User => {
       createdDate: undefined,
       moderator: false,
       isModerator: false,
+      authProvider: undefined,
     };
   }
 
@@ -68,6 +70,11 @@ const baseTransformUser = (raw: any): User => {
     moderator: raw.moderator || false,
     editorOfHubs: editorOfHubs,
     isModerator: raw.moderator || false,
+    authProvider: raw.auth_provider
+      ? raw.auth_provider === 'google'
+        ? 'google'
+        : 'credentials'
+      : undefined,
   };
 };
 
@@ -88,6 +95,7 @@ export const transformUser = (raw: any): TransformedUser => {
       moderator: false,
       raw: null,
       isModerator: false,
+      authProvider: undefined,
     };
   }
 

--- a/utils/experiment.ts
+++ b/utils/experiment.ts
@@ -1,0 +1,56 @@
+import Cookies from 'js-cookie';
+
+export enum Experiment {
+  HomepageExperiment = 'homepageExperiment',
+}
+
+// Experiment variants
+export enum ExperimentVariant {
+  A = 'A', // Control group (Current version)
+  B = 'B', // Treatment group
+}
+
+/**
+ * Get the experiment variant from the cookie.
+ *
+ * @returns The experiment variant or null if not set.
+ */
+export function getExperimentVariant(): string | null {
+  if (typeof document === 'undefined') return null;
+
+  return Cookies.get(Experiment.HomepageExperiment) || null;
+}
+
+/**
+ * Experiments for the application.
+ *
+ * Each experiment is a function that determines if the experiment is enabled.
+ * Centralize all experiment logic here.
+ */
+export const Experiments: Record<Experiment, () => boolean> = {
+  [Experiment.HomepageExperiment]: () =>
+    Cookies.get(Experiment.HomepageExperiment) === ExperimentVariant.B,
+};
+
+/**
+ * Check if an experiment is enabled
+ */
+export function isExperimentEnabled(experiment: Experiment): boolean {
+  const experimentFunction = Experiments[experiment];
+  if (!experimentFunction) {
+    console.warn(`Experiment "${experiment}" is not defined.`);
+    return false;
+  }
+
+  return experimentFunction();
+}
+
+/**
+ * Check if an experiment is enabled on the server.
+ *
+ * @param experimentVariant The experiment variant from the request (for server-side)
+ * @returns True if the experiment is enabled, false otherwise.
+ */
+export function isExperimentEnabledServer(experimentVariant?: ExperimentVariant | null): boolean {
+  return experimentVariant === ExperimentVariant.B;
+}

--- a/utils/navigation.ts
+++ b/utils/navigation.ts
@@ -1,5 +1,6 @@
 import { redirect } from 'next/navigation';
 import { Work } from '@/types/work';
+import { ExperimentVariant, isExperimentEnabledServer } from '@/utils/experiment';
 
 /**
  * Opens an author profile using the appropriate routing mechanism
@@ -34,11 +35,18 @@ export function handleFundraiseRedirect(work: Work, id: string, slug: string) {
 }
 
 /**
- * Handles redirection to trending page if user is authorized
- * @param isAuthorized Whether the user is authorized
+ * Handles redirection to trending page if user is authorized OR experiment is enabled
+ * @param isUserLoggedIn Whether the user is logged in
+ * @param experimentVariant The experiment variant from the request (optional, for server-side)
  */
-export function handleTrendingRedirect(isAuthorized: boolean) {
-  if (isAuthorized) {
+export function handleTrendingRedirect(
+  isUserLoggedIn: boolean,
+  experimentVariant?: ExperimentVariant | null
+) {
+  // Redirect if user is logged in OR if experiment variant B is enabled
+  const isExperimentEnabled = isExperimentEnabledServer(experimentVariant);
+
+  if (isUserLoggedIn || isExperimentEnabled) {
     redirect(`/trending`);
   }
 }


### PR DESCRIPTION
## What?
- Adds experiment tracking infrastructure to monitor homepage variant performance and user behavior.

## How?
- **New experiment system:** Implements cookie-based experiment variant assignment (A = control, B = treatment)
- **Analytics integration:** Tracks experiment exposure and user interactions via Amplitude

### Tracking Strategy
- Due to authentication flow limitations, we track experiment exposure at different points:
  - **Credentials/Email flow**: Track signed_up event immediately after client-side registration (cookies accessible)
  - **Google OAuth**: Track during onboarding flow by checking `authProvider === 'google'` (cookies accessible after redirect)
