### PR TITLE
Add loading skeleton for user avatar in TopBar

### DIFF
--- a/app/layouts/TopBar.tsx
+++ b/app/layouts/TopBar.tsx
@@ -430,7 +430,11 @@ export function TopBar({ onMenuClick }: TopBarProps) {
               )}
 
               {/* Avatar/Login buttons */}
-              {user && !isLoading ? (
+              {isLoading ? (
+                <div className="flex items-center">
+                  <div className="w-10 h-10 bg-gray-300 rounded-full animate-pulse"></div>
+                </div>
+              ) : user ? (
                 <UserMenu
                   user={user}
                   onViewProfile={handleViewProfile}
@@ -461,7 +465,11 @@ export function TopBar({ onMenuClick }: TopBarProps) {
 
             {/* Mobile user controls */}
             <div className="flex tablet:!hidden">
-              {user && !isLoading ? (
+              {isLoading ? (
+                <div className="flex items-center">
+                  <div className="w-10 h-10 bg-gray-300 rounded-full animate-pulse"></div>
+                </div>
+              ) : user ? (
                 <UserMenu
                   user={user}
                   onViewProfile={handleViewProfile}


### PR DESCRIPTION
What?
=====
- Improves the user experience by showing a loading skeleton instead of immediately displaying login/signup buttons while user authentication state is being determined.
- This prevents the jarring flash of login buttons that users might see while their authentication state is being verified

<img width="404" height="343" alt="image" src="https://github.com/user-attachments/assets/f35ef702-97da-42ca-8872-3c11712d6587" />
