### PR TITLE
Fix: Prevent Analytics Failures from Blocking Google OAuth Flow

### DIFF
--- a/components/Auth/screens/SelectProvider.tsx
+++ b/components/Auth/screens/SelectProvider.tsx
@@ -78,7 +78,10 @@ export default function SelectProvider({
   };
 
   const handleGoogleSignIn = async () => {
-    await AnalyticsService.logEvent(LogEvent.AUTH_VIA_GOOGLE_INITIATED);
+    AnalyticsService.logEvent(LogEvent.AUTH_VIA_GOOGLE_INITIATED).catch((error) => {
+      console.error('Analytics failed:', error);
+    });
+
     const searchParams = new URLSearchParams(window.location.search);
     const originalCallbackUrl = searchParams.get('callbackUrl') || '/';
 

--- a/services/analytics.service.ts
+++ b/services/analytics.service.ts
@@ -42,14 +42,22 @@ class AnalyticsService {
     const paddedUserId = userId ? userId.toString().padStart(6, '0') : null;
 
     if (!this.isInitialized.amplitude) {
-      // First time initialization
-      amplitude.init(apiKey, paddedUserId || undefined, {
-        autocapture: true,
-      });
-      this.isInitialized.amplitude = true;
+      try {
+        // First time initialization
+        amplitude.init(apiKey, paddedUserId || undefined, {
+          autocapture: true,
+        });
+        this.isInitialized.amplitude = true;
+      } catch (error) {
+        console.error('Failed to initialize Amplitude:', error);
+      }
     } else if (userId && this.userId !== userId) {
-      // Already initialized but user ID changed - update the user ID
-      amplitude.setUserId(paddedUserId ?? undefined);
+      try {
+        // Already initialized but user ID changed - update the user ID
+        amplitude.setUserId(paddedUserId ?? undefined);
+      } catch (error) {
+        console.error('Failed to set Amplitude user ID:', error);
+      }
     }
 
     this.userId = paddedUserId;


### PR DESCRIPTION
## what?
- Google sign-in button sometimes appears unresponsive when clicked. 
- This happens because analytics requests (Amplitude) can fail silently, blocking the entire authentication flow since `AnalyticsService.logEvent()` is awaited.

## How?
- `AnalyticsService.init()` throws unhandled exceptions when Amplitude initialization fails.
- Add try-catch around Amplitude initialization in `AnalyticsService.init()`
- remove `await`. Make analytics call non-blocking in `handleGoogleSignIn()` using fire-and-forget pattern. 
