### PR TITLE
Extend paper edit functionality to allow editors to edit topics

### DIFF
--- a/components/work/WorkLineItems.tsx
+++ b/components/work/WorkLineItems.tsx
@@ -104,8 +104,13 @@ export const WorkLineItems = ({
     }
   }, [work.contentType, work.id, isUpvoted, vote, refreshVotes]);
 
+  // Determine if current user is a moderator
+  const isModerator = !!user?.isModerator;
+  // Determine if current user is a hub editor
+  const isHubEditor = !!user?.authorProfile?.isHubEditor;
+
   const handleEdit = useCallback(() => {
-    if (work.contentType === 'paper' && user?.isModerator) {
+    if (work.contentType === 'paper' && (isModerator || isHubEditor)) {
       setIsWorkEditModalOpen(true);
     } else if (selectedOrg && work.note) {
       router.push(`/notebook/${work.note.organization.slug}/${work.note.id}`);
@@ -122,10 +127,6 @@ export const WorkLineItems = ({
   // Determine if the latest version has already been published
   const latestVersion = work.versions?.find((v) => v.isLatest);
   const isPublished = latestVersion?.publicationStatus === 'PUBLISHED';
-  // Determine if current user is a moderator
-  const isModerator = !!user?.isModerator;
-  // Determine if current user is a hub editor
-  const isHubEditor = !!user?.authorProfile?.isHubEditor;
 
   const handlePublish = useCallback(async () => {
     if (isPublished) return;

--- a/components/work/WorkLineItems.tsx
+++ b/components/work/WorkLineItems.tsx
@@ -124,6 +124,8 @@ export const WorkLineItems = ({
   const isPublished = latestVersion?.publicationStatus === 'PUBLISHED';
   // Determine if current user is a moderator
   const isModerator = !!user?.isModerator;
+  // Determine if current user is a hub editor
+  const isHubEditor = !!user?.authorProfile?.isHubEditor;
 
   const handlePublish = useCallback(async () => {
     if (isPublished) return;
@@ -162,7 +164,7 @@ export const WorkLineItems = ({
   const canEdit = (() => {
     switch (work.contentType) {
       case 'paper':
-        return isModerator;
+        return isModerator || isHubEditor;
       case 'funding_request':
         return isGrantContact || isAuthor || isModerator;
       default:
@@ -325,7 +327,11 @@ export const WorkLineItems = ({
           >
             {canEdit && (
               <BaseMenuItem
-                disabled={work.contentType === 'paper' ? !isModerator : !selectedOrg || !work.note}
+                disabled={
+                  work.contentType === 'paper'
+                    ? !isModerator && !isHubEditor
+                    : !selectedOrg || !work.note
+                }
                 onSelect={handleEdit}
               >
                 <Edit className="h-4 w-4 mr-2" />

--- a/types/authorProfile.ts
+++ b/types/authorProfile.ts
@@ -46,6 +46,7 @@ export interface AuthorProfile {
   i10Index?: number;
   userId?: number;
   editorOfHubs?: Hub[];
+  isHubEditor?: boolean;
 }
 
 export type TransformedAuthorProfile = AuthorProfile & BaseTransformed;
@@ -103,6 +104,7 @@ export const transformAuthorProfile = createTransformer<any, AuthorProfile>((raw
     userId: raw.user_id || undefined,
     editorOfHubs: editorOfHubs,
     isVerified: raw.is_verified_v2 || false,
+    isHubEditor: raw.is_hub_editor || false,
   };
 });
 


### PR DESCRIPTION
## What?
- Added support for editors to edit paper topics in addition to moderators and hub editors.

## How?
- Added `isHubEditor` property to the `User` type definition
- Updated the edit permission logic in `WorkLineItems` component to include editors