### PR TITLE
Enable the "Removed" tab back on in audit tab

### DIFF
--- a/app/moderators/audit/page.tsx
+++ b/app/moderators/audit/page.tsx
@@ -18,13 +18,6 @@ export default function AuditPage() {
   const [activeStatus, setActiveStatus] = useState<AuditStatus>('pending');
   const [isRefreshing, setIsRefreshing] = useState(false);
 
-  // Temporarily redirect away from 'removed' status due to backend issues
-  useEffect(() => {
-    if (activeStatus === 'removed') {
-      setActiveStatus('pending');
-    }
-  }, [activeStatus]);
-
   const {
     entries,
     isLoading,

--- a/components/Moderators/AuditTabs.tsx
+++ b/components/Moderators/AuditTabs.tsx
@@ -34,9 +34,8 @@ export const AuditTabs: FC<AuditTabsProps> = ({
   statusCounts,
   loading,
 }) => {
-  // Temporarily disable 'removed' tab due to backend issues
-  const statuses: AuditStatus[] = ['pending', 'dismissed'];
-  const disabledStatuses: AuditStatus[] = ['removed'];
+  const statuses: AuditStatus[] = ['pending', 'dismissed', 'removed'];
+  const disabledStatuses: AuditStatus[] = [];
 
   const tabs = [
     // Active tabs


### PR DESCRIPTION
- Remove the temporary redirect from the removed tab, which was in place because it was broken
- add back 'removed' to the AuditTabs statuses array
<img width="1509" height="765" alt="Screenshot 2025-09-07 at 4 45 19 PM" src="https://github.com/user-attachments/assets/166cac9b-55ff-4f9a-8d65-6706a7c59b83" />
