### PR TITLE
Add foundation award badge feature

### DIFF
--- a/components/Feed/items/FeedItemComment.tsx
+++ b/components/Feed/items/FeedItemComment.tsx
@@ -13,6 +13,7 @@ import { RelatedWorkCard } from '@/components/Paper/RelatedWorkCard';
 import { Avatar } from '@/components/ui/Avatar';
 import { LegacyCommentBanner } from '@/components/LegacyCommentBanner';
 import { BaseFeedItem } from '@/components/Feed/BaseFeedItem';
+import { FoundationAwardBadge } from '@/components/ui/FoundationAwardBadge';
 
 // Define the recursive rendering component for parent comments
 const RenderParentComment: FC<{ comment: ParentCommentPreview; level: number }> = ({
@@ -149,7 +150,10 @@ export const FeedItemComment: FC<FeedItemCommentProps> = ({
       <BaseFeedItem entry={entry} href={commentPageUrl} showHeader={false} showActions={false}>
         {isReview && (
           <div className="flex justify-between items-center mb-3">
-            <ContentTypeBadge type="review" />
+            <div className="flex items-center gap-2">
+              <ContentTypeBadge type="review" />
+              {comment.awardedBountySolution?.isFoundationAwarded && <FoundationAwardBadge />}
+            </div>
           </div>
         )}
 
@@ -157,6 +161,12 @@ export const FeedItemComment: FC<FeedItemCommentProps> = ({
           <div className="mb-4 text-gray-700 text-sm mt-0.5">
             <span className="font-medium">Review score: </span>
             <span className="text-yellow-500 font-medium">{reviewScore}/5</span>
+          </div>
+        )}
+
+        {!isReview && comment.awardedBountySolution?.isFoundationAwarded && (
+          <div className="mb-3">
+            <FoundationAwardBadge />
           </div>
         )}
 

--- a/components/ui/FoundationAwardBadge.tsx
+++ b/components/ui/FoundationAwardBadge.tsx
@@ -1,0 +1,15 @@
+import { Badge } from '@/components/ui/Badge';
+import { Tooltip } from '@/components/ui/Tooltip';
+import { ResearchCoinIcon } from '@/components/ui/icons/ResearchCoinIcon';
+
+export const FoundationAwardBadge = () => (
+  <Tooltip content="Verified and approved by the ResearchHub Editor Team">
+    <Badge 
+      variant="primary"
+      className="bg-purple-100 text-purple-700 border-purple-300 gap-1.5 py-1"
+    >
+      <ResearchCoinIcon size={16} outlined color="currentColor" />
+      <span>Awarded</span>
+    </Badge>
+  </Tooltip>
+);

--- a/types/feed.ts
+++ b/types/feed.ts
@@ -4,7 +4,7 @@ import { Topic, transformTopic } from './topic';
 import { createTransformer, BaseTransformed } from './transformer';
 import { Work, transformPaper, transformPost, FundingRequest, ContentType } from './work';
 import { Bounty, transformBounty } from './bounty';
-import { Comment, CommentType, ContentFormat, transformComment } from './comment';
+import { Comment, CommentType, ContentFormat, transformComment, AwardedBountySolution } from './comment';
 import { Fundraise, transformFundraise } from './funding';
 import { Journal } from './journal';
 import { UserVoteType } from './reaction';
@@ -113,6 +113,11 @@ export interface FeedBountyContent extends BaseFeedContent {
     contentFormat: ContentFormat;
     commentType: CommentType;
     id: number;
+    awardedBountySolution?: {
+      id: number;
+      awardedAmount: number;
+      isFoundationAwarded: boolean;
+    };
   };
 }
 
@@ -126,6 +131,7 @@ export interface FeedCommentContent extends BaseFeedContent {
     commentType: CommentType;
     score: number;
     reviewScore?: number;
+    awardedBountySolution?: AwardedBountySolution;
     thread?: {
       id: number;
       threadType: string;
@@ -499,6 +505,7 @@ export const transformFeedEntry = (feedEntry: RawApiFeedEntry): FeedEntry => {
           created_location: '',
           unified_document_id: content_object.unified_document_id,
           bounty_amount: content_object.bounty_amount,
+          awarded_bounty_solution: content_object.awarded_bounty_solution,
         };
 
         // Check if the comment is associated with a paper or post for related work
@@ -527,6 +534,7 @@ export const transformFeedEntry = (feedEntry: RawApiFeedEntry): FeedEntry => {
             commentType: content_object.comment_type as CommentType,
             score: transformedComment.score || 0,
             reviewScore: transformedComment.reviewScore || 0,
+            awardedBountySolution: transformedComment.awardedBountySolution,
             thread: content_object.thread_id
               ? {
                   id: content_object.thread_id,
@@ -813,6 +821,13 @@ export const transformCommentToFeedItem = (
             objectId: comment.thread.objectId,
           }
         : undefined,
+      awardedBountySolution: comment.awardedBountySolution
+        ? {
+            id: comment.awardedBountySolution.id,
+            awardedAmount: comment.awardedBountySolution.awardedAmount,
+            isFoundationAwarded: comment.awardedBountySolution.isFoundationAwarded,
+          }
+        : undefined,
     },
     relatedDocumentId: comment.thread?.objectId,
     relatedDocumentContentType: contentType,
@@ -879,6 +894,13 @@ export const transformBountyCommentToFeedItem = (
       content: comment.content,
       contentFormat: comment.contentFormat || 'QUILL_EDITOR',
       commentType: comment.commentType || 'BOUNTY',
+      awardedBountySolution: comment.awardedBountySolution
+        ? {
+            id: comment.awardedBountySolution.id,
+            awardedAmount: comment.awardedBountySolution.awardedAmount,
+            isFoundationAwarded: comment.awardedBountySolution.isFoundationAwarded,
+          }
+        : undefined,
     },
   };
 


### PR DESCRIPTION
  ### Summary
  Displays a purple "Awarded" badge with ResearchCoin icon when ResearchHub Foundation awards a bounty, helping users identify officially recognized solutions.

  ### What's Changed
  - Create `FoundationAwardBadge` component with purple styling and RSC coin icon
  - Display badge on awarded comments and reviews
  - Add `AwardedBountySolution` TypeScript interface
  - Update feed transformers to pass foundation award data from API

  ### Screenshots
  Badge appears in:
  - Review comments (next to Peer Review badge)
  - Regular comments that receive foundation awards
  - Both feed view and detail pages