### PR TITLE
Users Name - Open in New Tab

### DIFF
--- a/components/Feed/FeedItemHeader.tsx
+++ b/components/Feed/FeedItemHeader.tsx
@@ -7,7 +7,6 @@ import { AvatarStack } from '@/components/ui/AvatarStack';
 import { AuthorProfile } from '@/types/authorProfile';
 import { cn } from '@/utils/styles';
 import { AuthorTooltip } from '@/components/ui/AuthorTooltip';
-import { navigateToAuthorProfile } from '@/utils/navigation';
 import { formatTimeAgo } from '@/utils/date';
 import { VerifiedBadge } from '@/components/ui/VerifiedBadge';
 import { Tooltip } from '@/components/ui/Tooltip';

--- a/components/Feed/FeedItemHeader.tsx
+++ b/components/Feed/FeedItemHeader.tsx
@@ -110,7 +110,6 @@ export const FeedItemHeader: FC<FeedItemHeaderProps> = ({
           alt={displayAuthor?.fullName ?? 'Unknown'}
           size={avatarSize}
           className={authorId && authorId > 0 ? 'cursor-pointer' : ''}
-          onClick={authorId && authorId > 0 ? () => navigateToAuthorProfile(authorId) : undefined}
           authorId={authorId}
         />
 
@@ -124,6 +123,12 @@ export const FeedItemHeader: FC<FeedItemHeaderProps> = ({
                       href={`/author/${authorId}`}
                       className="font-semibold hover:text-blue-600 cursor-pointer"
                       onClick={(e) => {
+                        // Check if Command (Mac) or Ctrl (Windows/Linux) is pressed
+                        if (e.metaKey || e.ctrlKey) {
+                          // Open in new tab - let the browser handle it naturally
+                          return; // Don't prevent default, let the href work
+                        }
+                        // Normal click - use custom navigation
                         e.preventDefault();
                         navigateToAuthorProfile(authorId);
                       }}

--- a/components/Feed/FeedItemHeader.tsx
+++ b/components/Feed/FeedItemHeader.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { FC, useEffect } from 'react';
+import Link from 'next/link';
 import { Avatar } from '@/components/ui/Avatar';
 import { AvatarStack } from '@/components/ui/AvatarStack';
 import { AuthorProfile } from '@/types/authorProfile';
@@ -119,22 +120,12 @@ export const FeedItemHeader: FC<FeedItemHeaderProps> = ({
               <div className="flex items-center gap-1">
                 {authorId && authorId > 0 ? (
                   <AuthorTooltip authorId={authorId}>
-                    <a
+                    <Link
                       href={`/author/${authorId}`}
                       className="font-semibold hover:text-blue-600 cursor-pointer"
-                      onClick={(e) => {
-                        // Check if Command (Mac) or Ctrl (Windows/Linux) is pressed
-                        if (e.metaKey || e.ctrlKey) {
-                          // Open in new tab - let the browser handle it naturally
-                          return; // Don't prevent default, let the href work
-                        }
-                        // Normal click - use custom navigation
-                        e.preventDefault();
-                        navigateToAuthorProfile(authorId);
-                      }}
                     >
                       {displayAuthor.fullName}
-                    </a>
+                    </Link>
                   </AuthorTooltip>
                 ) : (
                   <span className="font-semibold">{displayAuthor.fullName}</span>

--- a/components/Feed/FeedItemHeader.tsx
+++ b/components/Feed/FeedItemHeader.tsx
@@ -121,7 +121,7 @@ export const FeedItemHeader: FC<FeedItemHeaderProps> = ({
                 {authorId && authorId > 0 ? (
                   <AuthorTooltip authorId={authorId}>
                     <a
-                      href="#"
+                      href={`/author/${authorId}`}
                       className="font-semibold hover:text-blue-600 cursor-pointer"
                       onClick={(e) => {
                         e.preventDefault();

--- a/components/Moderators/AuditItemPaper.tsx
+++ b/components/Moderators/AuditItemPaper.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { FC } from 'react';
+import Link from 'next/link';
 import { Avatar } from '@/components/ui/Avatar';
 import { AuthorTooltip } from '@/components/ui/AuthorTooltip';
 import { FlaggedContent } from '@/services/audit.service';
@@ -78,22 +79,12 @@ export const AuditItemPaper: FC<AuditItemPaperProps> = ({ entry, onAction, view 
         <div>
           {userInfo.authorId ? (
             <AuthorTooltip authorId={userInfo.authorId}>
-              <a
+              <Link
                 href={`/author/${userInfo.authorId}`}
                 className="font-medium text-gray-900 hover:text-blue-600 cursor-pointer"
-                onClick={(e) => {
-                  // Check if Command (Mac) or Ctrl (Windows/Linux) is pressed
-                  if (e.metaKey || e.ctrlKey) {
-                    // Open in new tab - let the browser handle it naturally
-                    return; // Don't prevent default, let the href work
-                  }
-                  // Normal click - use custom navigation
-                  e.preventDefault();
-                  navigateToAuthorProfile(userInfo.authorId);
-                }}
               >
                 {userInfo.name}
-              </a>
+              </Link>
             </AuthorTooltip>
           ) : (
             <span

--- a/components/Moderators/AuditItemPaper.tsx
+++ b/components/Moderators/AuditItemPaper.tsx
@@ -82,6 +82,12 @@ export const AuditItemPaper: FC<AuditItemPaperProps> = ({ entry, onAction, view 
                 href={`/author/${userInfo.authorId}`}
                 className="font-medium text-gray-900 hover:text-blue-600 cursor-pointer"
                 onClick={(e) => {
+                  // Check if Command (Mac) or Ctrl (Windows/Linux) is pressed
+                  if (e.metaKey || e.ctrlKey) {
+                    // Open in new tab - let the browser handle it naturally
+                    return; // Don't prevent default, let the href work
+                  }
+                  // Normal click - use custom navigation
                   e.preventDefault();
                   navigateToAuthorProfile(userInfo.authorId);
                 }}

--- a/components/Moderators/AuditItemPaper.tsx
+++ b/components/Moderators/AuditItemPaper.tsx
@@ -79,7 +79,7 @@ export const AuditItemPaper: FC<AuditItemPaperProps> = ({ entry, onAction, view 
           {userInfo.authorId ? (
             <AuthorTooltip authorId={userInfo.authorId}>
               <a
-                href="#"
+                href={`/author/${userInfo.authorId}`}
                 className="font-medium text-gray-900 hover:text-blue-600 cursor-pointer"
                 onClick={(e) => {
                   e.preventDefault();

--- a/components/Moderators/AuditItemPaper.tsx
+++ b/components/Moderators/AuditItemPaper.tsx
@@ -11,7 +11,6 @@ import { getAuditUserInfo, getAuditContentUrl } from './utils/auditUtils';
 import { formatTimestamp } from '@/utils/date';
 import { Tooltip } from '@/components/ui/Tooltip';
 import { ContentTypeBadge } from '@/components/ui/ContentTypeBadge';
-import { navigateToAuthorProfile } from '@/utils/navigation';
 import { ModerationMetadata } from './ModerationMetadata';
 import { ModerationActions } from './ModerationActions';
 import { truncateText } from '@/utils/stringUtils';

--- a/components/ui/AuthorTooltip.tsx
+++ b/components/ui/AuthorTooltip.tsx
@@ -280,7 +280,7 @@ export const AuthorTooltip: React.FC<AuthorTooltipProps> = ({
         {/* Profile link positioned right above the border */}
         <div className="mt-3 text-left">
           <a
-            href="#"
+            href={`/author/${userData.authorProfile?.id || userData.id}`}
             className="text-xs text-blue-600 hover:text-blue-800 font-medium inline-block"
             onClick={(e) => {
               e.preventDefault();

--- a/components/ui/AuthorTooltip.tsx
+++ b/components/ui/AuthorTooltip.tsx
@@ -283,6 +283,12 @@ export const AuthorTooltip: React.FC<AuthorTooltipProps> = ({
             href={`/author/${userData.authorProfile?.id || userData.id}`}
             className="text-xs text-blue-600 hover:text-blue-800 font-medium inline-block"
             onClick={(e) => {
+              // Check if Command (Mac) or Ctrl (Windows/Linux) is pressed
+              if (e.metaKey || e.ctrlKey) {
+                // Open in new tab - let the browser handle it naturally
+                return; // Don't prevent default, let the href work
+              }
+              // Normal click - use custom navigation
               e.preventDefault();
               navigateToAuthorProfile(userData.authorProfile?.id || userData.id);
             }}

--- a/components/ui/AuthorTooltip.tsx
+++ b/components/ui/AuthorTooltip.tsx
@@ -9,7 +9,6 @@ import { User } from '@/types/user';
 import { cn } from '@/utils/styles';
 import { InfoIcon } from 'lucide-react';
 import { SocialIcon } from '@/components/ui/SocialIcon';
-import { navigateToAuthorProfile } from '@/utils/navigation';
 
 interface AuthorTooltipProps {
   authorId?: number;
@@ -283,16 +282,6 @@ export const AuthorTooltip: React.FC<AuthorTooltipProps> = ({
           <Link
             href={`/author/${userData.authorProfile?.id || userData.id}`}
             className="text-xs text-blue-600 hover:text-blue-800 font-medium inline-block"
-            onClick={(e) => {
-              // Check if Command (Mac) or Ctrl (Windows/Linux) is pressed
-              if (e.metaKey || e.ctrlKey) {
-                // Open in new tab - let the browser handle it naturally
-                return; // Don't prevent default, let the href work
-              }
-              // Normal click - use custom navigation
-              e.preventDefault();
-              navigateToAuthorProfile(userData.authorProfile?.id || userData.id);
-            }}
           >
             View profile
           </Link>

--- a/components/ui/AuthorTooltip.tsx
+++ b/components/ui/AuthorTooltip.tsx
@@ -233,12 +233,18 @@ export const AuthorTooltip: React.FC<AuthorTooltipProps> = ({
 
           <div className="flex-1 min-w-0">
             <div className="flex items-center justify-between">
-              <Link
-                href={`/author/${userData.authorProfile?.id || userData.id}`}
-                className="font-semibold text-gray-900 hover:text-blue-600 block truncate"
-              >
-                {userData.fullName}
-              </Link>
+              {userData.authorProfile?.id ? (
+                <Link
+                  href={`/author/${userData.authorProfile.id}`}
+                  className="font-semibold text-gray-900 hover:text-blue-600 block truncate"
+                >
+                  {userData.fullName}
+                </Link>
+              ) : (
+                <span className="font-semibold text-gray-900 block truncate">
+                  {userData.fullName}
+                </span>
+              )}
             </div>
 
             {!userData.authorProfile.isClaimed && (
@@ -278,14 +284,16 @@ export const AuthorTooltip: React.FC<AuthorTooltipProps> = ({
         )}
 
         {/* Profile link positioned right above the border */}
-        <div className="mt-3 text-left">
-          <Link
-            href={`/author/${userData.authorProfile?.id || userData.id}`}
-            className="text-xs text-blue-600 hover:text-blue-800 font-medium inline-block"
-          >
-            View profile
-          </Link>
-        </div>
+        {userData.authorProfile?.id && (
+          <div className="mt-3 text-left">
+            <Link
+              href={`/author/${userData.authorProfile.id}`}
+              className="text-xs text-blue-600 hover:text-blue-800 font-medium inline-block"
+            >
+              View profile
+            </Link>
+          </div>
+        )}
 
         {/* Social links */}
         <div className="mt-3 flex items-center justify-center border-t pt-3">

--- a/components/ui/AuthorTooltip.tsx
+++ b/components/ui/AuthorTooltip.tsx
@@ -2,6 +2,7 @@
 
 import React, { useState, useRef, useEffect, useMemo } from 'react';
 import { createPortal } from 'react-dom';
+import Link from 'next/link';
 import { AuthorService } from '@/services/author.service';
 import { Avatar } from '@/components/ui/Avatar';
 import { User } from '@/types/user';
@@ -233,12 +234,12 @@ export const AuthorTooltip: React.FC<AuthorTooltipProps> = ({
 
           <div className="flex-1 min-w-0">
             <div className="flex items-center justify-between">
-              <a
-                href={userData.authorProfile.profileUrl}
+              <Link
+                href={`/author/${userData.authorProfile?.id || userData.id}`}
                 className="font-semibold text-gray-900 hover:text-blue-600 block truncate"
               >
                 {userData.fullName}
-              </a>
+              </Link>
             </div>
 
             {!userData.authorProfile.isClaimed && (
@@ -279,7 +280,7 @@ export const AuthorTooltip: React.FC<AuthorTooltipProps> = ({
 
         {/* Profile link positioned right above the border */}
         <div className="mt-3 text-left">
-          <a
+          <Link
             href={`/author/${userData.authorProfile?.id || userData.id}`}
             className="text-xs text-blue-600 hover:text-blue-800 font-medium inline-block"
             onClick={(e) => {
@@ -294,7 +295,7 @@ export const AuthorTooltip: React.FC<AuthorTooltipProps> = ({
             }}
           >
             View profile
-          </a>
+          </Link>
         </div>
 
         {/* Social links */}


### PR DESCRIPTION
Bugfix: When performing `right clicking and open link in new tab` on a users name, the new tab that opens takes you to the user's profile rather than back to the same original page.

Screenshot (Fix)
<img width="1246" height="666" alt="image" src="https://github.com/user-attachments/assets/c52a2306-d5b8-4bb2-bafa-d94895a4f3f1" />

<img width="1215" height="666" alt="image" src="https://github.com/user-attachments/assets/5ab68fee-d663-4938-9704-d60a0ce2be66" />


