### PR TITLE
Fix wording on "Stop fundraise" button

### DIFF
--- a/components/work/WorkLineItems.tsx
+++ b/components/work/WorkLineItems.tsx
@@ -296,7 +296,7 @@ export const WorkLineItems = ({
                 onSelect={() => executeAuthenticatedAction(handleCloseFundraise)}
               >
                 <Octagon className="h-4 w-4 mr-2" />
-                <span>Stop Fundraise</span>
+                <span>Close fundraise & refund contributors</span>
               </BaseMenuItem>
             )}
             <BaseMenuItem
@@ -427,9 +427,9 @@ export const WorkLineItems = ({
         isOpen={showCloseFundraiseConfirm}
         onClose={() => setShowCloseFundraiseConfirm(false)}
         onConfirm={confirmCloseFundraise}
-        title="Stop Fundraise"
-        message="Are you sure you want to stop this fundraise? This action will prevent further contributions and cannot be undone."
-        confirmText="Stop Fundraise"
+        title="Close fundraise & refund contributors"
+        message="Are you sure you want to close this fundraise? This will immediately refund all contributions to contributors and close the fundraise permanently. No funds will be distributed to Endaoment or the researcher. This action cannot be undone."
+        confirmText="Close fundraise & refund contributors"
         cancelText="Cancel"
         confirmButtonClass="bg-red-600 hover:bg-red-700"
         cancelButtonClass="bg-white text-gray-700 border border-gray-300 hover:bg-gray-50"


### PR DESCRIPTION
"Stop fundraise" actually sets the fundraise to "closed" and refunds all participants, but verbiage was unclear.

NEW:
<img width="905" height="523" alt="Screenshot 2025-07-30 at 10 18 28 AM" src="https://github.com/user-attachments/assets/7e301b2d-247f-427b-8fb9-770eea792fec" />
<img width="734" height="266" alt="Screenshot 2025-07-30 at 10 18 33 AM" src="https://github.com/user-attachments/assets/de16587d-63df-4c7a-845c-78db08010d33" />

OLD:
<img width="903" height="544" alt="Screenshot 2025-07-30 at 10 20 15 AM" src="https://github.com/user-attachments/assets/155be3ff-a188-49d3-94c1-bd33cb4b0864" />
<img width="756" height="272" alt="Screenshot 2025-07-30 at 10 20 19 AM" src="https://github.com/user-attachments/assets/ac222929-3dea-433d-a3c7-0d49046efc22" />
