### PR TITLE
Fix formatting on RSC Earned tab

### DIFF
--- a/app/leaderboard/page.tsx
+++ b/app/leaderboard/page.tsx
@@ -572,18 +572,19 @@ function LeaderboardPageContent() {
                         </div>
                       </div>
                     </div>
-                    <CurrencyBadge
-                      amount={reviewer.earnedRsc}
-                      variant="text"
-                      size="md"
-                      label={showUSD ? 'USD Earned' : 'RSC Earned'}
-                      currency={showUSD ? 'USD' : 'RSC'}
-                      textColor="text-gray-700"
-                      currencyLabelColor="text-gray-500"
-                      showIcon={true}
-                      showText={false}
-                      className="hidden sm:!block"
-                    />
+                    <div className="hidden sm:!block">
+                      <CurrencyBadge
+                        amount={reviewer.earnedRsc}
+                        variant="text"
+                        size="md"
+                        label={showUSD ? 'USD Earned' : 'RSC Earned'}
+                        currency={showUSD ? 'USD' : 'RSC'}
+                        textColor="text-gray-700"
+                        currencyLabelColor="text-gray-500"
+                        showIcon={true}
+                        showText={false}
+                      />
+                    </div>
                   </div>
                 );
               })}

--- a/app/leaderboard/page.tsx
+++ b/app/leaderboard/page.tsx
@@ -583,7 +583,6 @@ function LeaderboardPageContent() {
                         currencyLabelColor="text-gray-500"
                         showIcon={true}
                         showText={false}
-                        className="whitespace-nowrap"
                       />
                     </div>
                   </div>
@@ -668,7 +667,6 @@ function LeaderboardPageContent() {
                       currencyLabelColor="text-gray-500"
                       showIcon={true}
                       showText={false}
-                      className="whitespace-nowrap"
                     />
                   </div>
                 </div>

--- a/app/leaderboard/page.tsx
+++ b/app/leaderboard/page.tsx
@@ -583,6 +583,7 @@ function LeaderboardPageContent() {
                         currencyLabelColor="text-gray-500"
                         showIcon={true}
                         showText={false}
+                        className="whitespace-nowrap"
                       />
                     </div>
                   </div>
@@ -667,6 +668,7 @@ function LeaderboardPageContent() {
                       currencyLabelColor="text-gray-500"
                       showIcon={true}
                       showText={false}
+                      className="whitespace-nowrap"
                     />
                   </div>
                 </div>

--- a/components/ui/CurrencyBadge.tsx
+++ b/components/ui/CurrencyBadge.tsx
@@ -196,7 +196,7 @@ export const CurrencyBadge: FC<CurrencyBadgeProps> = ({
     return wrapWithTooltip(
       <div
         className={cn(
-          'flex items-center whitespace-nowrap',
+          'flex items-center',
           variant === 'inline' ? 'px-2 py-1' : '',
           sizeClasses[size],
           isUSD ? textColor || 'text-black' : '', // Example: Different base color for USD text variant

--- a/components/ui/CurrencyBadge.tsx
+++ b/components/ui/CurrencyBadge.tsx
@@ -196,7 +196,7 @@ export const CurrencyBadge: FC<CurrencyBadgeProps> = ({
     return wrapWithTooltip(
       <div
         className={cn(
-          'flex items-center',
+          'flex items-center whitespace-nowrap',
           variant === 'inline' ? 'px-2 py-1' : '',
           sizeClasses[size],
           isUSD ? textColor || 'text-black' : '', // Example: Different base color for USD text variant


### PR DESCRIPTION
### Issue: 
RSC Earned formatting spans 2 lines, and is inconsistent with RSC Funded

<img width="871" height="635" alt="Screenshot 2025-08-24 at 7 49 51 AM" src="https://github.com/user-attachments/assets/f0ade0b8-cdcd-4c2a-b9ed-c7cf89dabe33" />

### After fix: 
<img width="927" height="482" alt="Screenshot 2025-08-24 at 8 28 17 AM" src="https://github.com/user-attachments/assets/f1354f47-f08b-49b6-8805-7792c32940c0" />

### Reference: 
This is how RSC Funded currently looks (for comparison):
<img width="1257" height="554" alt="Screenshot 2025-08-24 at 7 58 03 AM" src="https://github.com/user-attachments/assets/87ae3f5b-a52b-47d5-a563-e5b092ef34ad" />