### PR TITLE
Fix LinkedIn pre-filled text

### DIFF
--- a/components/Referral/ReferralLinkCard.tsx
+++ b/components/Referral/ReferralLinkCard.tsx
@@ -70,7 +70,7 @@ Join with my link and we'll both receive a 10% bonus on every $RSC you donate ov
       referralCode,
     });
 
-    const text = `Fund breakthrough science with me on ResearchHub! Join with my link and we'll both receive a 10% bonus on every $RSC you donate over the next 6 months. Let's accelerate science together! 💰🧪\n\n${referralLink}`;
+    const text = `Fund breakthrough science with me on ResearchHub!\n\nJoin with my link and we'll both receive a 10% bonus on every $RSC you donate over the next 6 months. Let's accelerate science together! 💰🧪\n\n${referralLink}`;
     const url = `https://www.linkedin.com/feed/?shareActive=true&text=${encodeURIComponent(text)}`;
     window.open(url, '_blank');
   };


### PR DESCRIPTION
Updated the shareOnLinkedIn function to use the linkedin.com/feed/?shareActive=true endpoint with the text parameter

<img width="746" height="599" alt="Screenshot 2025-07-31 at 10 19 02 AM" src="https://github.com/user-attachments/assets/e11a66f4-2247-4f27-848f-b71334f0cf36" />
