### PR TITLE
Fix: Closed applications UI fixes

### DIFF
--- a/components/work/GrantDocument.tsx
+++ b/components/work/GrantDocument.tsx
@@ -9,7 +9,6 @@ import { WorkTabs, TabType } from './WorkTabs';
 import { CommentFeed } from '@/components/Comment/CommentFeed';
 import { GrantApplications } from './GrantApplications';
 import { differenceInCalendarDays, format } from 'date-fns';
-import { colors } from '@/app/styles/colors';
 import { PostBlockEditor } from './PostBlockEditor';
 
 interface GrantDocumentProps {
@@ -113,8 +112,7 @@ export const GrantDocument = ({
           <div className="flex-1 text-sm">
             <div className="flex items-center gap-2 text-gray-800">
               <span
-                className={`h-2 w-2 rounded-full ${isOpen ? 'bg-emerald-500' : ''} inline-block`}
-                style={!isOpen ? { backgroundColor: colors.gray[400] } : undefined}
+                className={`h-2 w-2 rounded-full ${isOpen ? 'bg-emerald-500' : 'bg-gray-400'} inline-block`}
               />
               <span>{isOpen ? 'Accepting Applications' : 'Closed'}</span>
               {endDate && isOpen && (

--- a/components/work/GrantDocument.tsx
+++ b/components/work/GrantDocument.tsx
@@ -9,6 +9,7 @@ import { WorkTabs, TabType } from './WorkTabs';
 import { CommentFeed } from '@/components/Comment/CommentFeed';
 import { GrantApplications } from './GrantApplications';
 import { differenceInCalendarDays, format } from 'date-fns';
+import { colors } from '@/app/styles/colors';
 import { PostBlockEditor } from './PostBlockEditor';
 
 interface GrantDocumentProps {
@@ -112,9 +113,8 @@ export const GrantDocument = ({
           <div className="flex-1 text-sm">
             <div className="flex items-center gap-2 text-gray-800">
               <span
-                className={`h-2 w-2 rounded-full ${
-                  isOpen ? 'bg-emerald-500' : 'bg-red-500'
-                } inline-block`}
+                className={`h-2 w-2 rounded-full ${isOpen ? 'bg-emerald-500' : ''} inline-block`}
+                style={!isOpen ? { backgroundColor: colors.gray[400] } : undefined}
               />
               <span>{isOpen ? 'Accepting Applications' : 'Closed'}</span>
               {endDate && isOpen && (

--- a/components/work/GrantDocument.tsx
+++ b/components/work/GrantDocument.tsx
@@ -77,7 +77,11 @@ export const GrantDocument = ({
     }
   }, [activeTab, work, metadata]);
 
-  const isOpen = work.note?.post?.grant?.status === 'OPEN';
+  const endDate = work.note?.post?.grant?.endDate
+    ? new Date(work.note?.post?.grant?.endDate)
+    : undefined;
+  const isClosedByDate = endDate ? differenceInCalendarDays(endDate, new Date()) < 0 : false;
+  const isOpen = work.note?.post?.grant?.status === 'OPEN' && !isClosedByDate;
 
   return (
     <div>
@@ -113,11 +117,19 @@ export const GrantDocument = ({
                 } inline-block`}
               />
               <span>{isOpen ? 'Accepting Applications' : 'Closed'}</span>
-              {work.note?.post?.grant?.endDate && isOpen && (
+              {endDate && isOpen && (
                 <>
                   <div className="h-4 w-px bg-gray-300" />
                   <span className="text-gray-600 text-sm">
-                    Closes on {format(new Date(work.note?.post?.grant?.endDate), 'MMMM d, yyyy')}
+                    Closes on {format(endDate, 'MMMM d, yyyy')}
+                  </span>
+                </>
+              )}
+              {!isOpen && endDate && (
+                <>
+                  <div className="h-4 w-px bg-gray-300" />
+                  <span className="text-gray-600 text-sm">
+                    Closed on {format(endDate, 'MMMM d, yyyy')}
                   </span>
                 </>
               )}

--- a/components/work/components/GrantStatusSection.tsx
+++ b/components/work/components/GrantStatusSection.tsx
@@ -2,6 +2,7 @@
 
 import { Work } from '@/types/work';
 import { differenceInCalendarDays, format } from 'date-fns';
+import { colors } from '@/app/styles/colors';
 import { Clock } from 'lucide-react';
 
 interface GrantStatusSectionProps {
@@ -30,7 +31,8 @@ export const GrantStatusSection = ({ work }: GrantStatusSectionProps) => {
       <h3 className="text-base font-semibold text-gray-900 mb-2">Status</h3>
       <div className="flex items-center gap-2 text-gray-800 text-sm">
         <span
-          className={`h-2 w-2 rounded-full ${isOpen ? 'bg-emerald-500' : 'bg-rose-500'} inline-block`}
+          className={`h-2 w-2 rounded-full ${isOpen ? 'bg-emerald-500' : ''} inline-block`}
+          style={!isOpen ? { backgroundColor: colors.gray[400] } : undefined}
         />
         <span>{isOpen ? 'Accepting Applications' : 'Closed'}</span>
       </div>

--- a/components/work/components/GrantStatusSection.tsx
+++ b/components/work/components/GrantStatusSection.tsx
@@ -2,7 +2,6 @@
 
 import { Work } from '@/types/work';
 import { differenceInCalendarDays, format } from 'date-fns';
-import { colors } from '@/app/styles/colors';
 import { Clock } from 'lucide-react';
 
 interface GrantStatusSectionProps {
@@ -31,8 +30,7 @@ export const GrantStatusSection = ({ work }: GrantStatusSectionProps) => {
       <h3 className="text-base font-semibold text-gray-900 mb-2">Status</h3>
       <div className="flex items-center gap-2 text-gray-800 text-sm">
         <span
-          className={`h-2 w-2 rounded-full ${isOpen ? 'bg-emerald-500' : ''} inline-block`}
-          style={!isOpen ? { backgroundColor: colors.gray[400] } : undefined}
+          className={`h-2 w-2 rounded-full ${isOpen ? 'bg-emerald-500' : 'bg-gray-400'} inline-block`}
         />
         <span>{isOpen ? 'Accepting Applications' : 'Closed'}</span>
       </div>

--- a/components/work/components/GrantStatusSection.tsx
+++ b/components/work/components/GrantStatusSection.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Work } from '@/types/work';
-import { format } from 'date-fns';
+import { differenceInCalendarDays, format } from 'date-fns';
 import { Clock } from 'lucide-react';
 
 interface GrantStatusSectionProps {
@@ -9,8 +9,6 @@ interface GrantStatusSectionProps {
 }
 
 export const GrantStatusSection = ({ work }: GrantStatusSectionProps) => {
-  const isOpen = work.note?.post?.grant?.status === 'OPEN';
-
   if (!work.note?.post?.grant?.endDate) {
     return (
       <div>
@@ -24,6 +22,8 @@ export const GrantStatusSection = ({ work }: GrantStatusSectionProps) => {
   }
 
   const endDate = new Date(work.note?.post?.grant?.endDate);
+  const isClosedByDate = differenceInCalendarDays(endDate, new Date()) < 0;
+  const isOpen = work.note?.post?.grant?.status === 'OPEN' && !isClosedByDate;
 
   return (
     <div>


### PR DESCRIPTION
### Issue: RFP's that are closed are still "Accepting Applications" & "Closes on" past date
<img width="1224" height="588" alt="Screenshot 2025-08-24 at 4 21 03 PM" src="https://github.com/user-attachments/assets/85582b7c-f945-41b7-8bb4-e34b2f8a015e" />

### After fix: Gray-400 & "Closed on" 
<img width="1207" height="763" alt="Screenshot 2025-08-24 at 4 19 01 PM" src="https://github.com/user-attachments/assets/9a2d9f71-e4d5-4378-8e29-6c78ab887dc1" />

### Reference for Gray-400 color choice:
<img width="816" height="407" alt="Screenshot 2025-08-24 at 4 22 20 PM" src="https://github.com/user-attachments/assets/5df5a568-425b-42d4-bec0-1a004c70f005" />

