### PR TITLE
RFP Countdown

### DIFF
--- a/components/Feed/items/FeedItemGrant.tsx
+++ b/components/Feed/items/FeedItemGrant.tsx
@@ -210,9 +210,7 @@ export const FeedItemGrant: FC<FeedItemGrantRefactoredProps> = ({
                   {expiringSoon && (
                     <>
                       <div className="h-4 w-px bg-gray-300" />
-                      <span className="text-amber-600 font-medium">
-                        {formatDeadline(deadline, 'grant')}
-                      </span>
+                      <span className="text-amber-600 font-medium">{formatDeadline(deadline)}</span>
                     </>
                   )}
                 </div>

--- a/components/Feed/items/FeedItemGrant.tsx
+++ b/components/Feed/items/FeedItemGrant.tsx
@@ -205,7 +205,8 @@ export const FeedItemGrant: FC<FeedItemGrantRefactoredProps> = ({
                 <div className="flex items-center gap-1.5 text-sm mb-3">
                   <Calendar className="w-4 h-4 text-gray-500 flex-shrink-0" />
                   <span className="text-gray-500">
-                    Apply by: {format(new Date(deadline), 'MMM d, yyyy')}
+                    Apply by: {format(new Date(deadline), 'MMM d, yyyy')} at{' '}
+                    {format(new Date(deadline), 'h:mm a')}
                   </span>
                   {expiringSoon && (
                     <>

--- a/components/Feed/items/FeedItemGrant.tsx
+++ b/components/Feed/items/FeedItemGrant.tsx
@@ -94,7 +94,6 @@ export const FeedItemGrant: FC<FeedItemGrantRefactoredProps> = ({
   // Calculate status and deadline
   const isOpen = grant.grant?.status === 'OPEN' && !grant.grant?.isExpired;
   const deadline = grant.grant?.endDate;
-  const daysLeft = deadline ? differenceInCalendarDays(new Date(deadline), new Date()) : null;
   const expiringSoon = isExpiringSoon(deadline, 1); // Use 1-day threshold for grants
 
   // Prepare applicants data

--- a/components/Feed/items/FeedItemGrant.tsx
+++ b/components/Feed/items/FeedItemGrant.tsx
@@ -17,7 +17,7 @@ import { ContentTypeBadge } from '@/components/ui/ContentTypeBadge';
 import { TopicAndJournalBadge } from '@/components/ui/TopicAndJournalBadge';
 import { AvatarStack } from '@/components/ui/AvatarStack';
 import { Building, Calendar } from 'lucide-react';
-import { differenceInCalendarDays, format } from 'date-fns';
+import { format } from 'date-fns';
 import { useRouter } from 'next/navigation';
 import Icon from '@/components/ui/icons/Icon';
 import { formatDeadline } from '@/utils/date';
@@ -205,8 +205,7 @@ export const FeedItemGrant: FC<FeedItemGrantRefactoredProps> = ({
                 <div className="flex items-center gap-1.5 text-sm mb-3">
                   <Calendar className="w-4 h-4 text-gray-500 flex-shrink-0" />
                   <span className="text-gray-500">
-                    Apply by: {format(new Date(deadline), 'MMM d, yyyy')} at{' '}
-                    {format(new Date(deadline), 'h:mm a')}
+                    Apply by: {format(new Date(deadline), 'MMM d, yyyy')}
                   </span>
                   {expiringSoon && (
                     <>

--- a/components/Feed/items/FeedItemGrant.tsx
+++ b/components/Feed/items/FeedItemGrant.tsx
@@ -20,6 +20,8 @@ import { Building, Calendar } from 'lucide-react';
 import { differenceInCalendarDays, format } from 'date-fns';
 import { useRouter } from 'next/navigation';
 import Icon from '@/components/ui/icons/Icon';
+import { formatDeadline } from '@/utils/date';
+import { isExpiringSoon } from '@/components/Bounty/lib/bountyUtil';
 
 // Grant-specific content type that extends the feed entry structure
 export interface FeedGrantContent {
@@ -93,7 +95,7 @@ export const FeedItemGrant: FC<FeedItemGrantRefactoredProps> = ({
   const isOpen = grant.grant?.status === 'OPEN' && !grant.grant?.isExpired;
   const deadline = grant.grant?.endDate;
   const daysLeft = deadline ? differenceInCalendarDays(new Date(deadline), new Date()) : null;
-  const isExpiringSoon = daysLeft !== null && daysLeft <= 7 && daysLeft > 0;
+  const expiringSoon = isExpiringSoon(deadline, 1); // Use 1-day threshold for grants
 
   // Prepare applicants data
   const applicants = grant.grant?.applicants || [];
@@ -203,9 +205,17 @@ export const FeedItemGrant: FC<FeedItemGrantRefactoredProps> = ({
               <MetadataSection>
                 <div className="flex items-center gap-1.5 text-sm mb-3">
                   <Calendar className="w-4 h-4 text-gray-500 flex-shrink-0" />
-                  <span className={isExpiringSoon ? 'text-amber-600' : 'text-gray-500'}>
+                  <span className="text-gray-500">
                     Apply by: {format(new Date(deadline), 'MMM d, yyyy')}
                   </span>
+                  {expiringSoon && (
+                    <>
+                      <div className="h-4 w-px bg-gray-300" />
+                      <span className="text-amber-600 font-medium">
+                        {formatDeadline(deadline, 'grant')}
+                      </span>
+                    </>
+                  )}
                 </div>
               </MetadataSection>
             )}
@@ -243,11 +253,6 @@ export const FeedItemGrant: FC<FeedItemGrantRefactoredProps> = ({
                 >
                   Apply
                 </button>
-                {isExpiringSoon && daysLeft !== null && (
-                  <span className="text-sm text-amber-600 font-medium">
-                    {daysLeft} day{daysLeft !== 1 ? 's' : ''} left
-                  </span>
-                )}
               </CTASection>
             )}
           </>

--- a/components/work/GrantDocument.tsx
+++ b/components/work/GrantDocument.tsx
@@ -134,7 +134,7 @@ export const GrantDocument = ({
                   {expiringSoon && work.note?.post?.grant?.endDate && (
                     <>
                       <div className="hidden md:block h-4 w-px bg-gray-300" />
-                      <span className="text-sm text-amber-600 font-medium">
+                      <span className="text-sm text-amber-600 font-medium block md:inline">
                         {formatDeadline(work.note.post.grant.endDate)}
                       </span>
                     </>

--- a/components/work/GrantDocument.tsx
+++ b/components/work/GrantDocument.tsx
@@ -10,6 +10,8 @@ import { CommentFeed } from '@/components/Comment/CommentFeed';
 import { GrantApplications } from './GrantApplications';
 import { differenceInCalendarDays, format } from 'date-fns';
 import { PostBlockEditor } from './PostBlockEditor';
+import { formatDeadline } from '@/utils/date';
+import { isExpiringSoon } from '@/components/Bounty/lib/bountyUtil';
 
 interface GrantDocumentProps {
   work: Work;
@@ -83,6 +85,9 @@ export const GrantDocument = ({
   const isClosedByDate = endDate ? differenceInCalendarDays(endDate, new Date()) < 0 : false;
   const isOpen = work.note?.post?.grant?.status === 'OPEN' && !isClosedByDate;
 
+  // Check if we should show countdown (within 1 day for grants)
+  const expiringSoon = isExpiringSoon(work.note?.post?.grant?.endDate, 1);
+
   return (
     <div>
       <PageHeader title={work.title} className="text-2xl md:!text-3xl mt-2" />
@@ -118,9 +123,17 @@ export const GrantDocument = ({
               {endDate && isOpen && (
                 <>
                   <div className="h-4 w-px bg-gray-300" />
-                  <span className="text-gray-600 text-sm">
+                  <span className="text-sm text-gray-600">
                     Closes on {format(endDate, 'MMMM d, yyyy')}
                   </span>
+                  {expiringSoon && work.note?.post?.grant?.endDate && (
+                    <>
+                      <div className="h-4 w-px bg-gray-300" />
+                      <span className="text-sm text-amber-600 font-medium">
+                        {formatDeadline(work.note.post.grant.endDate, 'grant')}
+                      </span>
+                    </>
+                  )}
                 </>
               )}
               {!isOpen && endDate && (

--- a/components/work/GrantDocument.tsx
+++ b/components/work/GrantDocument.tsx
@@ -99,13 +99,13 @@ export const GrantDocument = ({
         {work.note?.post?.grant?.amount && work.note?.post?.grant?.currency && (
           <div className="flex items-start">
             <span className="font-medium text-gray-900 w-28">Amount</span>
-            <div className="flex flex-row items-center gap-2">
+            <div className="space-y-1 md:space-y-0 md:flex md:items-center md:gap-2">
               <div className="font-semibold text-orange-500 flex items-center gap-1">
                 <span>$</span>
                 {(work.note?.post?.grant?.amount.usd || 0).toLocaleString()}
                 <span>USD</span>
               </div>
-              <div className="h-4 w-px bg-gray-300" />
+              <div className="hidden md:block h-4 w-px bg-gray-300" />
               <div className="text-sm text-gray-600">Multiple applicants can be selected</div>
             </div>
           </div>
@@ -115,36 +115,38 @@ export const GrantDocument = ({
         <div className="flex items-start">
           <span className="font-medium text-gray-900 w-28">Status</span>
           <div className="flex-1 text-sm">
-            <div className="flex items-center gap-2 text-gray-800">
-              <span
-                className={`h-2 w-2 rounded-full ${isOpen ? 'bg-emerald-500' : 'bg-gray-400'} inline-block`}
-              />
-              <span>{isOpen ? 'Accepting Applications' : 'Closed'}</span>
-              {/* Deadline with countdown for open grants */}
+            <div className="space-y-2">
+              {/* Status line */}
+              <div className="flex items-center gap-2 text-gray-800">
+                <span
+                  className={`h-2 w-2 rounded-full ${isOpen ? 'bg-emerald-500' : 'bg-gray-400'} inline-block`}
+                />
+                <span>{isOpen ? 'Accepting Applications' : 'Closed'}</span>
+              </div>
+
+              {/* Deadline and countdown - stack on mobile */}
               {endDate && isOpen && (
-                <>
-                  <div className="h-4 w-px bg-gray-300" />
+                <div className="space-y-1 md:space-y-0 md:flex md:items-center md:gap-2">
                   <span className="text-sm text-gray-600">
                     Closes on {format(endDate, 'MMMM d, yyyy')} at {format(endDate, 'h:mm a')}
                   </span>
                   {/* Show countdown when expiring soon */}
                   {expiringSoon && work.note?.post?.grant?.endDate && (
                     <>
-                      <div className="h-4 w-px bg-gray-300" />
+                      <div className="hidden md:block h-4 w-px bg-gray-300" />
                       <span className="text-sm text-amber-600 font-medium">
                         {formatDeadline(work.note.post.grant.endDate)}
                       </span>
                     </>
                   )}
-                </>
+                </div>
               )}
+
+              {/* Closed grant deadline */}
               {!isOpen && endDate && (
-                <>
-                  <div className="h-4 w-px bg-gray-300" />
-                  <span className="text-gray-600 text-sm">
-                    Closed on {format(endDate, 'MMMM d, yyyy')} at {format(endDate, 'h:mm a')}
-                  </span>
-                </>
+                <span className="text-gray-600 text-sm">
+                  Closed on {format(endDate, 'MMMM d, yyyy')} at {format(endDate, 'h:mm a')}
+                </span>
               )}
             </div>
           </div>

--- a/components/work/GrantDocument.tsx
+++ b/components/work/GrantDocument.tsx
@@ -125,7 +125,7 @@ export const GrantDocument = ({
                 <>
                   <div className="h-4 w-px bg-gray-300" />
                   <span className="text-sm text-gray-600">
-                    Closes on {format(endDate, 'MMMM d, yyyy')}
+                    Closes on {format(endDate, 'MMMM d, yyyy')} at {format(endDate, 'h:mm a')}
                   </span>
                   {/* Show countdown when expiring soon */}
                   {expiringSoon && work.note?.post?.grant?.endDate && (
@@ -142,7 +142,7 @@ export const GrantDocument = ({
                 <>
                   <div className="h-4 w-px bg-gray-300" />
                   <span className="text-gray-600 text-sm">
-                    Closed on {format(endDate, 'MMMM d, yyyy')}
+                    Closed on {format(endDate, 'MMMM d, yyyy')} at {format(endDate, 'h:mm a')}
                   </span>
                 </>
               )}

--- a/components/work/GrantDocument.tsx
+++ b/components/work/GrantDocument.tsx
@@ -132,7 +132,7 @@ export const GrantDocument = ({
                     <>
                       <div className="h-4 w-px bg-gray-300" />
                       <span className="text-sm text-amber-600 font-medium">
-                        {formatDeadline(work.note.post.grant.endDate, 'grant')}
+                        {formatDeadline(work.note.post.grant.endDate)}
                       </span>
                     </>
                   )}

--- a/components/work/GrantDocument.tsx
+++ b/components/work/GrantDocument.tsx
@@ -85,7 +85,7 @@ export const GrantDocument = ({
   const isClosedByDate = endDate ? differenceInCalendarDays(endDate, new Date()) < 0 : false;
   const isOpen = work.note?.post?.grant?.status === 'OPEN' && !isClosedByDate;
 
-  // Check if we should show countdown (within 1 day for grants)
+  // Show countdown when grant expires within 24 hours
   const expiringSoon = isExpiringSoon(work.note?.post?.grant?.endDate, 1);
 
   return (
@@ -120,12 +120,14 @@ export const GrantDocument = ({
                 className={`h-2 w-2 rounded-full ${isOpen ? 'bg-emerald-500' : 'bg-gray-400'} inline-block`}
               />
               <span>{isOpen ? 'Accepting Applications' : 'Closed'}</span>
+              {/* Deadline with countdown for open grants */}
               {endDate && isOpen && (
                 <>
                   <div className="h-4 w-px bg-gray-300" />
                   <span className="text-sm text-gray-600">
                     Closes on {format(endDate, 'MMMM d, yyyy')}
                   </span>
+                  {/* Show countdown when expiring soon */}
                   {expiringSoon && work.note?.post?.grant?.endDate && (
                     <>
                       <div className="h-4 w-px bg-gray-300" />

--- a/components/work/GrantDocument.tsx
+++ b/components/work/GrantDocument.tsx
@@ -128,7 +128,7 @@ export const GrantDocument = ({
               {endDate && isOpen && (
                 <div className="space-y-1 md:space-y-0 md:flex md:items-center md:gap-2">
                   <span className="text-sm text-gray-600">
-                    Closes on {format(endDate, 'MMMM d, yyyy')} at {format(endDate, 'h:mm a')}
+                    Closes {format(endDate, 'MMMM d, yyyy')} at {format(endDate, 'h:mm a')}
                   </span>
                   {/* Show countdown when expiring soon */}
                   {expiringSoon && work.note?.post?.grant?.endDate && (

--- a/components/work/components/GrantStatusSection.tsx
+++ b/components/work/components/GrantStatusSection.tsx
@@ -40,16 +40,17 @@ export const GrantStatusSection = ({ work }: GrantStatusSectionProps) => {
         <span>{isOpen ? 'Accepting Applications' : 'Closed'}</span>
       </div>
       {isOpen && (
-        <div className="flex items-center gap-1 text-sm text-gray-600 mt-1">
-          <Clock size={14} className="text-gray-500" />
-          <span>Closes {format(endDate, 'MMMM d, yyyy')}</span>
+        <div className="text-sm text-gray-600 mt-1">
+          <div className="flex items-center gap-1">
+            <Clock size={14} className="text-gray-500" />
+            <span>Closes {format(endDate, 'MMMM d, yyyy')}</span>
+          </div>
           {expiringSoon && work.note?.post?.grant?.endDate && (
-            <>
-              <div className="h-4 w-px bg-gray-300" />
+            <div className="mt-1">
               <span className="text-amber-600 font-medium">
                 {formatDeadline(work.note.post.grant.endDate, 'grant')}
               </span>
-            </>
+            </div>
           )}
         </div>
       )}

--- a/components/work/components/GrantStatusSection.tsx
+++ b/components/work/components/GrantStatusSection.tsx
@@ -43,20 +43,19 @@ export const GrantStatusSection = ({ work }: GrantStatusSectionProps) => {
       {/* Deadline information for open grants */}
       {isOpen && (
         <div className="text-sm text-gray-600 mt-1">
-          {/* Main deadline date */}
           <div className="flex items-center gap-1">
             <Clock size={14} className="text-gray-500" />
             <span>Closes {format(endDate, 'MMMM d, yyyy')}</span>
+            {/* Countdown timer when expiring soon */}
+            {expiringSoon && work.note?.post?.grant?.endDate && (
+              <>
+                <div className="h-4 w-px bg-gray-300" />
+                <span className="text-amber-600 font-medium">
+                  {formatDeadline(work.note.post.grant.endDate, 'grant')}
+                </span>
+              </>
+            )}
           </div>
-
-          {/* Countdown timer when expiring soon */}
-          {expiringSoon && work.note?.post?.grant?.endDate && (
-            <div className="mt-1">
-              <span className="text-amber-600 font-medium">
-                {formatDeadline(work.note.post.grant.endDate, 'grant')}
-              </span>
-            </div>
-          )}
         </div>
       )}
       {!isOpen && (

--- a/components/work/components/GrantStatusSection.tsx
+++ b/components/work/components/GrantStatusSection.tsx
@@ -45,7 +45,9 @@ export const GrantStatusSection = ({ work }: GrantStatusSectionProps) => {
         <div className="text-sm text-gray-600 mt-1">
           <div className="flex items-center gap-1">
             <Clock size={14} className="text-gray-500" />
-            <span>Closes {format(endDate, 'MMMM d, yyyy')}</span>
+            <span>
+              Closes on {format(endDate, 'MMMM d, yyyy')} at {format(endDate, 'h:mm a')}
+            </span>
             {/* Countdown timer when expiring soon */}
             {expiringSoon && work.note?.post?.grant?.endDate && (
               <>
@@ -61,7 +63,9 @@ export const GrantStatusSection = ({ work }: GrantStatusSectionProps) => {
       {!isOpen && (
         <div className="flex items-center gap-1 text-sm text-gray-600 mt-1">
           <Clock size={14} className="text-gray-500" />
-          <span>Closed on {format(endDate, 'MMMM d, yyyy')}</span>
+          <span>
+            Closed on {format(endDate, 'MMMM d, yyyy')} at {format(endDate, 'h:mm a')}
+          </span>
         </div>
       )}
     </div>

--- a/components/work/components/GrantStatusSection.tsx
+++ b/components/work/components/GrantStatusSection.tsx
@@ -3,8 +3,6 @@
 import { Work } from '@/types/work';
 import { differenceInCalendarDays, format } from 'date-fns';
 import { Clock } from 'lucide-react';
-import { formatDeadline } from '@/utils/date';
-import { isExpiringSoon } from '@/components/Bounty/lib/bountyUtil';
 
 interface GrantStatusSectionProps {
   work: Work;
@@ -28,9 +26,6 @@ export const GrantStatusSection = ({ work }: GrantStatusSectionProps) => {
   const isClosedByDate = differenceInCalendarDays(endDate, new Date()) < 0;
   const isOpen = work.note?.post?.grant?.status === 'OPEN' && !isClosedByDate;
 
-  // Show countdown when grant expires within 24 hours
-  const expiringSoon = isExpiringSoon(work.note?.post?.grant?.endDate, 1);
-
   return (
     <div>
       <h3 className="text-base font-semibold text-gray-900 mb-2">Status</h3>
@@ -48,15 +43,6 @@ export const GrantStatusSection = ({ work }: GrantStatusSectionProps) => {
             <span>
               Closes on {format(endDate, 'MMMM d, yyyy')} at {format(endDate, 'h:mm a')}
             </span>
-            {/* Countdown timer when expiring soon */}
-            {expiringSoon && work.note?.post?.grant?.endDate && (
-              <>
-                <div className="h-4 w-px bg-gray-300" />
-                <span className="text-amber-600 font-medium">
-                  {formatDeadline(work.note.post.grant.endDate)}
-                </span>
-              </>
-            )}
           </div>
         </div>
       )}

--- a/components/work/components/GrantStatusSection.tsx
+++ b/components/work/components/GrantStatusSection.tsx
@@ -41,7 +41,7 @@ export const GrantStatusSection = ({ work }: GrantStatusSectionProps) => {
           <div className="flex items-center gap-1">
             <Clock size={14} className="text-gray-500" />
             <span>
-              Closes on {format(endDate, 'MMMM d, yyyy')} at {format(endDate, 'h:mm a')}
+              Closes {format(endDate, 'MMMM d, yyyy')} at {format(endDate, 'h:mm a')}
             </span>
           </div>
         </div>

--- a/components/work/components/GrantStatusSection.tsx
+++ b/components/work/components/GrantStatusSection.tsx
@@ -51,7 +51,7 @@ export const GrantStatusSection = ({ work }: GrantStatusSectionProps) => {
               <>
                 <div className="h-4 w-px bg-gray-300" />
                 <span className="text-amber-600 font-medium">
-                  {formatDeadline(work.note.post.grant.endDate, 'grant')}
+                  {formatDeadline(work.note.post.grant.endDate)}
                 </span>
               </>
             )}

--- a/components/work/components/GrantStatusSection.tsx
+++ b/components/work/components/GrantStatusSection.tsx
@@ -3,6 +3,8 @@
 import { Work } from '@/types/work';
 import { differenceInCalendarDays, format } from 'date-fns';
 import { Clock } from 'lucide-react';
+import { formatDeadline } from '@/utils/date';
+import { isExpiringSoon } from '@/components/Bounty/lib/bountyUtil';
 
 interface GrantStatusSectionProps {
   work: Work;
@@ -25,6 +27,9 @@ export const GrantStatusSection = ({ work }: GrantStatusSectionProps) => {
   const isClosedByDate = differenceInCalendarDays(endDate, new Date()) < 0;
   const isOpen = work.note?.post?.grant?.status === 'OPEN' && !isClosedByDate;
 
+  // Check if we should show countdown (within 1 day for grants)
+  const expiringSoon = isExpiringSoon(work.note?.post?.grant?.endDate, 1);
+
   return (
     <div>
       <h3 className="text-base font-semibold text-gray-900 mb-2">Status</h3>
@@ -38,6 +43,14 @@ export const GrantStatusSection = ({ work }: GrantStatusSectionProps) => {
         <div className="flex items-center gap-1 text-sm text-gray-600 mt-1">
           <Clock size={14} className="text-gray-500" />
           <span>Closes {format(endDate, 'MMMM d, yyyy')}</span>
+          {expiringSoon && work.note?.post?.grant?.endDate && (
+            <>
+              <div className="h-4 w-px bg-gray-300" />
+              <span className="text-amber-600 font-medium">
+                {formatDeadline(work.note.post.grant.endDate, 'grant')}
+              </span>
+            </>
+          )}
         </div>
       )}
       {!isOpen && (

--- a/components/work/components/GrantStatusSection.tsx
+++ b/components/work/components/GrantStatusSection.tsx
@@ -11,6 +11,7 @@ interface GrantStatusSectionProps {
 }
 
 export const GrantStatusSection = ({ work }: GrantStatusSectionProps) => {
+  // Handle missing deadline gracefully
   if (!work.note?.post?.grant?.endDate) {
     return (
       <div>
@@ -27,7 +28,7 @@ export const GrantStatusSection = ({ work }: GrantStatusSectionProps) => {
   const isClosedByDate = differenceInCalendarDays(endDate, new Date()) < 0;
   const isOpen = work.note?.post?.grant?.status === 'OPEN' && !isClosedByDate;
 
-  // Check if we should show countdown (within 1 day for grants)
+  // Show countdown when grant expires within 24 hours
   const expiringSoon = isExpiringSoon(work.note?.post?.grant?.endDate, 1);
 
   return (
@@ -39,12 +40,16 @@ export const GrantStatusSection = ({ work }: GrantStatusSectionProps) => {
         />
         <span>{isOpen ? 'Accepting Applications' : 'Closed'}</span>
       </div>
+      {/* Deadline information for open grants */}
       {isOpen && (
         <div className="text-sm text-gray-600 mt-1">
+          {/* Main deadline date */}
           <div className="flex items-center gap-1">
             <Clock size={14} className="text-gray-500" />
             <span>Closes {format(endDate, 'MMMM d, yyyy')}</span>
           </div>
+
+          {/* Countdown timer when expiring soon */}
           {expiringSoon && work.note?.post?.grant?.endDate && (
             <div className="mt-1">
               <span className="text-amber-600 font-medium">

--- a/utils/date.ts
+++ b/utils/date.ts
@@ -42,15 +42,15 @@ export function formatTimestamp(timestamp: string): string {
 }
 
 /**
- * Gets terminology mapping for different deadline types
+ * Gets consistent terminology for deadline formatting
  */
-function getTerminology(type: 'bounty' | 'grant') {
+function getTerminology() {
   return {
-    pastTense: type === 'grant' ? 'Closed' : 'Ended',
-    presentTense: type === 'grant' ? 'Closes' : 'Ends',
-    pastToday: type === 'grant' ? 'Closed today' : 'Ended today',
-    presentToday: type === 'grant' ? 'Closes today' : 'Ends today',
-    presentTomorrow: type === 'grant' ? 'Closes tomorrow' : 'Ends tomorrow',
+    pastTense: 'Ended',
+    presentTense: 'Ends',
+    pastToday: 'Ended today',
+    presentToday: 'Ends today',
+    presentTomorrow: 'Ends tomorrow',
   };
 }
 
@@ -70,38 +70,34 @@ function formatSameDayCountdown(
   const diffHours = deadlineDate.diff(now, 'hour');
   const diffMinutes = deadlineDate.diff(now, 'minute');
 
-  // Show countdown for same-day deadlines within 24 hours
-  if (diffHours >= 0 && diffHours < 24) {
-    if (diffHours === 0) {
-      return `${terminology.presentTense} in ${diffMinutes}m`;
-    }
-    return `${terminology.presentTense} in ${diffHours}h`;
+  // Show countdown for same-day deadlines
+  if (diffHours === 0) {
+    return `${terminology.presentTense} in ${diffMinutes}m`;
   }
 
-  return terminology.presentToday;
+  return `${terminology.presentTense} in ${diffHours}h`;
 }
 
 /**
  * Formats a deadline timestamp into a human-readable countdown string
  *
- * This function provides consistent deadline formatting across the application,
- * supporting both bounty and grant terminology with appropriate countdown displays.
+ * This function provides consistent deadline formatting across the application
+ * using unified "Ends" terminology for all deadline types.
  *
  * @param deadline ISO timestamp string of the deadline
- * @param type Type of deadline - 'bounty' or 'grant' (default: 'bounty')
  * @returns Formatted deadline string with countdown logic:
- *   - Under 1 hour: Shows minutes (e.g., "Closes in 30m")
- *   - 1-23 hours: Shows hours (e.g., "Closes in 3h")
- *   - 1 day: Shows "Closes tomorrow"
+ *   - Under 1 hour: Shows minutes (e.g., "Ends in 30m")
+ *   - 1-23 hours: Shows hours (e.g., "Ends in 3h")
+ *   - 1 day: Shows "Ends tomorrow"
  *   - 2-29 days: Shows "X days left"
  *   - 30+ days: Shows full date
- *   - Past deadline: Shows "Closed" or "Ended"
+ *   - Past deadline: Shows "Ended"
  */
-export function formatDeadline(deadline: string, type: 'bounty' | 'grant' = 'bounty'): string {
+export function formatDeadline(deadline: string): string {
   const now = dayjs();
   const deadlineDate = dayjs(deadline);
   const diffDays = deadlineDate.diff(now, 'day');
-  const terminology = getTerminology(type);
+  const terminology = getTerminology();
 
   // Handle past deadlines
   if (diffDays < 0) {

--- a/utils/date.ts
+++ b/utils/date.ts
@@ -44,33 +44,45 @@ export function formatTimestamp(timestamp: string): string {
 /**
  * Formats a deadline timestamp into a human-readable string
  * @param deadline ISO timestamp string
+ * @param type Type of deadline - 'bounty' or 'grant' (default: 'bounty')
  * @returns Formatted deadline string (e.g. "Ended", "Ends today", "5 days left", etc.)
  */
-export function formatDeadline(deadline: string): string {
+export function formatDeadline(deadline: string, type: 'bounty' | 'grant' = 'bounty'): string {
   const now = dayjs();
   const deadlineDate = dayjs(deadline);
   const diffDays = deadlineDate.diff(now, 'day');
+  const diffHours = deadlineDate.diff(now, 'hour');
+  const diffMinutes = deadlineDate.diff(now, 'minute');
+
+  // Choose terminology based on type
+  const pastTense = type === 'grant' ? 'Closed' : 'Ended';
+  const presentTense = type === 'grant' ? 'Closes' : 'Ends';
+  const pastToday = type === 'grant' ? 'Closed today' : 'Ended today';
+  const presentToday = type === 'grant' ? 'Closes today' : 'Ends today';
+  const presentTomorrow = type === 'grant' ? 'Closes tomorrow' : 'Ends tomorrow';
 
   if (diffDays < 0) {
-    return 'Ended';
+    return pastTense;
   } else if (diffDays === 0) {
     const diffMs = deadlineDate.diff(now);
-    const diffHours = deadlineDate.diff(now, 'hour');
     if (diffMs < 0) {
-      return 'Ended today';
-    } else if (diffHours === 0) {
-      return 'Ends in less than an hour';
-    } else if (diffHours > 0 && diffHours < 24) {
-      return `Ends in ${diffHours} hours`;
+      return pastToday;
+    } else if (diffHours >= 0 && diffHours < 24) {
+      // Show countdown in minutes when under 1 hour, hours when 1+ hours
+      if (diffHours === 0) {
+        return `${presentTense} in ${diffMinutes}m`;
+      } else {
+        return `${presentTense} in ${diffHours}h`;
+      }
     } else {
-      return 'Ends today';
+      return presentToday;
     }
   } else if (diffDays === 1) {
-    return 'Ends tomorrow';
+    return presentTomorrow;
   } else if (diffDays < 30) {
     return `${diffDays} days left`;
   } else {
-    return `Ends ${formatTimestamp(deadline)}`;
+    return `${presentTense} ${formatTimestamp(deadline)}`;
   }
 }
 


### PR DESCRIPTION
Include a countdown for RFP cards when there is <24 hours because researchers submit applications on the last day. The deadline didn't have enough granularity to the hour and minutes, resulting in researchers missing the deadline. 

**Before**
<img width="787" height="397" alt="image" src="https://github.com/user-attachments/assets/b41cac47-96e3-4b96-8286-66ddfed943a1" />

**After**
Countdown in the RFP Card in the feed
<img width="804" height="375" alt="image" src="https://github.com/user-attachments/assets/83dbc2b2-d7f4-42a4-b27c-b16d96e522b4" />

RFP Page - Granular time (hour/minute) and Countdown
<img width="586" height="285" alt="image" src="https://github.com/user-attachments/assets/4450d821-91bd-4136-9eec-e94776b3ea42" />

Sidebar - Granular time (hour/minute)
<img width="333" height="358" alt="image" src="https://github.com/user-attachments/assets/d3173cc4-aff5-41b3-a181-a073099c49aa" />

Mobile - include vertical stack for the status section
<img width="204" height="447" alt="image" src="https://github.com/user-attachments/assets/2449e1c8-38b7-4860-825e-fb0df2e2d367" />

