### PR TITLE
Fix ImageUploadModal to render above other content 

### DIFF
--- a/components/modals/ImageUploadModal.tsx
+++ b/components/modals/ImageUploadModal.tsx
@@ -51,7 +51,7 @@ export function ImageUploadModal({
   };
 
   return (
-    <Dialog open={isOpen} onClose={onClose} className="relative z-[10000]">
+    <Dialog open={isOpen} onClose={onClose} className="relative z-[1000]">
       <div className="fixed inset-0 bg-black/30" aria-hidden="true" />
 
       <div className="fixed inset-0 flex items-center justify-center p-4">

--- a/components/modals/ImageUploadModal.tsx
+++ b/components/modals/ImageUploadModal.tsx
@@ -51,7 +51,7 @@ export function ImageUploadModal({
   };
 
   return (
-    <Dialog open={isOpen} onClose={onClose} className="relative z-50">
+    <Dialog open={isOpen} onClose={onClose} className="relative z-[10000]">
       <div className="fixed inset-0 bg-black/30" aria-hidden="true" />
 
       <div className="fixed inset-0 flex items-center justify-center p-4">

--- a/components/modals/ImageUploadModal.tsx
+++ b/components/modals/ImageUploadModal.tsx
@@ -51,7 +51,7 @@ export function ImageUploadModal({
   };
 
   return (
-    <Dialog open={isOpen} onClose={onClose} className="relative z-[1000]">
+    <Dialog open={isOpen} onClose={onClose} className="relative z-[10000]">
       <div className="fixed inset-0 bg-black/30" aria-hidden="true" />
 
       <div className="fixed inset-0 flex items-center justify-center p-4">


### PR DESCRIPTION
### Issue:
Right now, the ImageUploadModal renders beneath the author edit mode, which prevents the user from changing their profile picture.

### Proposed fix:
Increase the z-index of the ImageUploadModal to appear above others

<img width="1004" height="759" alt="Screenshot 2025-09-03 at 6 03 11 PM" src="https://github.com/user-attachments/assets/39777190-c096-4edc-8c70-499a802ea99e" />
