### PR TITLE
Add support for reason_memo

### DIFF
--- a/components/Moderators/ModerationMetadata.tsx
+++ b/components/Moderators/ModerationMetadata.tsx
@@ -54,6 +54,13 @@ export const ModerationMetadata: FC<ModerationMetadataProps> = ({ entry, classNa
             )}
           </div>
         </div>
+        {entry.reasonMemo && (
+          <div className="mt-2 ml-1">
+            <blockquote className="border-l-4 border-gray-200 pl-3 text-sm text-gray-700 italic">
+              {entry.reasonMemo}
+            </blockquote>
+          </div>
+        )}
       </div>
 
       {/* Show moderator action for removed content */}

--- a/components/modals/FlagContentModal.tsx
+++ b/components/modals/FlagContentModal.tsx
@@ -9,6 +9,7 @@ import { FlagRadioGroup } from '@/components/ui/form/FlagRadioGroup';
 import { toast } from 'react-hot-toast';
 import { useFlag } from '@/hooks/useFlagging';
 import { ContentType } from '@/types/work';
+import { Textarea } from '@/components/ui/form/Textarea';
 
 interface FlagContentModalProps {
   isOpen: boolean;
@@ -28,6 +29,7 @@ export function FlagContentModal({
   commentId,
 }: FlagContentModalProps) {
   const [selectedReason, setSelectedReason] = useState<FlagReasonKey | null>(null);
+  const [reasonMemo, setReasonMemo] = useState('');
   const [{ isLoading }, flag] = useFlag();
 
   const handleSubmit = async () => {
@@ -39,6 +41,7 @@ export function FlagContentModal({
         documentId,
         reason: selectedReason,
         commentId: commentId ? Number(commentId) : undefined,
+        reasonMemo: reasonMemo.trim(),
       });
       toast.success('Content reported successfully');
       onClose();
@@ -88,6 +91,26 @@ export function FlagContentModal({
                     onChange={(value) => setSelectedReason(value as FlagReasonKey)}
                     className="space-y-1.5"
                   />
+
+                  <div className="mt-4">
+                    <label htmlFor="reason-memo" className="block text-xs text-gray-600 mb-1">
+                      Additional information (optional)
+                    </label>
+                    <Textarea
+                      id="reason-memo"
+                      value={reasonMemo}
+                      onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) =>
+                        setReasonMemo(e.target.value)
+                      }
+                      placeholder="Provide more details..."
+                      className="w-full"
+                      rows={3}
+                      maxLength={1000}
+                    />
+                    <p className="text-xs text-gray-500 mt-1 text-right">
+                      {reasonMemo.length} / 1000
+                    </p>
+                  </div>
 
                   <div className="mt-5 flex justify-end gap-3">
                     <Button variant="ghost" size="sm" onClick={onClose}>

--- a/services/audit.service.ts
+++ b/services/audit.service.ts
@@ -39,6 +39,7 @@ interface FlaggedContentApiResponse {
   };
   reason: string;
   reason_choice: string;
+  reason_memo?: string;
   content_type: {
     id: ID;
     name: string;
@@ -75,6 +76,7 @@ export interface FlaggedContent {
   };
   reason: string;
   reasonChoice: string;
+  reasonMemo?: string;
   contentType: {
     id: ID;
     name: string;
@@ -148,6 +150,7 @@ const transformFlaggedContent = (apiItem: FlaggedContentApiResponse): FlaggedCon
     : undefined,
   reason: apiItem.reason,
   reasonChoice: apiItem.reason_choice,
+  reasonMemo: apiItem.reason_memo,
   contentType: {
     id: apiItem.content_type.id,
     name: apiItem.content_type.name,

--- a/services/reaction.service.ts
+++ b/services/reaction.service.ts
@@ -42,6 +42,7 @@ export interface FlagOptions {
   documentType: DocumentType;
   documentId: ID; // ID of the document to flag
   reason: FlagReasonKey;
+  reasonMemo?: string;
   threadId?: ID;
   commentId?: ID; // ID of the comment to flag (if flagging a comment)
   replyId?: ID;
@@ -126,7 +127,13 @@ export class ReactionService {
     }
   }
 
-  static async flag({ documentType, documentId, reason, commentId }: FlagOptions): Promise<Flag> {
+  static async flag({
+    documentType,
+    documentId,
+    reason,
+    commentId,
+    reasonMemo,
+  }: FlagOptions): Promise<Flag> {
     if (!documentId) {
       throw new Error('Document ID is required');
     }
@@ -135,7 +142,12 @@ export class ReactionService {
     const commentPart = commentId ? `/comments/${commentId}` : '';
     const url = `${this.BASE_PATH}/${baseUrl}${commentPart}/flag/`;
 
-    const response = await ApiClient.post(url, { reason });
+    const payload: { reason: FlagReasonKey; reason_memo?: string } = { reason };
+    if (reasonMemo) {
+      payload.reason_memo = reasonMemo;
+    }
+
+    const response = await ApiClient.post(url, payload);
 
     return transformFlag(response);
   }


### PR DESCRIPTION
- FlagContent modal now supports optional custom note with max characters = 1000
- Moderation dashboard now shows the user's submitted reason_memo in the MOderationMetadata.