### PR TITLE
Update copy and info for the ResearchHub Journal

### DIFF
--- a/app/layouts/PublishMenu.tsx
+++ b/app/layouts/PublishMenu.tsx
@@ -23,8 +23,8 @@ const PUBLISH_MENU_SECTIONS = [
     items: [
       {
         id: 'submit-paper',
-        title: 'Submit your paper',
-        description: 'Preprint or peer reviewed publication',
+        title: 'Get published',
+        description: 'Submit a manuscript as a preprint or publication',
         icon: <Icon name="submit1" size={24} color="#2563eb" />,
         action: 'navigate',
         path: '/paper/create',

--- a/app/layouts/TopBar.tsx
+++ b/app/layouts/TopBar.tsx
@@ -84,7 +84,7 @@ const getPageInfo = (pathname: string): PageInfo | null => {
   if (pathname.startsWith('/paper/create')) {
     return {
       title: 'Submit your paper',
-      subtitle: 'Share your research with the community',
+      subtitle: 'Submit your original work as a preprint or publication',
       icon: <Icon name="submit2" size={20} className="text-primary-600" />,
     };
   }

--- a/app/paper/create/components/DeclarationCheckbox.tsx
+++ b/app/paper/create/components/DeclarationCheckbox.tsx
@@ -1,13 +1,14 @@
 'use client';
 
 import { Checkbox } from '@/components/ui/form/Checkbox';
+import { ReactNode } from 'react';
 
 interface DeclarationCheckboxProps {
   id: string;
   checked: boolean;
   onChange: (checked: boolean) => void;
   label: string;
-  description?: string;
+  description?: ReactNode;
   error?: string | null;
 }
 

--- a/app/paper/create/page.tsx
+++ b/app/paper/create/page.tsx
@@ -11,6 +11,7 @@ import { FileUp, Notebook, Eye, BadgeCheck, BookOpen, Loader2 } from 'lucide-rea
 import type { SearchSuggestion } from '@/types/search';
 import { PaperActionCard } from './PaperActionCard';
 import { Alert } from '@/components/ui/Alert';
+import { Callout } from '@/components/ui/Callout';
 
 type PublishOption = 'notebook' | 'pdf' | null;
 
@@ -197,15 +198,12 @@ export default function WorkCreatePage() {
                         {option.title}
                       </Button>
                       {option.id === 'pdf' && (
-                        <div className="mt-6 ml-1 p-3 bg-gray-50 border-l-4 border-gray-300 rounded-r-md flex items-center gap-3">
-                          <div className="flex-shrink-0 w-5 h-5 rounded-full border border-gray-400 flex items-center justify-center">
-                            <span className="text-gray-500 text-xs font-bold">!</span>
-                          </div>
-                          <p className="text-sm text-gray-700">
-                            You will be able to submit as preprint only (free) or peer-reviewed
-                            publication in the ResearchHub Journal ($300 APC) at the end of the
-                            submission process.
-                          </p>
+                        <div className="mt-6 ml-1">
+                          <Callout
+                            variant="gray"
+                            showBorder={true}
+                            message="You will be able to submit as preprint only (free) or peer-reviewed publication in the ResearchHub Journal ($300 APC) at the end of the submission process."
+                          />
                         </div>
                       )}
                     </div>

--- a/app/paper/create/page.tsx
+++ b/app/paper/create/page.tsx
@@ -202,9 +202,9 @@ export default function WorkCreatePage() {
                             <span className="text-gray-500 text-xs font-bold">!</span>
                           </div>
                           <p className="text-sm text-gray-700">
-                            In the final step of the submission process, you will have the option to
-                            either preprint your manuscript (free) or submit it for peer-reviewed
-                            publication in the ResearchHub Journal (publication fees apply).
+                            You will be able to submit as preprint only (free) or peer-reviewed
+                            publication in the ResearchHub Journal ($300 APC) at the end of the
+                            submission process.
                           </p>
                         </div>
                       )}

--- a/app/paper/create/page.tsx
+++ b/app/paper/create/page.tsx
@@ -85,7 +85,8 @@ export default function WorkCreatePage() {
           </div>
           <h1 className="text-3xl font-bold text-gray-900 text-center">Submit your paper</h1>
           <p className="text-lg text-gray-600 text-center max-w-xl">
-            Share your original work with the ResearchHub community.
+            Publish your original work as a preprint natively on ResearchHub or as a publication in
+            the ResearchHub Journal.
           </p>
         </div>
 
@@ -180,21 +181,34 @@ export default function WorkCreatePage() {
               <p className="text-gray-500 mb-6">
                 Select how you would like to submit your research to ResearchHub.
               </p>
-              <div className="space-y-4">
+              <div className="space-y-6">
                 {publishOptions.map((option) => {
                   const Icon = option.icon;
                   return (
-                    <Button
-                      key={option.id}
-                      variant="outlined"
-                      size="lg"
-                      className="w-full flex items-center gap-2"
-                      onClick={() => !isPending && handleOptionClick(option.id as PublishOption)}
-                      disabled={isPending}
-                    >
-                      <Icon className="h-5 w-5 mr-2" />
-                      {option.title}
-                    </Button>
+                    <div key={option.id}>
+                      <Button
+                        variant="outlined"
+                        size="lg"
+                        className="w-full flex items-center gap-2"
+                        onClick={() => !isPending && handleOptionClick(option.id as PublishOption)}
+                        disabled={isPending}
+                      >
+                        <Icon className="h-5 w-5 mr-2" />
+                        {option.title}
+                      </Button>
+                      {option.id === 'pdf' && (
+                        <div className="mt-6 ml-1 p-3 bg-gray-50 border-l-4 border-gray-300 rounded-r-md flex items-center gap-3">
+                          <div className="flex-shrink-0 w-5 h-5 rounded-full border border-gray-400 flex items-center justify-center">
+                            <span className="text-gray-500 text-xs font-bold">!</span>
+                          </div>
+                          <p className="text-sm text-gray-700">
+                            In the final step of the submission process, you will have the option to
+                            either preprint your manuscript (free) or submit it for peer-reviewed
+                            publication in the ResearchHub Journal (publication fees apply).
+                          </p>
+                        </div>
+                      )}
+                    </div>
                   );
                 })}
               </div>

--- a/app/paper/create/pdf/page.tsx
+++ b/app/paper/create/pdf/page.tsx
@@ -416,9 +416,9 @@ export default function UploadPDFPage() {
               </div>
             </div>
 
-            <div className="ml-1 p-3 bg-red-50 border-l-4 border-red-300 rounded-r-md flex items-center gap-3">
-              <div className="flex-shrink-0 w-5 h-5 rounded-full border border-red-400 flex items-center justify-center">
-                <span className="text-red-500 text-xs font-bold">!</span>
+            <div className="ml-1 p-3 bg-yellow-50 border-l-4 border-yellow-500 rounded-r-md flex items-center gap-3">
+              <div className="flex-shrink-0 w-5 h-5 rounded-full border border-yellow-600 flex items-center justify-center">
+                <span className="text-yellow-700 text-xs font-bold">!</span>
               </div>
               <p className="text-sm text-gray-900">
                 If submitting to the <em>ResearchHub Journal</em>, please ensure your manuscript

--- a/app/paper/create/pdf/page.tsx
+++ b/app/paper/create/pdf/page.tsx
@@ -420,14 +420,14 @@ export default function UploadPDFPage() {
               <div className="flex-shrink-0 w-5 h-5 rounded-full border border-red-400 flex items-center justify-center">
                 <span className="text-red-500 text-xs font-bold">!</span>
               </div>
-              <p className="text-sm text-red-700">
+              <p className="text-sm text-gray-900">
                 If submitting to the <em>ResearchHub Journal</em>, please ensure your manuscript
                 fits within the{' '}
                 <a
                   href="https://www.researchhub.com/journal?tab=about"
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="text-red-600 hover:text-red-800 underline"
+                  className="text-blue-600 hover:text-blue-800 underline"
                 >
                   Aims and Scope
                 </a>

--- a/app/paper/create/pdf/page.tsx
+++ b/app/paper/create/pdf/page.tsx
@@ -29,6 +29,7 @@ import toast from 'react-hot-toast';
 import { Switch } from '@/components/ui/Switch';
 import { AvatarStack } from '@/components/ui/AvatarStack';
 import { useScreenSize } from '@/hooks/useScreenSize';
+import { Callout } from '@/components/ui/Callout';
 
 // Define the steps of our flow
 const steps: SimpleStep[] = [
@@ -416,22 +417,25 @@ export default function UploadPDFPage() {
               </div>
             </div>
 
-            <div className="ml-1 p-3 bg-yellow-50 border-l-4 border-yellow-500 rounded-r-md flex items-center gap-3">
-              <div className="flex-shrink-0 w-5 h-5 rounded-full border border-yellow-600 flex items-center justify-center">
-                <span className="text-yellow-700 text-xs font-bold">!</span>
-              </div>
-              <p className="text-sm text-gray-900">
-                If submitting to the <em>ResearchHub Journal</em>, please ensure your manuscript
-                fits within the{' '}
-                <a
-                  href="https://www.researchhub.com/journal?tab=about"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-blue-600 hover:text-blue-800 underline"
-                >
-                  Aims and Scope
-                </a>
-              </p>
+            <div className="ml-1">
+              <Callout
+                variant="warning"
+                showBorder={true}
+                message={
+                  <>
+                    If submitting to the <em>ResearchHub Journal</em>, please ensure your manuscript
+                    fits the{' '}
+                    <a
+                      href="https://www.researchhub.com/journal?tab=about"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-blue-600 hover:text-blue-800 underline"
+                    >
+                      Aims and Scope
+                    </a>
+                  </>
+                }
+              />
             </div>
           </div>
         );

--- a/app/paper/create/pdf/page.tsx
+++ b/app/paper/create/pdf/page.tsx
@@ -415,6 +415,24 @@ export default function UploadPDFPage() {
                 />
               </div>
             </div>
+
+            <div className="ml-1 p-3 bg-red-50 border-l-4 border-red-300 rounded-r-md flex items-center gap-3">
+              <div className="flex-shrink-0 w-5 h-5 rounded-full border border-red-400 flex items-center justify-center">
+                <span className="text-red-500 text-xs font-bold">!</span>
+              </div>
+              <p className="text-sm text-red-700">
+                If submitting to the <em>ResearchHub Journal</em>, please ensure your manuscript
+                fits within the{' '}
+                <a
+                  href="https://www.researchhub.com/journal?tab=about"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-red-600 hover:text-red-800 underline"
+                >
+                  Aims and Scope
+                </a>
+              </p>
+            </div>
           </div>
         );
 
@@ -434,7 +452,21 @@ export default function UploadPDFPage() {
                 checked={acceptedTerms}
                 onChange={handleTermsChange}
                 label="I accept the terms and conditions"
-                description="By checking this box, you confirm that you have read and agree to the ResearchHub terms of service."
+                description={
+                  <>
+                    By checking this box, you confirm that you have read and agree to the
+                    ResearchHub{' '}
+                    <a
+                      href="https://www.researchhub.com/about/tos"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-primary-600 hover:text-primary-700 hover:underline"
+                    >
+                      terms of service
+                    </a>
+                    .
+                  </>
+                }
                 error={errors.terms || null}
               />
 
@@ -443,7 +475,20 @@ export default function UploadPDFPage() {
                 checked={acceptedLicense}
                 onChange={handleLicenseChange}
                 label="I agree to publish under the CC BY 4.0 License"
-                description="By checking this box, you license your work under the Creative Commons Attribution 4.0 International License."
+                description={
+                  <>
+                    By checking this box, you license your work under the{' '}
+                    <a
+                      href="https://creativecommons.org/licenses/by/4.0/deed.en"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-primary-600 hover:text-primary-700 hover:underline"
+                    >
+                      Creative Commons Attribution 4.0 International License
+                    </a>
+                    .
+                  </>
+                }
                 error={errors.license || null}
               />
 

--- a/components/Journal/RHJRightSidebar.tsx
+++ b/components/Journal/RHJRightSidebar.tsx
@@ -25,7 +25,7 @@ const keyFeatures = [
 
 const quickLinks = [
   {
-    href: 'https://docs.google.com/document/d/1a3WrTSDOCvWXxWetbPn-TDav56Y7EFwpyzK5B8Ll3Io/edit?tab=t.0',
+    href: 'https://drive.google.com/file/d/1qKlGnNSA-98kg-RhmTFKYVB85X0PJWYr/view?usp=sharing',
     text: 'Author Guidelines',
     icon: Feather,
   },

--- a/components/Journal/about/JournalEditorialBoard.tsx
+++ b/components/Journal/about/JournalEditorialBoard.tsx
@@ -8,9 +8,11 @@ export const JournalEditorialBoard = () => {
       <div className="max-w-4xl mx-auto">
         <div className="mb-12 max-w-3xl">
           <h2 className="text-3xl font-medium text-gray-900 mb-4 text-left">Editorial Board</h2>
-          <p className="text-lg text-gray-600 text-left">
-            Our goal at ResearchHub is to drive scientific progress by introducing innovative reward
-            systems that compensate peer reviewers for their contributions.
+          <p className="text-base text-gray-600 text-left">
+            The following people constitute the Editorial Board of Academic Editors for the
+            ResearchHub Journal. These active academics are the Editors who seek peer reviewers,
+            evaluate their responses, and make editorial decisions on each submission to the
+            journal.
           </p>
         </div>
         <div className="grid grid-cols-1 gap-6">

--- a/components/Journal/about/JournalEditorialBoard.tsx
+++ b/components/Journal/about/JournalEditorialBoard.tsx
@@ -9,7 +9,7 @@ export const JournalEditorialBoard = () => {
         <div className="mb-12 max-w-3xl">
           <h2 className="text-3xl font-medium text-gray-900 mb-4 text-left">Editorial Board</h2>
           <p className="text-base text-gray-600 text-left">
-            The following people constitute the Editorial Board of Academic Editors for the
+            The following people constitute the editorial board of academic editors for the
             ResearchHub Journal. These active academics are the Editors who seek peer reviewers,
             evaluate their responses, and make editorial decisions on each submission to the
             journal.

--- a/components/Journal/about/JournalFeatures.tsx
+++ b/components/Journal/about/JournalFeatures.tsx
@@ -6,12 +6,18 @@ export const JournalFeatures: FC = () => {
   return (
     <div className="bg-gray-50 py-16 px-4">
       <div className="max-w-5xl mx-auto text-center">
-        <h2 className="text-3xl font-medium text-gray-900 mb-4 text-left">About this journal</h2>
-        <p className="text-lg text-gray-600 mb-12 max-w-3xl text-left">
+        <h2 className="text-3xl font-medium text-gray-900 mb-4 text-left -mt-8">
+          About this journal
+        </h2>
+        <p className="text-base text-gray-600 mb-12 max-w-3xl text-left">
           The ResearchHub Journal aims to accelerate the pace of science through novel incentive
           structures that reward authors for reproducible research and compensate peer reviewers for
-          their expertise. Authors receive rapid, constructive feedback through 2+ expert open peer
-          reviews.
+          their expertise. Through an open and transparent peer review process, submitted preprints
+          are assigned to an academic editor to oversee a rigorous, open peer review process.
+          Authors receive rapid, constructive feedback through 2+ expert open peer reviews and are
+          asked to revise their preprint based on these reviews. Once completed, the handling editor
+          accepts the peer-reviewed preprint for final publication, which is then published as a
+          completed, version of record article.
         </p>
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-2 gap-6 text-left">
           <FeatureCard icon={BookPlus} title="Preprint Publication">

--- a/components/Journal/about/JournalHowItWorks.tsx
+++ b/components/Journal/about/JournalHowItWorks.tsx
@@ -9,8 +9,8 @@ const howItWorksItems = [
     content: (
       <>
         <p>
-          ResearchHub Journal welcomes submissions across all scientific disciplines, with a
-          particular focus on:
+          ResearchHub Journal welcomes submissions across all Biological and Biomedical Sciences
+          with a particular focus on:
         </p>
         <ul className="list-disc pl-6 my-2 space-y-1">
           <li>Biological and Biomedical Sciences</li>
@@ -35,9 +35,18 @@ const howItWorksItems = [
         <p>We accept the following types of submissions:</p>
         <p className="font-medium mt-3 mb-1">Original Research Articles</p>
         <ul className="list-disc pl-6 space-y-1">
-          <li>Full research papers presenting novel findings</li>
+          <li>
+            Full research papers presenting novel findings, confirmatory findings, contradictory
+            findings, negative and null results, replication and reanalysis studies
+          </li>
           <li>Complete methodology and results required</li>
           <li>No length restrictions, but clarity and conciseness valued</li>
+        </ul>
+        <p className="font-medium mt-3 mb-1">Pre-Registrations</p>
+        <ul className="list-disc pl-6 space-y-1">
+          <li>Publicly document study design before data collection or analysis</li>
+          <li>Detailed Methodology and Analysis Plan required</li>
+          <li>Option to publish and link subsequent data and results</li>
         </ul>
         <p className="font-medium mt-3 mb-1">Short Communications</p>
         <ul className="list-disc pl-6 space-y-1">
@@ -57,6 +66,13 @@ const howItWorksItems = [
           <li>Must provide novel synthesis or perspective</li>
           <li>By invitation only - contact Editorial Board if interested</li>
           <li>Systematic reviews particularly welcomed</li>
+        </ul>
+        <p className="font-medium mt-3 mb-1">Commentaries (Invitation Only)</p>
+        <ul className="list-disc pl-6 space-y-1">
+          <li>Must include expert interpretation and perspective</li>
+          <li>Highlights implications and stimulates debate</li>
+          <li>Maximum 3,000 words</li>
+          <li>Support concise and timely contribution</li>
         </ul>
       </>
     ),
@@ -98,7 +114,7 @@ const howItWorksItems = [
         </p>
         <div className="mt-4">
           <a
-            href="https://docs.google.com/document/d/1a3WrTSDOCvWXxWetbPn-TDav56Y7EFwpyzK5B8Ll3Io/edit?tab=t.0"
+            href="https://drive.google.com/file/d/1qKlGnNSA-98kg-RhmTFKYVB85X0PJWYr/view?usp=sharing"
             target="_blank"
             rel="noopener noreferrer"
             className="inline-flex items-center gap-2 px-4 py-2 bg-primary-600 text-white text-sm font-medium rounded-md hover:bg-primary-700 transition-colors"
@@ -216,6 +232,78 @@ const howItWorksItems = [
     ),
   },
   {
+    id: 'editorial-processes',
+    title: 'Editorial and Peer Review Processes',
+    content: (
+      <>
+        <p>
+          ResearchHub journal has clear and rigorous editorial and processes from initial submission
+          to final publication. To find out more, please consult our editorial and peer review
+          processes. Contact the editorial team if you have any questions.
+        </p>
+        <div className="mt-4">
+          <a
+            href="https://drive.google.com/file/d/1imBbn1pOCM7OYZEJ054Cgm9cxVrQMlIM/view?usp=sharing"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-2 px-4 py-2 bg-primary-600 text-white text-sm font-medium rounded-md hover:bg-primary-700 transition-colors"
+          >
+            View Editorial and Peer Review Process
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="12"
+              height="12"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <path d="M7 17l9.2-9.2M17 17V7H7" />
+            </svg>
+          </a>
+        </div>
+      </>
+    ),
+  },
+  {
+    id: 'editorial-policies',
+    title: 'Editorial Policies',
+    content: (
+      <>
+        <p>
+          ResearchHub journal fully adheres to industry standards for its editorial policies,
+          ensuring only rigorous and trustworthy content is published. To find out more, please
+          consult our editorial policies. Contact the editorial team if you have any questions.
+        </p>
+        <div className="mt-4">
+          <a
+            href="https://drive.google.com/file/d/1jLeo73A_tY8MvQ6noevH7CYE2_3mho9X/view?usp=sharing"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-2 px-4 py-2 bg-primary-600 text-white text-sm font-medium rounded-md hover:bg-primary-700 transition-colors"
+          >
+            View Editorial Policies
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="12"
+              height="12"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <path d="M7 17l9.2-9.2M17 17V7H7" />
+            </svg>
+          </a>
+        </div>
+      </>
+    ),
+  },
+  {
     id: 'apc',
     title: 'Article processing charge',
     content: (
@@ -284,7 +372,7 @@ const howItWorksItems = [
     title: 'Open access policies',
     content: (
       <>
-        <p>All content is published under open licenses:</p>
+        <p>Since we started publishing in 2024, all content is published under open licenses:</p>
         <ul className="list-disc pl-6 my-2 space-y-1">
           <li>Manuscripts: CC-BY 4.0</li>
         </ul>
@@ -323,7 +411,7 @@ export const JournalHowItWorks: FC<JournalHowItWorksProps> = ({ openItemId, onTo
       <div className="max-w-4xl mx-auto">
         <div className="mb-12 max-w-3xl">
           <h2 className="text-3xl font-medium text-gray-900 mb-4 text-left">How it Works</h2>
-          <p className="text-lg text-gray-600 text-left">
+          <p className="text-base text-gray-600 text-left">
             Learn about our publication process, peer review system, and how we accelerate
             scientific discovery through open access and fair compensation.
           </p>

--- a/components/Journal/about/JournalHowItWorks.tsx
+++ b/components/Journal/about/JournalHowItWorks.tsx
@@ -45,7 +45,7 @@ const howItWorksItems = [
         <p className="font-medium mt-3 mb-1">Pre-Registrations</p>
         <ul className="list-disc pl-6 space-y-1">
           <li>Publicly document study design before data collection or analysis</li>
-          <li>Detailed Methodology and Analysis Plan required</li>
+          <li>Detailed methodology and analysis plan required</li>
           <li>Option to publish and link subsequent data and results</li>
         </ul>
         <p className="font-medium mt-3 mb-1">Short Communications</p>
@@ -239,7 +239,7 @@ const howItWorksItems = [
         <p>
           ResearchHub journal has clear and rigorous editorial and processes from initial submission
           to final publication. To find out more, please consult our editorial and peer review
-          processes. Contact the editorial team if you have any questions.
+          processes linked below. Contact the editorial team if you have any questions.
         </p>
         <div className="mt-4">
           <a

--- a/components/landing/LandingPageFooter.tsx
+++ b/components/landing/LandingPageFooter.tsx
@@ -46,7 +46,7 @@ export function LandingPageFooter() {
     },
     {
       label: 'Author guidelines',
-      href: 'https://docs.google.com/document/d/1a3WrTSDOCvWXxWetbPn-TDav56Y7EFwpyzK5B8Ll3Io/edit?tab=t.0',
+      href: 'https://drive.google.com/file/d/1qKlGnNSA-98kg-RhmTFKYVB85X0PJWYr/view?usp=sharing',
     },
   ];
 

--- a/components/ui/Callout.tsx
+++ b/components/ui/Callout.tsx
@@ -29,26 +29,31 @@ const variantStyles = {
     container: 'bg-blue-50 text-blue-800',
     border: 'border-blue-300',
     icon: 'text-blue-600',
+    iconBorder: 'border-blue-600',
   },
   warning: {
     container: 'bg-yellow-50 text-gray-900',
     border: 'border-yellow-500',
     icon: 'text-yellow-600',
+    iconBorder: 'border-yellow-600',
   },
   error: {
     container: 'bg-red-50 text-red-800',
     border: 'border-red-300',
     icon: 'text-red-600',
+    iconBorder: 'border-red-600',
   },
   success: {
     container: 'bg-green-50 text-green-800',
     border: 'border-green-300',
     icon: 'text-green-600',
+    iconBorder: 'border-green-600',
   },
   gray: {
     container: 'bg-gray-50 text-gray-700',
     border: 'border-gray-300',
     icon: 'text-gray-500',
+    iconBorder: 'border-gray-500',
   },
 };
 
@@ -81,7 +86,7 @@ export function Callout({
       )}
     >
       <div
-        className={`flex-shrink-0 w-5 h-5 rounded-full border flex items-center justify-center ${styles.icon.replace('text-', 'border-')}`}
+        className={`flex-shrink-0 w-5 h-5 rounded-full border flex items-center justify-center ${styles.iconBorder}`}
       >
         <span className={`text-xs font-bold leading-none ${styles.icon}`}>!</span>
       </div>

--- a/components/ui/Callout.tsx
+++ b/components/ui/Callout.tsx
@@ -1,0 +1,91 @@
+'use client';
+
+import { cn } from '@/utils/styles';
+import { ReactNode } from 'react';
+
+type CalloutVariant = 'info' | 'warning' | 'error' | 'success' | 'gray';
+
+interface CalloutProps {
+  /**
+   * The variant of the callout
+   */
+  variant?: CalloutVariant;
+  /**
+   * The message content of the callout
+   */
+  message: ReactNode;
+  /**
+   * Optional CSS class name
+   */
+  className?: string;
+  /**
+   * Whether to show the left border accent
+   */
+  showBorder?: boolean;
+}
+
+const variantStyles = {
+  info: {
+    container: 'bg-blue-50 text-blue-800',
+    border: 'border-blue-300',
+    icon: 'text-blue-600',
+  },
+  warning: {
+    container: 'bg-yellow-50 text-gray-900',
+    border: 'border-yellow-500',
+    icon: 'text-yellow-600',
+  },
+  error: {
+    container: 'bg-red-50 text-red-800',
+    border: 'border-red-300',
+    icon: 'text-red-600',
+  },
+  success: {
+    container: 'bg-green-50 text-green-800',
+    border: 'border-green-300',
+    icon: 'text-green-600',
+  },
+  gray: {
+    container: 'bg-gray-50 text-gray-700',
+    border: 'border-gray-300',
+    icon: 'text-gray-500',
+  },
+};
+
+/**
+ * Callout component for displaying informational, warning, or error messages
+ *
+ * @example
+ * <Callout variant="warning" showBorder={true} message="This is a warning message" />
+ *
+ * @example
+ * <Callout variant="info" message={
+ *   <>This is an info message with a <a href="#">link</a></>
+ * } />
+ */
+export function Callout({
+  variant = 'info',
+  message,
+  className,
+  showBorder = false,
+}: CalloutProps) {
+  const styles = variantStyles[variant];
+
+  return (
+    <div
+      className={cn(
+        'flex items-center gap-3 p-3 rounded-md text-sm',
+        showBorder && `border-l-4 ${styles.border}`,
+        styles.container,
+        className
+      )}
+    >
+      <div
+        className={`flex-shrink-0 w-5 h-5 rounded-full border flex items-center justify-center ${styles.icon.replace('text-', 'border-')}`}
+      >
+        <span className={`text-xs font-bold leading-none ${styles.icon}`}>!</span>
+      </div>
+      <div className="flex-1">{message}</div>
+    </div>
+  );
+}


### PR DESCRIPTION
A step by step walkthrough was done with Senior/Associate Editors to refine confusing components of the RHJ submission workflow. Additionally, copy for the "About" section was updated according to recommendations for indexing.

**Highlights**
1. `+new` copy was confusing users - they would go through this flow to upload an already existing paper into ResearchHub when they couldn't find it in search. 

<img width="341" height="228" alt="image" src="https://github.com/user-attachments/assets/178c880c-7886-4c52-a6dc-05cb653c033d" />

2. Informational section upfront indicating there will be 2 options at the end. Users were confused since it's the same workflow for both preprint or peer-reviewed publication.

<img width="801" height="307" alt="image" src="https://github.com/user-attachments/assets/4c0c64e4-278f-4f74-b673-c111a48b6d14" />

3. One of the largest issues we are receiving for the ResearchHub Journal is submissions beyond the scope of the journal and our editors expertise (i.e. non-biomedical sciences or chemistry submissions). Added an informational in red to alert users to ensure they are within scope if submitting to the ResearchHub Journal

<img width="801" height="261" alt="image" src="https://github.com/user-attachments/assets/696cf1eb-4fa0-4221-beaf-219134b0ee30" />