### PR TITLE
Landing page small updates

### DIFF
--- a/components/landing/RSCPriceSection.tsx
+++ b/components/landing/RSCPriceSection.tsx
@@ -87,7 +87,7 @@ export function RSCPriceSection() {
                   className="hover:shadow-lg flex items-center space-x-2"
                   onClick={() =>
                     window.open(
-                      'https://app.uniswap.org/swap?inputCurrency=ETH&outputCurrency=0xd101dcc414f310268c37eeb4cd376ccfa507f571',
+                      'https://aerodrome.finance/swap?from=eth&to=0xfbb75a59193a3525a8825bebe7d4b56899e2f7e1&chain0=8453&chain1=8453',
                       '_blank'
                     )
                   }

--- a/components/landing/StatsSection.tsx
+++ b/components/landing/StatsSection.tsx
@@ -75,10 +75,10 @@ export function StatsSection() {
         </div>
 
         <div className="grid grid-cols-2 md:grid-cols-4 gap-8 md:gap-12">
-          <StatItem value="$650K" label="awarded in research funding" delay={300} />
+          <StatItem value="$1.2M" label="awarded in research funding" delay={300} />
           <StatItem value="16" label="experiments funded" delay={100} />
           <StatItem value="$1M" label="earned by peer reviewers" delay={200} />
-          <StatItem value="6.7K" label="peer reviews completed" delay={400} />
+          <StatItem value="8.5K" label="peer reviews completed" delay={400} />
         </div>
       </div>
     </section>


### PR DESCRIPTION
1. Update the funding and peer review performance numbers. 

Old
<img width="1219" height="318" alt="image" src="https://github.com/user-attachments/assets/2f4a31e5-1ccd-40ca-8054-4d4bd9b07fa6" />

New
<img width="1219" height="318" alt="image" src="https://github.com/user-attachments/assets/eeabe139-ae29-499a-9a46-1ff361d0af91" />

2. Additionally, update the out link to buy RSC from Uniswap (Mainnet) to Aerodrome (Base).