### PR TITLE
Fix paper search redirect 404 when title contains forward slashes

### DIFF
--- a/app/paper/page.tsx
+++ b/app/paper/page.tsx
@@ -1,6 +1,6 @@
 import { PaperService } from '@/services/paper.service';
 import { redirect } from 'next/navigation';
-import { buildWorkUrl } from '@/utils/url';
+import { buildWorkUrl, generateSlug } from '@/utils/url';
 
 type Props = {
   params: Promise<Record<string, never>>;
@@ -21,7 +21,7 @@ export default async function WorkPage({ params, searchParams }: Props) {
       buildWorkUrl({
         id: work.id,
         contentType: 'paper',
-        slug: work.title,
+        slug: work.slug || generateSlug(work.title),
       })
     );
   } catch (error: any) {


### PR DESCRIPTION
## What?
- Papers with forward slashes in titles (e.g., "QM/MM") caused 404 errors when accessed via search results due to improper slug handling.


## How?
- Use `work.slug` when available, fallback to `generateSlug(work.title)` for proper URL sanitization.
