### PR TITLE
Add "Complete Fundraise" Button for Mod Users

### DIFF
--- a/components/Fund/FundraiseProgress.tsx
+++ b/components/Fund/FundraiseProgress.tsx
@@ -4,7 +4,7 @@ import { FC, useState } from 'react';
 import { Progress } from '@/components/ui/Progress';
 import { ContributorsButton } from '@/components/ui/ContributorsButton';
 import { Clock } from 'lucide-react';
-import { formatDeadline, isDeadlineInFuture } from '@/utils/date';
+import { formatDeadline, formatExactTime, isDeadlineInFuture } from '@/utils/date';
 import type { Fundraise } from '@/types/funding';
 import { Button } from '@/components/ui/Button';
 import { cn } from '@/utils/styles';
@@ -15,6 +15,7 @@ import { AvatarStack } from '@/components/ui/AvatarStack';
 import { useCurrencyPreference } from '@/contexts/CurrencyPreferenceContext';
 import { useShareModalContext } from '@/contexts/ShareContext';
 import { useRouter } from 'next/navigation';
+import { Tooltip } from '@/components/ui/Tooltip';
 
 interface FundraiseProgressProps {
   fundraise: Fundraise;
@@ -91,14 +92,18 @@ export const FundraiseProgress: FC<FundraiseProgressProps> = ({
           </span>
         );
       case 'OPEN':
-        return deadlineText === 'Ended' ? (
+        return deadlineText?.includes('Ended') ? (
           <span className={`${compact ? 'text-xs' : 'text-sm'} text-gray-500 font-medium`}>
             Ended
           </span>
         ) : deadlineText ? (
           <div className="flex items-center gap-1.5 text-gray-800">
             <Clock className={compact ? 'h-3 w-3' : 'h-4 w-4'} />
-            <span className={compact ? 'text-xs' : 'text-sm'}>{deadlineText}</span>
+            <Tooltip content={formatExactTime(fundraise.endDate!)} position="top" width="w-48">
+              <span className={`${compact ? 'text-xs' : 'text-sm'} cursor-help`}>
+                {deadlineText}
+              </span>
+            </Tooltip>
           </div>
         ) : null;
       default:

--- a/hooks/useFundraise.ts
+++ b/hooks/useFundraise.ts
@@ -18,6 +18,9 @@ type UseCreateContributionReturn = [UseFundraiseState, CreateContributionFn];
 type CloseFundraiseFn = (id: ID) => Promise<void>;
 type UseCloseFundraiseReturn = [UseFundraiseState, CloseFundraiseFn];
 
+type CompleteFundraiseFn = (id: ID) => Promise<void>;
+type UseCompleteFundraiseReturn = [UseFundraiseState, CompleteFundraiseFn];
+
 export const useCreateContribution = (): UseCreateContributionReturn => {
   const [data, setData] = useState<Fundraise | null>(null);
   const [isLoading, setIsLoading] = useState(false);
@@ -65,4 +68,28 @@ export const useCloseFundraise = (): UseCloseFundraiseReturn => {
   };
 
   return [{ data, isLoading, error }, closeFundraise];
+};
+
+export const useCompleteFundraise = (): UseCompleteFundraiseReturn => {
+  const [data, setData] = useState<Fundraise | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const completeFundraise = async (id: ID) => {
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const response = await FundraiseService.completeFundraise(id);
+      setData(response);
+    } catch (err) {
+      const errorMsg = err instanceof ApiError ? err.message : 'Failed to complete fundraise';
+      setError(errorMsg);
+      throw err;
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return [{ data, isLoading, error }, completeFundraise];
 };

--- a/services/fundraise.service.ts
+++ b/services/fundraise.service.ts
@@ -42,6 +42,16 @@ export class FundraiseService {
   }
 
   /**
+   * Complete a fundraise
+   * @param fundraiseId The ID of the fundraise to complete
+   * @returns The updated fundraise with COMPLETED status
+   */
+  static async completeFundraise(fundraiseId: ID): Promise<Fundraise> {
+    const response = await ApiClient.post<any>(`${this.BASE_PATH}/${fundraiseId}/complete/`);
+    return transformFundraise(response);
+  }
+
+  /**
    * Alias for contributeToFundraise to maintain backwards compatibility with existing hooks
    * @param id The ID of the fundraise to contribute to
    * @param payload The payload containing the amount

--- a/utils/date.ts
+++ b/utils/date.ts
@@ -54,7 +54,17 @@ export function formatDeadline(deadline: string): string {
   if (diffDays < 0) {
     return 'Ended';
   } else if (diffDays === 0) {
-    return 'Ends today';
+    const diffMs = deadlineDate.diff(now);
+    const diffHours = deadlineDate.diff(now, 'hour');
+    if (diffMs < 0) {
+      return 'Ended today';
+    } else if (diffHours === 0) {
+      return 'Ends in less than an hour';
+    } else if (diffHours > 0 && diffHours < 24) {
+      return `Ends in ${diffHours} hours`;
+    } else {
+      return 'Ends today';
+    }
   } else if (diffDays === 1) {
     return 'Ends tomorrow';
   } else if (diffDays < 30) {
@@ -106,3 +116,12 @@ export function specificTimeSince(dateInput: string | Date): string {
     return `${result[0]}, ${result[1]} and ${result[2]}`;
   }
 }
+
+/**
+ * Formats a deadline timestamp into a human-readable string with exact time
+ * @param deadline ISO timestamp string
+ * @returns Formatted deadline string (e.g. "Dec 15, 2024 at 12:00 PM")
+ */
+export const formatExactTime = (deadline: string): string => {
+  return dayjs(deadline).format('MMM D, YYYY [at] h:mm A');
+};


### PR DESCRIPTION
## What?
- https://github.com/ResearchHub/issues/issues/390
- Moderators can now complete fundraises to distribute funds to researchers
- Only available for preregistration content with active fundraises

## How?
- Added `completeFundraise()` method to `FundraiseService` calling `/api/fundraise/{id}/complete/`
- Added menu item in `WorkLineItems` dropdown with **CheckCircle** icon

<img width="756" height="434" alt="image" src="https://github.com/user-attachments/assets/696d6ce9-d562-4a5d-a63f-81adcad9e1a6" />
