### PR TITLE
Add "Explore" button on landing page hero

### DIFF
--- a/components/landing/LandingPageHero.tsx
+++ b/components/landing/LandingPageHero.tsx
@@ -5,12 +5,18 @@ import { useAuthModalContext } from '@/contexts/AuthModalContext';
 import { HeroCardSwap } from './HeroCardSwap';
 import Aurora from '@/components/ui/Aurora';
 import { colors } from '@/app/styles/colors';
+import { useRouter } from 'next/navigation';
 
 export function LandingPageHero() {
   const { showAuthModal } = useAuthModalContext();
+  const router = useRouter();
 
   const handleSignUp = () => {
     showAuthModal();
+  };
+
+  const handleExplore = () => {
+    router.push('/trending');
   };
 
   return (
@@ -56,16 +62,29 @@ export function LandingPageHero() {
                   review lead to funding.
                 </p>
 
-                {/* Sign Up Button */}
+                {/* Primary CTA + Explore CTA */}
                 <div className="flex flex-col items-center lg:!items-start">
-                  <Button
-                    variant="default"
-                    size="lg"
-                    onClick={handleSignUp}
-                    className="bg-gradient-to-r from-[#3971FF] to-[#4A7FFF] hover:from-[#2C5EE8] hover:to-[#3971FF] text-white font-semibold px-8 py-3 text-lg rounded-xl shadow-lg hover:shadow-xl transition-all duration-200 border-0"
-                  >
-                    Sign up
-                  </Button>
+                  <div className="flex flex-col lg:!flex-row items-stretch lg:!items-center gap-3">
+                    <Button
+                      variant="default"
+                      size="lg"
+                      onClick={handleSignUp}
+                      className="bg-gradient-to-r from-[#3971FF] to-[#4A7FFF] hover:from-[#2C5EE8] hover:to-[#3971FF] text-white font-semibold px-8 py-3 text-lg rounded-xl shadow-lg hover:shadow-xl transition-all duration-200 border-0"
+                      aria-label="Sign up to ResearchHub"
+                    >
+                      Sign up
+                    </Button>
+
+                    <Button
+                      variant="outlined"
+                      size="lg"
+                      onClick={handleExplore}
+                      className="h-11 md:h-12 px-6 md:px-8 text-sm md:text-base"
+                      aria-label="Explore research on ResearchHub"
+                    >
+                      Explore ResearchHub
+                    </Button>
+                  </div>
                   <p className="text-sm lg:!text-lg text-gray-600 mt-2">
                     Start earning for open science today.
                   </p>


### PR DESCRIPTION
### Issue: 
Joyce: _"Our new landing page makes it very difficult for 1st time users to view content on RH without signing up. You have to scroll to the fund/earn/publish carousel to find a link to the homepage"_

### Proposed solution: 
Add a secondary CTA button next to "Sign up"
<img width="1510" height="763" alt="Screenshot 2025-08-28 at 3 21 16 PM" src="https://github.com/user-attachments/assets/c5ecccc1-229e-47fd-8bbc-d94c1e3a51f6" />
<img width="1508" height="813" alt="Screenshot 2025-08-28 at 3 21 08 PM" src="https://github.com/user-attachments/assets/452b223b-ba92-43f5-9321-f030b5e9aa3e" />
