### PR TITLE
Rebrand all user facing "Grant" to "RFP"

### DIFF
--- a/app/grant/create/page.tsx
+++ b/app/grant/create/page.tsx
@@ -54,8 +54,8 @@ export default function CreateGrantPage() {
       <div className="w-full max-w-3xl mx-auto space-y-8 py-8">
         <div className="text-center pb-8">
           <div className="flex flex-col items-center gap-3">
-            <h1 className="text-4xl font-bold text-gray-900">Open a Grant</h1>
-            <p className="text-lg text-gray-600">Accelerate scientific research with a grant.</p>
+            <h1 className="text-4xl font-bold text-gray-900">Open an RFP</h1>
+            <p className="text-lg text-gray-600">Accelerate scientific research with an RFP.</p>
           </div>
         </div>
 
@@ -74,7 +74,7 @@ export default function CreateGrantPage() {
             <div className="bg-gradient-to-r from-blue-500 to-purple-600 p-1 rounded-xl shadow-lg my-8">
               <div className="bg-white p-6 md:p-8 rounded-lg space-y-6">
                 <h2 className="text-3xl font-bold text-center text-gray-800">
-                  Why Fund with ResearchHub Grants?
+                  Why fund with ResearchHub RFPs?
                 </h2>
                 <div className="grid md:grid-cols-2 gap-x-6 gap-y-8">
                   {[
@@ -125,7 +125,7 @@ export default function CreateGrantPage() {
                     },
                     {
                       title: 'Expert Support',
-                      text: 'We assign a dedicated contact person to ensure your grant process is smooth and successful.',
+                      text: 'We assign a dedicated contact person to ensure your RFP process is smooth and successful.',
                       iconName: 'LifeBuoy',
                       style: {
                         iconColor: 'text-black-500',

--- a/app/layouts/TopBar.tsx
+++ b/app/layouts/TopBar.tsx
@@ -176,7 +176,7 @@ const getPageInfo = (pathname: string): PageInfo | null => {
   // Grant routes
   if (pathname.startsWith('/grant')) {
     return {
-      title: 'Grant',
+      title: 'RFP',
       icon: <Icon name="fund" size={24} className="text-gray-900" />,
     };
   }

--- a/app/notebook/LeftSidebar.tsx
+++ b/app/notebook/LeftSidebar.tsx
@@ -162,8 +162,8 @@ export const LeftSidebar = () => {
             <FileText className="h-4 w-4" />
           )}
           <div>
-            <div className="font-medium text-gray-900">Grant Proposal</div>
-            <div className="text-xs text-gray-500">Structured grant application</div>
+            <div className="font-medium text-gray-900">RFP</div>
+            <div className="text-xs text-gray-500">Request for Proposals</div>
           </div>
         </BaseMenuItem>
       }

--- a/app/notebook/components/PublishingForm/components/ContactsSection.tsx
+++ b/app/notebook/components/PublishingForm/components/ContactsSection.tsx
@@ -48,7 +48,7 @@ export function ContactsSection() {
         placeholder="Search for contacts..."
         error={getFieldErrorMessage(errors.contacts, 'Invalid contacts')}
         debounceMs={500}
-        helperText="Add contacts who will be responsible for managing this grant. These contacts will receive important updates about the grant's progress."
+        helperText="Add contacts who will be responsible for managing this RFP. These contacts will receive important updates about the RFP's progress."
       />
     </div>
   );

--- a/app/notebook/components/PublishingForm/components/GrantApplicationDeadlineSection.tsx
+++ b/app/notebook/components/PublishingForm/components/GrantApplicationDeadlineSection.tsx
@@ -22,7 +22,7 @@ export function GrantApplicationDeadlineSection() {
           onChange={(date) => setValue('applicationDeadline', date, { shouldValidate: true })}
           placeholder="Select deadline date"
           error={errors.applicationDeadline?.message?.toString()}
-          helperText="When applications for this grant should be submitted by"
+          helperText="When applications for this RFP should be submitted by"
           minDate={new Date()} // Prevent selecting past dates
           required
         />

--- a/app/notebook/components/PublishingForm/components/GrantDescriptionSection.tsx
+++ b/app/notebook/components/PublishingForm/components/GrantDescriptionSection.tsx
@@ -15,7 +15,7 @@ export function GrantDescriptionSection() {
       <div className="mt-2">
         <Textarea
           {...register('shortDescription')}
-          placeholder="Describe what this grant is for and what you're looking to fund"
+          placeholder="Describe what this RFP is for and what you're looking to fund"
           error={errors.shortDescription?.message?.toString()}
           required
         />

--- a/app/notebook/components/PublishingForm/components/GrantFundingAmountSection.tsx
+++ b/app/notebook/components/PublishingForm/components/GrantFundingAmountSection.tsx
@@ -24,7 +24,7 @@ export function GrantFundingAmountSection() {
           rightElement={
             <div className="flex items-center pr-4 font-medium text-sm text-orange-600">USD</div>
           }
-          helperText="How much money you are giving for this grant"
+          helperText="How much money you are giving for this RFP"
           required
           onChange={(e) => {
             const numericValue = e.target.value.replace(/[^0-9]/g, '');

--- a/app/notebook/components/PublishingForm/components/WorkTypeSection.tsx
+++ b/app/notebook/components/PublishingForm/components/WorkTypeSection.tsx
@@ -21,8 +21,8 @@ const articleTypes: Record<
     description: 'Get funding by sharing your research plan',
   },
   grant: {
-    title: 'Grant',
-    description: 'Create a funding opportunity',
+    title: 'RFP',
+    description: 'Create a request for proposals',
   },
 };
 

--- a/components/Editor/lib/data/initialContent.tsx
+++ b/components/Editor/lib/data/initialContent.tsx
@@ -177,7 +177,7 @@ const grantTemplate: Template = {
       content: [
         {
           type: 'text',
-          text: 'Grant Proposal Title',
+          text: 'RFP Title',
         },
       ],
     },

--- a/components/modals/ApplyToGrantModal.tsx
+++ b/components/modals/ApplyToGrantModal.tsx
@@ -110,12 +110,12 @@ export const ApplyToGrantModal: React.FC<ApplyToGrantModalProps> = ({
     setSubmitting(true);
     try {
       await GrantService.applyToGrant(grantId, selectedProposal.postId);
-      toast.success('Successfully applied to grant!');
+      toast.success('Successfully applied to RFP!');
       onClose();
       onUseSelected(selectedProposal);
     } catch (error) {
-      console.error('Error applying to grant:', error);
-      toast.error('Failed to apply to grant. Please try again.');
+      console.error('Error applying to RFP:', error);
+      toast.error('Failed to apply to RFP. Please try again.');
     } finally {
       setSubmitting(false);
     }
@@ -157,7 +157,7 @@ export const ApplyToGrantModal: React.FC<ApplyToGrantModalProps> = ({
               </button>
             )}
             <h2 className="text-lg font-medium text-gray-900">
-              {showProposalList ? 'Select Proposal' : 'Apply to Grant'}
+              {showProposalList ? 'Select Proposal' : 'Apply to RFP'}
             </h2>
           </div>
           <button
@@ -179,7 +179,7 @@ export const ApplyToGrantModal: React.FC<ApplyToGrantModalProps> = ({
                   {/* Description */}
                   <div className="space-y-3">
                     <p className="text-base text-gray-700 font-medium leading-relaxed">
-                      Applying to grants on ResearchHub happens via proposals.
+                      Applying to RFPs on ResearchHub happens via proposals.
                     </p>
                   </div>
 
@@ -235,7 +235,7 @@ export const ApplyToGrantModal: React.FC<ApplyToGrantModalProps> = ({
                           <p className="text-xs text-blue-800 leading-relaxed">
                             Documenting and sharing your research plan before conducting research as
                             well as specifying funding requirements. We believe open access
-                            proposals are the perfect format for grant applications.
+                            proposals are the perfect format for RFP applications.
                           </p>
                         </div>
                       </div>

--- a/components/modals/GrantModal.tsx
+++ b/components/modals/GrantModal.tsx
@@ -73,7 +73,7 @@ export function GrantModal({ isOpen, onClose }: GrantModalProps) {
 
                 <form onSubmit={handleSubmit} className="space-y-6">
                   <div>
-                    <h3 className="text-lg font-medium text-gray-900">Submit a Grant</h3>
+                    <h3 className="text-lg font-medium text-gray-900">Publish an RFP</h3>
                     <p className="mt-1 text-sm text-gray-500">
                       Fund promising research by publishing a Request for Proposals (RFP)
                     </p>
@@ -91,7 +91,7 @@ export function GrantModal({ isOpen, onClose }: GrantModalProps) {
                         onChange={(e: ChangeEvent<HTMLInputElement>) =>
                           setGrantInfo({ ...grantInfo, title: e.target.value })
                         }
-                        placeholder="Enter grant title"
+                        placeholder="Enter RFP title"
                         className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"
                         required
                       />
@@ -119,7 +119,7 @@ export function GrantModal({ isOpen, onClose }: GrantModalProps) {
 
                     <div>
                       <label htmlFor="amount" className="block text-sm font-medium text-gray-700">
-                        Grant Amount (RSC)
+                        Funding Amount (RSC)
                       </label>
                       <input
                         id="amount"
@@ -129,18 +129,18 @@ export function GrantModal({ isOpen, onClose }: GrantModalProps) {
                         onChange={(e: ChangeEvent<HTMLInputElement>) =>
                           setGrantInfo({ ...grantInfo, amount: Number(e.target.value) })
                         }
-                        placeholder="Enter grant amount in ResearchCoin"
+                        placeholder="Enter funding amount in ResearchCoin"
                         className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"
                         required
                       />
                       <p className="mt-1 text-xs text-gray-500">
-                        Minimum grant amount is 10,000 RSC
+                        Minimum funding amount is 10,000 RSC
                       </p>
                     </div>
                   </div>
 
                   <div className="bg-gray-50 p-4 rounded-lg space-y-2">
-                    <h4 className="text-sm font-medium text-gray-900">Grant Process</h4>
+                    <h4 className="text-sm font-medium text-gray-900">RFP Process</h4>
                     <ul className="text-xs text-gray-600 space-y-1">
                       <li>• Applications are reviewed on a rolling basis</li>
                       <li>• Decisions are made monthly</li>
@@ -150,7 +150,7 @@ export function GrantModal({ isOpen, onClose }: GrantModalProps) {
                   </div>
 
                   <Button type="submit" className="w-full justify-center">
-                    Submit Grant
+                    Publish RFP
                   </Button>
                 </form>
               </Dialog.Panel>

--- a/components/ui/ContentTypeBadge.tsx
+++ b/components/ui/ContentTypeBadge.tsx
@@ -136,7 +136,7 @@ export const ContentTypeBadge = ({
         className={cn('gap-1.5 py-1 border-gray-300 cursor-pointer', className)}
       >
         <Icon name="fund" size={16} color="#374151" />
-        <span>Grant</span>
+        <span>RFP</span>
       </Badge>
     );
 
@@ -151,7 +151,7 @@ export const ContentTypeBadge = ({
             <div className="bg-gray-100 p-2 rounded-md flex items-center justify-center">
               <Icon name="fund" size={24} color="#059669" />
             </div>
-            <div>Available funding opportunities for researchers to apply for grants.</div>
+            <div>Request for proposals inviting researchers to apply for funding.</div>
           </div>
         }
         position="top"

--- a/components/work/WorkTabs.tsx
+++ b/components/work/WorkTabs.tsx
@@ -117,7 +117,7 @@ export const WorkTabs = ({
   const getMainTabLabel = () => {
     if (contentType === 'paper') return 'Paper';
     if (contentType === 'fund') return 'Project';
-    if (contentType === 'grant') return 'Grant';
+    if (contentType === 'grant') return 'RFP';
     if (work.postType === 'QUESTION') return 'Question';
     return 'Post';
   };


### PR DESCRIPTION
### Issue:
Legacy verbiage of 'grant' and 'grant proposal' were being used in various lingering places like the notebook, topper, and content badge

### UI-only text/labels:
- app/notebook/LeftSidebar.tsx: “RFP” in template menu. No data/route changes.
- components/Editor/lib/data/initialContent.tsx and components/Editor/lib/data/grantTemplate.tsx: template copy only.
- app/notebook/components/PublishingForm/components/WorkTypeSection.tsx: work type label/description only.
- app/layouts/TopBar.tsx: title for /grant routes now “RFP”. No route change.
- app/grant/create/page.tsx: hero/section copy only.
- components/ui/ContentTypeBadge.tsx: label/tooltip only.
- components/work/WorkTabs.tsx: main tab label “RFP” when contentType === 'grant' (contentType check unchanged). Applications tab still keyed on contentType === 'grant' and reads work.note?.post?.grant?.applicants?.length (pre-existing).
- components/modals/GrantModal.tsx: copy and placeholders only; still routes to existing paths (e.g., /grants). No API changes.
- components/Fund/GrantRightSidebar.tsx: buttonText “Open an RFP”, link to /notebook?newGrant=true (UI only).
- components/modals/ShareModal.tsx: maps URLs including '/grant/' to label “RFP” (UI only).

### Images
<img width="290" height="148" alt="Screenshot 2025-09-09 at 7 52 43 AM" src="https://github.com/user-attachments/assets/db753219-ee67-4b8c-8b66-a6b0554a1d3f" />
<img width="203" height="124" alt="Screenshot 2025-09-09 at 7 52 31 AM" src="https://github.com/user-attachments/assets/c5896e52-35dd-44ee-b72b-da7e9af652a0" />
<img width="612" height="261" alt="Screenshot 2025-09-09 at 7 52 08 AM" src="https://github.com/user-attachments/assets/5532c19c-b6ea-4ac5-a5c8-80b40fc4c113" />
<img width="368" height="394" alt="Screenshot 2025-09-09 at 7 51 55 AM" src="https://github.com/user-attachments/assets/af6005d5-4397-4106-86bf-a2ce6f31ee7d" />
<img width="633" height="506" alt="Screenshot 2025-09-09 at 7 51 49 AM" src="https://github.com/user-attachments/assets/91ea738d-29f7-40e6-88fa-1382e40f5258" />
<img width="606" height="467" alt="Screenshot 2025-09-09 at 8 01 15 AM" src="https://github.com/user-attachments/assets/4b014626-8f4a-464e-b978-36fa6f67ab5a" />

