### PR TITLE
Add "Flag User" to call api/markProbableSpammer

### DIFF
--- a/hooks/useUserModeration.ts
+++ b/hooks/useUserModeration.ts
@@ -6,6 +6,7 @@ import type {
   UserModerationState,
   UserModerationActions,
   UseUserModerationReturn,
+  MarkProbableSpammerAction,
 } from '@/types/moderation';
 
 /**
@@ -68,9 +69,33 @@ export const useUserModeration = (): UseUserModerationReturn => {
     }
   }, []);
 
+  const markProbableSpammer: MarkProbableSpammerAction = useCallback(async (authorId: string) => {
+    setState((prev) => ({ ...prev, isLoading: true, error: null }));
+
+    try {
+      await UserModerationService.markProbableSpammer(authorId);
+      setState((prev) => ({
+        ...prev,
+        isLoading: false,
+        lastAction: 'flag',
+        error: null,
+      }));
+    } catch (error) {
+      const errorMessage =
+        error instanceof UserModerationError ? error.message : 'Failed to flag user';
+      setState((prev) => ({
+        ...prev,
+        isLoading: false,
+        error: errorMessage,
+      }));
+      throw error; // Re-throw for component handling
+    }
+  }, []);
+
   const actions: UserModerationActions = {
     suspendUser,
     reinstateUser,
+    markProbableSpammer,
   };
 
   return [state, actions];

--- a/services/user-moderation.service.ts
+++ b/services/user-moderation.service.ts
@@ -5,6 +5,8 @@ import type {
   ReinstateUserParams,
   ReinstateUserResponse,
   ReinstateUserApiResponse,
+  MarkProbableSpammerParams,
+  MarkProbableSpammerResponse,
 } from '@/types/moderation';
 import { transformReinstateUserResponse } from '@/types/moderation';
 
@@ -63,6 +65,25 @@ export class UserModerationService {
     } catch (error) {
       console.error(`Error reinstating user ${authorId}:`, error);
       throw new UserModerationError('Failed to reinstate user. Please try again.', error);
+    }
+  }
+
+  /**
+   * Flags a user as probable spammer
+   * @param authorId - The author profile ID of the user to flag
+   * @returns Promise with confirmation message
+   */
+  static async markProbableSpammer(authorId: string): Promise<MarkProbableSpammerResponse> {
+    try {
+      const params: MarkProbableSpammerParams = { authorId };
+      const response = await ApiClient.post<MarkProbableSpammerResponse>(
+        `${this.BASE_PATH}/mark_probable_spammer/`,
+        params
+      );
+      return response;
+    } catch (error) {
+      console.error(`Error flagging user ${authorId} as probable spammer:`, error);
+      throw new UserModerationError('Failed to flag user as probable spammer.', error);
     }
   }
 }

--- a/types/moderation.ts
+++ b/types/moderation.ts
@@ -13,6 +13,15 @@ export interface SuspendUserResponse {
   message: string;
 }
 
+// New: Mark user as probable spammer
+export interface MarkProbableSpammerParams {
+  authorId: string;
+}
+
+export interface MarkProbableSpammerResponse {
+  message: string;
+}
+
 // Raw API response (snake_case from Django backend)
 export interface ReinstateUserApiResponse {
   id: number;
@@ -51,16 +60,18 @@ export const transformReinstateUserResponse = createTransformer<
 export interface UserModerationState {
   isLoading: boolean;
   error: string | null;
-  lastAction: 'suspend' | 'reinstate' | null;
+  lastAction: 'suspend' | 'reinstate' | 'flag' | null;
 }
 
 // Hook action types
 export type SuspendUserAction = (authorId: string) => Promise<void>;
 export type ReinstateUserAction = (authorId: string) => Promise<void>;
+export type MarkProbableSpammerAction = (authorId: string) => Promise<void>;
 
 export type UserModerationActions = {
   suspendUser: SuspendUserAction;
   reinstateUser: ReinstateUserAction;
+  markProbableSpammer: MarkProbableSpammerAction;
 };
 
 export type UseUserModerationReturn = [UserModerationState, UserModerationActions];


### PR DESCRIPTION
**Context**: Moderators were missing the ability to flag users, which was previously done on SIFT. With SIFT paused, they have been missing this option and could only Ban or Reinstate.

<img width="1503" height="823" alt="Screenshot 2025-08-11 at 5 37 41 PM" src="https://github.com/user-attachments/assets/e2344134-3d96-4ace-ac7a-0804a32f16d3" />
<img width="1512" height="982" alt="Screenshot 2025-08-11 at 5 37 44 PM" src="https://github.com/user-attachments/assets/b03f2fde-82a7-4a26-a35c-7739d2569f75" />
<img width="1506" height="769" alt="Screenshot 2025-08-11 at 5 37 54 PM" src="https://github.com/user-attachments/assets/40a04810-c94b-4f2a-9283-f11307d5ae9e" />
