### PR TITLE
Kill Homepage A/B Experiment

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,8 +1,6 @@
 import { getServerSession } from 'next-auth/next';
 import { handleTrendingRedirect } from '@/utils/navigation';
 import { LandingPage } from '@/components/landing/LandingPage';
-import { headers } from 'next/headers';
-import { ExperimentVariant } from '@/utils/experiment';
 
 export default async function Home({
   searchParams,
@@ -10,9 +8,6 @@ export default async function Home({
   searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
 }) {
   const session = await getServerSession();
-
-  const headersList = await headers();
-  const homepageExperimentVariant = headersList.get('x-homepage-experiment');
 
   const resolvedSearchParams = await searchParams;
 
@@ -27,11 +22,7 @@ export default async function Home({
     }
   });
 
-  handleTrendingRedirect(
-    !!session?.user,
-    homepageExperimentVariant as ExperimentVariant | null,
-    urlSearchParams
-  );
+  handleTrendingRedirect(!!session?.user, undefined, urlSearchParams);
 
   return <LandingPage />;
 }

--- a/components/Auth/screens/SelectProvider.tsx
+++ b/components/Auth/screens/SelectProvider.tsx
@@ -5,7 +5,6 @@ import { isValidEmail } from '@/utils/validation';
 import { useAutoFocus } from '@/hooks/useAutoFocus';
 import AnalyticsService, { LogEvent } from '@/services/analytics.service';
 import { useReferral } from '@/contexts/ReferralContext';
-import { Experiment, getHomepageExperimentVariant } from '@/utils/experiment';
 import { Button } from '@/components/ui/Button';
 
 interface SelectProviderProps {
@@ -53,13 +52,13 @@ export default function SelectProvider({
           const originalCallbackUrl = '/';
           let finalCallbackUrl = originalCallbackUrl;
 
-          const experimentVariant = getHomepageExperimentVariant();
-          if (experimentVariant) {
-            // Create URL with experiment parameter
-            const experimentUrl = new URL(originalCallbackUrl, window.location.origin);
-            experimentUrl.searchParams.set(Experiment.HomepageExperiment, experimentVariant);
-            finalCallbackUrl = experimentUrl.toString();
-          }
+          // const experimentVariant = getHomepageExperimentVariant(); // Removed - experiment killed
+          // if (experimentVariant) { // Removed - experiment killed
+          //   // Create URL with experiment parameter
+          //   const experimentUrl = new URL(originalCallbackUrl, window.location.origin);
+          //   experimentUrl.searchParams.set(Experiment.HomepageExperiment, experimentVariant);
+          //   finalCallbackUrl = experimentUrl.toString();
+          // }
 
           signIn('google', { callbackUrl: finalCallbackUrl });
         } else if (response.is_verified) {
@@ -93,14 +92,6 @@ export default function SelectProvider({
       referralUrl.searchParams.set('refr', referralCode);
       referralUrl.searchParams.set('redirect', originalCallbackUrl);
       finalCallbackUrl = referralUrl.toString();
-    }
-
-    const homepageExperimentVariant = getHomepageExperimentVariant();
-    if (homepageExperimentVariant) {
-      // Create URL with experiment parameter
-      const experimentUrl = new URL(finalCallbackUrl, window.location.origin);
-      experimentUrl.searchParams.set(Experiment.HomepageExperiment, homepageExperimentVariant);
-      finalCallbackUrl = experimentUrl.toString();
     }
 
     signIn('google', { callbackUrl: finalCallbackUrl });

--- a/components/Auth/screens/Signup.tsx
+++ b/components/Auth/screens/Signup.tsx
@@ -9,7 +9,6 @@ import { faChevronLeft } from '@fortawesome/pro-light-svg-icons';
 import { Button } from '@/components/ui/Button';
 import { useReferral } from '@/contexts/ReferralContext';
 import AnalyticsService from '@/services/analytics.service';
-import { Experiment, ExperimentVariant, isExperimentEnabled } from '@/utils/experiment';
 
 interface Props extends BaseScreenProps {
   onBack: () => void;
@@ -61,11 +60,7 @@ export default function Signup({
 
       await AuthService.register(registrationData);
 
-      AnalyticsService.logSignedUp('credentials', {
-        homepage_experiment: isExperimentEnabled(Experiment.HomepageExperiment)
-          ? ExperimentVariant.B
-          : ExperimentVariant.A,
-      });
+      AnalyticsService.logSignedUp('credentials');
 
       onVerify();
     } catch (err) {

--- a/components/modals/SignupModalContainer.tsx
+++ b/components/modals/SignupModalContainer.tsx
@@ -5,7 +5,7 @@ import { useSession } from 'next-auth/react';
 import SignupPromoModal from '@/components/modals/SignupPromoModal';
 import AnalyticsService, { LogEvent } from '@/services/analytics.service';
 import { usePathname } from 'next/navigation';
-import { isExperimentEnabled, Experiment } from '@/utils/experiment';
+// import { isExperimentEnabled, Experiment } from '@/utils/experiment'; // Removed - experiment killed
 
 const EXCLUDED_PATHS = [
   '/', // landing page
@@ -23,11 +23,12 @@ export default function SignupModalContainer() {
     const modalDismissed = sessionStorage.getItem('signupModalDismissed') === 'true';
     const isExcludedPath = EXCLUDED_PATHS.some((path) => pathname.startsWith(path));
 
-    const isHomepageExperimentEnabled = isExperimentEnabled(Experiment.HomepageExperiment);
+    // const isHomepageExperimentEnabled = isExperimentEnabled(Experiment.HomepageExperiment); // Removed - experiment killed
 
     // Define pages that should be excluded when homepage experiment is enabled
     const feedPages = ['/trending', '/latest', '/following'];
-    const shouldExcludeFeedPages = isHomepageExperimentEnabled && feedPages.includes(pathname);
+    // const shouldExcludeFeedPages = isHomepageExperimentEnabled && feedPages.includes(pathname); // Removed - experiment killed
+    const shouldExcludeFeedPages = false; // Experiment killed - always false
 
     if (
       status === 'unauthenticated' &&

--- a/contexts/UserContext.tsx
+++ b/contexts/UserContext.tsx
@@ -72,34 +72,37 @@ export function UserProvider({ children }: { children: ReactNode }) {
 
         // Track Google OAuth sign-up if applicable
         if (user.authProvider === 'google' && user.hasCompletedOnboarding === false) {
-          const urlParams = new URLSearchParams(window.location.search);
-          const urlHPExperimentVariant = urlParams.get(Experiment.HomepageExperiment);
+          // const urlParams = new URLSearchParams(window.location.search); // Removed - experiment killed
+          // const urlHPExperimentVariant = urlParams.get(Experiment.HomepageExperiment); // Removed - experiment killed
 
-          if (urlHPExperimentVariant) {
-            /**
-             * Due to authentication flow limitations:
-             *
-             * 1. Credentials/Email flow: Track signed_up event immediately after client-side registration
-             *    (cookies accessible in Signup.tsx component)
-             *
-             * 2. Google OAuth: Track during user context initialization by checking authProvider === 'google'
-             *    (cookies accessible after redirect from Google OAuth)
-             *
-             * We track here instead of in SelectProvider because:
-             * - Google OAuth redirects to a new page, losing the original context
-             * - The experiment variant is passed via URL parameter and needs to be captured after redirect
-             * - UserContext is the first place where we have both user data and access to URL parameters
-             * - This ensures we capture the experiment variant before it gets cleaned up
-             */
-            AnalyticsService.logSignedUp('google', {
-              homepage_experiment: urlHPExperimentVariant,
-            });
-          }
+          // if (urlHPExperimentVariant) { // Removed - experiment killed
+          //   /**
+          //    * Due to authentication flow limitations:
+          //    *
+          //    * 1. Credentials/Email flow: Track signed_up event immediately after client-side registration
+          //    *    (cookies accessible in Signup.tsx component)
+          //    *
+          //    * 2. Google OAuth: Track during user context initialization by checking authProvider === 'google'
+          //    *    (cookies accessible after redirect from Google OAuth)
+          //    *
+          //    * We track here instead of in SelectProvider because:
+          //    * - Google OAuth redirects to a new page, losing the original context
+          //    * - The experiment variant is passed via URL parameter and needs to be captured after redirect
+          //    * - UserContext is the first place where we have both user data and access to URL parameters
+          //    * - This ensures we capture the experiment variant before it gets cleaned up
+          //    */
+          //   AnalyticsService.logSignedUp('google', {
+          //     homepage_experiment: urlHPExperimentVariant,
+          //   });
+          // }
+
+          // Track Google OAuth sign-up without experiment data
+          AnalyticsService.logSignedUp('google', {});
         }
 
         // Clean up URL parameter
         const newUrl = new URL(window.location.href);
-        newUrl.searchParams.delete(Experiment.HomepageExperiment);
+        // newUrl.searchParams.delete(Experiment.HomepageExperiment); // Removed - experiment killed
         window.history.replaceState({}, '', newUrl.toString());
 
         // Mark analytics as initialized for this user

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,47 +1,47 @@
 import { NextRequestWithAuth, withAuth } from 'next-auth/middleware';
 import { NextRequest, NextResponse } from 'next/server';
-import { Experiment, ExperimentVariant } from './utils/experiment';
+// import { Experiment, ExperimentVariant } from './utils/experiment'; // Removed - experiment killed
 
-function getExperimentVariant(request: NextRequest): string {
-  // Check if user already has an experiment assignment
-  const existingVariant = request.cookies.get(Experiment.HomepageExperiment);
+// function getExperimentVariant(request: NextRequest): string { // Removed - experiment killed
+//   // Check if user already has an experiment assignment
+//   const existingVariant = request.cookies.get(Experiment.HomepageExperiment);
 
-  if (existingVariant?.value) {
-    return existingVariant.value;
-  }
+//   if (existingVariant?.value) {
+//     return existingVariant.value;
+//   }
 
-  // Assign new variant (50/50 split)
-  const variant = Math.random() < 0.5 ? ExperimentVariant.A : ExperimentVariant.B;
+//   // Assign new variant (50/50 split)
+//   const variant = Math.random() < 0.5 ? ExperimentVariant.A : ExperimentVariant.B;
 
-  return variant;
-}
+//   return variant;
+// }
 
-function setExperimentCookie(response: NextResponse, variant: string): void {
-  const expirationDate = new Date(Date.now() + 1 * 24 * 60 * 60 * 1000); // 1 day in milliseconds
+// function setExperimentCookie(response: NextResponse, variant: string): void { // Removed - experiment killed
+//   const expirationDate = new Date(Date.now() + 1 * 24 * 60 * 60 * 1000); // 1 day in milliseconds
 
-  response.cookies.set(Experiment.HomepageExperiment, variant, {
-    expires: expirationDate,
-    secure: process.env.NEXT_PUBLIC_VERCEL_ENV !== undefined,
-    sameSite: 'lax',
-    path: '/',
-  });
-}
+//   response.cookies.set(Experiment.HomepageExperiment, variant, {
+//     expires: expirationDate,
+//     secure: process.env.NEXT_PUBLIC_VERCEL_ENV !== undefined,
+//     sameSite: 'lax',
+//     path: '/',
+//   });
+// }
 
 // Main middleware function
 export function middleware(request: NextRequest) {
-  // Only apply A/B testing to the homepage for logged-out users
-  if (request.nextUrl.pathname === '/') {
-    const variant = getExperimentVariant(request);
-    const response = NextResponse.next();
+  // Homepage experiment removed - no longer apply A/B testing
+  // if (request.nextUrl.pathname === '/') {
+  //   const variant = getExperimentVariant(request);
+  //   const response = NextResponse.next();
 
-    // Set experiment cookie
-    setExperimentCookie(response, variant);
+  //   // Set experiment cookie
+  //   setExperimentCookie(response, variant);
 
-    // Add experiment variant to headers for client-side access
-    response.headers.set('x-homepage-experiment', variant);
+  //   // Add experiment variant to headers for client-side access
+  //   response.headers.set('x-homepage-experiment', variant);
 
-    return response;
-  }
+  //   return response;
+  // }
 
   // For protected routes, use auth middleware
   return withAuth(request as NextRequestWithAuth, {
@@ -52,5 +52,5 @@ export function middleware(request: NextRequest) {
 }
 
 export const config = {
-  matcher: ['/', '/notebook/:path*', '/notebook/api/:path*', '/referral'],
+  matcher: ['/notebook/:path*', '/notebook/api/:path*', '/referral'], // Removed '/' from matcher
 };

--- a/utils/experiment.ts
+++ b/utils/experiment.ts
@@ -1,8 +1,7 @@
 import Cookies from 'js-cookie';
 
-export enum Experiment {
-  HomepageExperiment = 'homepage_experiment',
-}
+export enum Experiment {}
+// HomepageExperiment = 'homepage_experiment', // Experiment killed. Leaving for further reference usage.
 
 // Experiment variants
 export enum ExperimentVariant {
@@ -14,12 +13,13 @@ export enum ExperimentVariant {
  * Get the homepage experiment from the cookie.
  *
  * @returns The experiment variant or null if not set.
+ * @deprecated Experiment has been killed
  */
-export function getHomepageExperimentVariant(): string | null {
-  if (typeof document === 'undefined') return null;
+// export function getHomepageExperimentVariant(): string | null {
+//   if (typeof document === 'undefined') return null;
 
-  return Cookies.get(Experiment.HomepageExperiment) || null;
-}
+//   return Cookies.get(Experiment.HomepageExperiment) || null;
+// }
 
 /**
  * Experiments for the application.
@@ -28,8 +28,8 @@ export function getHomepageExperimentVariant(): string | null {
  * Centralize all experiment logic here.
  */
 export const Experiments: Record<Experiment, () => boolean> = {
-  [Experiment.HomepageExperiment]: () =>
-    Cookies.get(Experiment.HomepageExperiment) === ExperimentVariant.B,
+  // [Experiment.HomepageExperiment]: () =>
+  //   Cookies.get(Experiment.HomepageExperiment) === ExperimentVariant.B,
 };
 
 /**

--- a/utils/navigation.ts
+++ b/utils/navigation.ts
@@ -1,6 +1,6 @@
 import { redirect } from 'next/navigation';
 import { Work } from '@/types/work';
-import { ExperimentVariant, isExperimentEnabledServer } from '@/utils/experiment';
+// import { ExperimentVariant, isExperimentEnabledServer } from '@/utils/experiment'; // Removed - experiment killed
 
 /**
  * Opens an author profile using the appropriate routing mechanism
@@ -35,20 +35,18 @@ export function handleFundraiseRedirect(work: Work, id: string, slug: string) {
 }
 
 /**
- * Handles redirection to trending page if user is authorized OR homepage experiment is enabled
+ * Handles redirection to trending page if user is authorized
  * @param isUserLoggedIn Whether the user is logged in
- * @param homepageExperimentVariant The experiment variant from the request (optional, for server-side)
+ * @param homepageExperimentVariant @deprecated No longer used - experiment killed
  * @param searchParams Optional search parameters to preserve in the redirect
  */
 export function handleTrendingRedirect(
   isUserLoggedIn: boolean,
-  homepageExperimentVariant?: ExperimentVariant | null,
+  homepageExperimentVariant?: any, // @deprecated - kept for backward compatibility
   searchParams?: URLSearchParams
 ) {
-  // Redirect if user is logged in OR if homepage experiment is enabled
-  const isHPExperimentEnabled = isExperimentEnabledServer(homepageExperimentVariant);
-
-  if (isUserLoggedIn || isHPExperimentEnabled) {
+  // Redirect if user is logged in (experiment logic removed)
+  if (isUserLoggedIn) {
     let redirectUrl = '/trending';
 
     // Preserve search parameters if provided


### PR DESCRIPTION
## Why This Change?
- The homepage A/B experiment has completed its testing phase
- All users should now see the current version (A) consistently
- Removing active experiment logic reduces complexity and potential bugs
- Preserving commented code(in the `utils/experiment.ts`) makes it easier to implement future A/B tests
