### PR TITLE
Fix RSC formatting on Top Funders to match Top Peer Reviewers

### DIFF
--- a/components/Leaderboard/LeaderboardOverview.tsx
+++ b/components/Leaderboard/LeaderboardOverview.tsx
@@ -240,7 +240,7 @@ export const LeaderboardOverview = () => {
                         currency={showUSD ? 'USD' : 'RSC'}
                         shorten={true}
                         showIcon={true}
-                        showText={true}
+                        showText={showUSD}
                         className="justify-end"
                       />
                     </div>


### PR DESCRIPTION
### Issue: "Top Funders" has a different format than "Top Peer Reviews" for RSC, and "RSC" goes off page

<img width="345" height="506" alt="Screenshot 2025-08-24 at 4 36 22 PM" src="https://github.com/user-attachments/assets/018ce80c-c219-48a3-aadc-7a275b8cb24b" />

### After Fix: Removed "RSC", now it's "{RSC Icon} {RSC Amount}" or "{USD Icon} {USD Amount}"
On this one, the current layout is inconsistent between Top Peer Reviews and Top Funders; so I opted to remove the "RSC" from "Top Funders" section. But alternatively we can add the "RSC" to the "Top Peer Reviewers" section and fix the formatting so "RSC" doesn't go off-screen

<img width="304" height="483" alt="Screenshot 2025-08-24 at 4 47 00 PM" src="https://github.com/user-attachments/assets/65405caa-4ae6-494d-9954-1bb15ad23ff2" />
