### PR TITLE
Feat/405 funding tab filter sort

### DIFF
--- a/app/bounty/create/page.tsx
+++ b/app/bounty/create/page.tsx
@@ -11,7 +11,7 @@ import { WorkSuggestion } from '@/types/search';
 import { CommentEditor } from '@/components/Comment/CommentEditor';
 import { JSONContent } from '@tiptap/core';
 import { SessionProvider, useSession } from 'next-auth/react';
-import { HubsSelector, Hub } from '@/app/paper/create/components/HubsSelector';
+import { HubsSelector } from '@/app/paper/create/components/HubsSelector';
 import { Currency } from '@/types/root';
 import { BountyType } from '@/types/bounty';
 import { useExchangeRate } from '@/contexts/ExchangeRateContext';
@@ -42,6 +42,7 @@ import { Icon } from '@/components/ui/icons/Icon';
 import { ResearchCoinIcon } from '@/components/ui/icons/ResearchCoinIcon';
 import { extractUserMentions } from '@/components/Comment/lib/commentUtils';
 import { removeCommentDraftById } from '@/components/Comment/lib/commentDraftStorage';
+import { IHub } from '@/types/hub';
 
 // Wizard steps.
 // We intentionally separate review-specific and answer-specific steps.
@@ -82,7 +83,7 @@ export default function CreateBountyPage() {
   const [questionTitle, setQuestionTitle] = useState('');
   const [questionPlainText, setQuestionPlainText] = useState<string>('');
   const [questionHtml, setQuestionHtml] = useState<string>('');
-  const [selectedHubs, setSelectedHubs] = useState<Hub[]>([]);
+  const [selectedHubs, setSelectedHubs] = useState<IHub[]>([]);
 
   // Shared – amount / currency
   const [currency, setCurrency] = useState<Currency>('RSC');

--- a/app/earn/page.tsx
+++ b/app/earn/page.tsx
@@ -9,11 +9,12 @@ import { EarnRightSidebar } from '@/components/Earn/EarnRightSidebar';
 import { Coins } from 'lucide-react';
 import { MainPageHeader } from '@/components/ui/MainPageHeader';
 import Icon from '@/components/ui/icons/Icon';
-import { BountyHubSelector as HubsSelector, Hub } from '@/components/Earn/BountyHubSelector';
+import { BountyHubSelector as HubsSelector } from '@/components/Earn/BountyHubSelector';
 import SortDropdown, { SortOption } from '@/components/ui/SortDropdown';
 import { Badge } from '@/components/ui/Badge';
 import { X } from 'lucide-react';
 import { useClickContext } from '@/contexts/ClickContext';
+import { IHub } from '@/types/hub';
 
 export default function EarnPage() {
   const [bounties, setBounties] = useState<FeedEntry[]>([]);
@@ -21,7 +22,7 @@ export default function EarnPage() {
   const [hasMore, setHasMore] = useState(false);
   const [total, setTotal] = useState(0);
   const [page, setPage] = useState(1);
-  const [selectedHubs, setSelectedHubs] = useState<Hub[]>([]);
+  const [selectedHubs, setSelectedHubs] = useState<IHub[]>([]);
   const [sort, setSort] = useState<string>('personalized');
 
   // Click context for topic filter
@@ -35,7 +36,7 @@ export default function EarnPage() {
     { label: 'RSC amount', value: '-total_amount' },
   ];
 
-  const fetchBounties = async (reset = false, hubs: Hub[] = selectedHubs) => {
+  const fetchBounties = async (reset = false, hubs: IHub[] = selectedHubs) => {
     if (reset) {
       // Clear current bounties so skeleton loaders show instead of stale data
       setBounties([]);
@@ -76,7 +77,7 @@ export default function EarnPage() {
     }
   };
 
-  const handleHubsChange = (hubs: Hub[]) => {
+  const handleHubsChange = (hubs: IHub[]) => {
     setSelectedHubs(hubs);
     // Reset pagination and fetch bounties based on new hubs selection
     setPage(1);
@@ -104,7 +105,7 @@ export default function EarnPage() {
   useEffect(() => {
     if (event && event.type === 'topic') {
       const topic = event.payload;
-      const newHub: Hub = {
+      const newHub: IHub = {
         id: topic.id,
         name: topic.name,
         description: topic.description,

--- a/app/fund/components/FundPageContent.tsx
+++ b/app/fund/components/FundPageContent.tsx
@@ -130,7 +130,6 @@ export function FundPageContent({ marketplaceTab }: FundPageContentProps) {
               onTaxDeductibleChange={setSelectedTaxDeductible}
               selectedPreviouslyFunded={selectedPreviouslyFunded}
               onPreviouslyFundedChange={setSelectedPreviouslyFunded}
-              hideSelectedItems={true}
             />
           </div>
           <div className="w-1/2 sm:!w-[120px] flex-1 sm:!flex-none pl-1 sm:!pl-0">

--- a/app/fund/components/FundPageContent.tsx
+++ b/app/fund/components/FundPageContent.tsx
@@ -46,7 +46,7 @@ export function FundPageContent({ marketplaceTab }: FundPageContentProps) {
       filters.push(`hub_ids=${hubIds}`);
     }
     if (selectedVotes > 0) {
-      filters.push(`min_votes=${selectedVotes}`);
+      filters.push(`min_upvotes=${selectedVotes}`);
     }
     if (selectedScore > 0) {
       filters.push(`min_score=${selectedScore}`);

--- a/app/fund/components/FundPageContent.tsx
+++ b/app/fund/components/FundPageContent.tsx
@@ -10,14 +10,15 @@ import { MarketplaceTabs, MarketplaceTab } from '@/components/Fund/MarketplaceTa
 import Icon from '@/components/ui/icons/Icon';
 import SortDropdown, { SortOption } from '@/components/ui/SortDropdown';
 import { useState } from 'react';
-import { FundingSelector, Hub } from '@/components/Fund/FundingSelector';
+import { FundingSelector } from '@/components/Fund/FundingSelector';
+import { IHub } from '@/types/hub';
 
 interface FundPageContentProps {
   marketplaceTab: MarketplaceTab;
 }
 
 export function FundPageContent({ marketplaceTab }: FundPageContentProps) {
-  const [selectedHubs, setSelectedHubs] = useState<Hub[]>([]);
+  const [selectedHubs, setSelectedHubs] = useState<IHub[]>([]);
   const [selectedVotes, setSelectedVotes] = useState<number>(0);
   const [selectedScore, setSelectedScore] = useState<number>(0);
   const [selectedVerifiedAuthorsOnly, setSelectedVerifiedAuthorsOnly] = useState<boolean>(false);

--- a/app/fund/previously-funded/page.tsx
+++ b/app/fund/previously-funded/page.tsx
@@ -1,5 +1,0 @@
-import { FundPageContent } from '../components/FundPageContent';
-
-export default function PreviouslyFundedPage() {
-  return <FundPageContent marketplaceTab="previously-funded" />;
-}

--- a/app/paper/[id]/create/version/UploadVersionForm.tsx
+++ b/app/paper/[id]/create/version/UploadVersionForm.tsx
@@ -12,13 +12,14 @@ import {
   AuthorsAndAffiliations,
   SelectedAuthor,
 } from '@/app/paper/create/components/AuthorsAndAffiliations';
-import { HubsSelector, Hub } from '@/app/paper/create/components/HubsSelector';
+import { HubsSelector } from '@/app/paper/create/components/HubsSelector';
 import { FileText, FileUp, Users, Tags, ArrowLeft, Info, MessageCircle } from 'lucide-react';
 import { UploadFileResult } from '@/services/file.service';
 import { PaperService } from '@/services/paper.service';
 import toast from 'react-hot-toast';
 import { Work } from '@/types/work';
 import { WorkMetadata } from '@/services/metadata.service';
+import { IHub } from '@/types/hub';
 
 interface UploadVersionFormProps {
   initialPaper: Work;
@@ -49,7 +50,7 @@ export default function UploadVersionForm({
       isCorrespondingAuthor: auth.isCorresponding,
     }))
   );
-  const [selectedHubs, setSelectedHubs] = useState<Hub[]>(() => {
+  const [selectedHubs, setSelectedHubs] = useState<IHub[]>(() => {
     const sourceTopics = metadata?.topics ?? initialPaper.topics;
     return sourceTopics.map((topic) => ({
       id: topic.id,
@@ -117,7 +118,7 @@ export default function UploadVersionForm({
     }
   };
 
-  const handleHubsChange = (newHubs: Hub[]) => {
+  const handleHubsChange = (newHubs: IHub[]) => {
     setSelectedHubs(newHubs);
     if (errors.hubs) {
       setErrors({ ...errors, hubs: null });

--- a/app/paper/create/components/HubsSelector.tsx
+++ b/app/paper/create/components/HubsSelector.tsx
@@ -11,17 +11,11 @@ import { X, ChevronDown, Filter } from 'lucide-react';
 import { BaseMenu } from '@/components/ui/form/BaseMenu';
 import { HubService } from '@/services/hub.service';
 import { Topic } from '@/types/topic';
-
-export interface Hub {
-  id: string | number;
-  name: string;
-  description?: string;
-  color?: string;
-}
+import { IHub } from '@/types/hub';
 
 interface HubsSelectorProps {
-  selectedHubs: Hub[];
-  onChange: (hubs: Hub[]) => void;
+  selectedHubs: IHub[];
+  onChange: (hubs: IHub[]) => void;
   error?: string | null;
   displayCountOnly?: boolean;
   hideSelectedItems?: boolean;
@@ -35,7 +29,7 @@ export function HubsSelector({
   hideSelectedItems = false,
 }: HubsSelectorProps) {
   // Convert hubs to the format expected by SearchableMultiSelect
-  const hubsToOptions = (hubs: Hub[]): MultiSelectOption[] => {
+  const hubsToOptions = (hubs: IHub[]): MultiSelectOption[] => {
     return hubs.map((hub) => ({
       value: String(hub.id),
       label: hub.name,
@@ -43,7 +37,7 @@ export function HubsSelector({
   };
 
   // Convert Topic to Hub
-  const topicsToHubs = (topics: Topic[]): Hub[] => {
+  const topicsToHubs = (topics: Topic[]): IHub[] => {
     return topics.map((topic) => ({
       id: topic.id,
       name: topic.name,
@@ -52,7 +46,7 @@ export function HubsSelector({
   };
 
   // Convert MultiSelectOption back to Hub objects
-  const optionsToHubs = (options: MultiSelectOption[]): Hub[] => {
+  const optionsToHubs = (options: MultiSelectOption[]): IHub[] => {
     return options.map((option) => {
       // Find the original hub in the selectedHubs array
       const existingHub = selectedHubs.find((hub) => String(hub.id) === option.value);

--- a/app/paper/create/pdf/page.tsx
+++ b/app/paper/create/pdf/page.tsx
@@ -10,7 +10,7 @@ import { Input } from '@/components/ui/form/Input';
 import { FileUpload } from '@/components/ui/form/FileUpload';
 import { SimpleStepProgress, SimpleStep } from '@/components/ui/SimpleStepProgress';
 import { AuthorsAndAffiliations, SelectedAuthor } from '../components/AuthorsAndAffiliations';
-import { HubsSelector, Hub } from '../components/HubsSelector';
+import { HubsSelector } from '../components/HubsSelector';
 import { DeclarationCheckbox } from '../components/DeclarationCheckbox';
 import {
   ArrowLeft,
@@ -30,6 +30,7 @@ import { Switch } from '@/components/ui/Switch';
 import { AvatarStack } from '@/components/ui/AvatarStack';
 import { useScreenSize } from '@/hooks/useScreenSize';
 import { Callout } from '@/components/ui/Callout';
+import { IHub } from '@/types/hub';
 
 // Define the steps of our flow
 const steps: SimpleStep[] = [
@@ -52,7 +53,7 @@ export default function UploadPDFPage() {
   const [abstract, setAbstract] = useState('');
   const [selectedFile, setSelectedFile] = useState<File | null>(null);
   const [authors, setAuthors] = useState<SelectedAuthor[]>([]);
-  const [selectedHubs, setSelectedHubs] = useState<Hub[]>([]);
+  const [selectedHubs, setSelectedHubs] = useState<IHub[]>([]);
   const [changeDescription, setChangeDescription] = useState('Initial submission');
   const [fileUploadResult, setFileUploadResult] = useState<UploadFileResult | null>(null);
 
@@ -151,7 +152,7 @@ export default function UploadPDFPage() {
     }
   };
 
-  const handleHubsChange = (newHubs: Hub[]) => {
+  const handleHubsChange = (newHubs: IHub[]) => {
     setSelectedHubs(newHubs);
     if (errors.hubs) {
       setErrors({ ...errors, hubs: null });

--- a/components/Comment/lib/ReviewExtension.tsx
+++ b/components/Comment/lib/ReviewExtension.tsx
@@ -1,7 +1,7 @@
 import { Node, Extension, mergeAttributes } from '@tiptap/core';
 import { ReactNodeViewRenderer, NodeViewWrapper } from '@tiptap/react';
 import React from 'react';
-import { Star } from 'lucide-react';
+import { Ban, Star } from 'lucide-react';
 import { useState } from 'react';
 
 // Common ReviewStars component used by both overall and section ratings
@@ -10,12 +10,14 @@ export const ReviewStars = ({
   onRatingChange,
   isRequired = false,
   isReadOnly = false,
+  isClearable = false,
   label = 'Overall rating:',
 }: {
   rating: number;
   onRatingChange: (rating: number) => void;
   isRequired?: boolean;
   isReadOnly?: boolean;
+  isClearable?: boolean;
   label?: string;
 }) => {
   const [hoverRating, setHoverRating] = useState(0);
@@ -41,6 +43,17 @@ export const ReviewStars = ({
             <Star className="h-5 w-5 fill-current" />
           </button>
         ))}
+        {isClearable && (
+          <button
+            type="button"
+            onClick={() => onRatingChange(0)}
+            className={`pl-2 cursor-pointer hover:text-red-500 transition-colors ${
+              rating ? 'text-red-200' : 'text-gray-300'
+            }`}
+          >
+            <Ban className="h-5 w-5" />
+          </button>
+        )}
       </div>
     </div>
   );

--- a/components/Earn/BountyHubSelector.tsx
+++ b/components/Earn/BountyHubSelector.tsx
@@ -11,17 +11,11 @@ import { X, ChevronDown, Filter } from 'lucide-react';
 import { BaseMenu } from '@/components/ui/form/BaseMenu';
 import { BountyService } from '@/services/bounty.service';
 import { Topic } from '@/types/topic';
-
-export interface Hub {
-  id: string | number;
-  name: string;
-  description?: string;
-  color?: string;
-}
+import { IHub } from '@/types/hub';
 
 interface BountyHubSelectorProps {
-  selectedHubs: Hub[];
-  onChange: (hubs: Hub[]) => void;
+  selectedHubs: IHub[];
+  onChange: (hubs: IHub[]) => void;
   error?: string | null;
   displayCountOnly?: boolean;
   hideSelectedItems?: boolean;
@@ -70,17 +64,17 @@ export function BountyHubSelector({
   }, []);
 
   // utility conversions
-  const hubsToOptions = (hubs: Hub[]): MultiSelectOption[] =>
+  const hubsToOptions = (hubs: IHub[]): MultiSelectOption[] =>
     hubs.map((hub) => ({ value: String(hub.id), label: hub.name }));
 
-  const topicsToHubs = (topics: Topic[]): Hub[] =>
+  const topicsToHubs = (topics: Topic[]): IHub[] =>
     topics.map((topic) => ({
       id: topic.id,
       name: topic.name,
       description: topic.description,
     }));
 
-  const optionsToHubs = (options: MultiSelectOption[]): Hub[] =>
+  const optionsToHubs = (options: MultiSelectOption[]): IHub[] =>
     options.map(
       (opt) =>
         selectedHubs.find((h) => String(h.id) === opt.value) || {

--- a/components/Feed/items/FeedItemFundraise.tsx
+++ b/components/Feed/items/FeedItemFundraise.tsx
@@ -17,6 +17,7 @@ import { TopicAndJournalBadge } from '@/components/ui/TopicAndJournalBadge';
 import { TaxDeductibleBadge } from '@/components/ui/TaxDeductibleBadge';
 import { FundraiseProgress } from '@/components/Fund/FundraiseProgress';
 import { Users, Building, Pin } from 'lucide-react';
+import TopicAndJournalBadges from '@/components/ui/TopicAndJournalBadges';
 
 interface FeedItemFundraiseProps {
   entry: FeedEntry;
@@ -84,6 +85,7 @@ export const FeedItemFundraise: FC<FeedItemFundraiseProps> = ({
   // Image URL
   const imageUrl = post.previewImage ?? undefined;
 
+  // debugger;
   return (
     <BaseFeedItem
       entry={entry}
@@ -117,15 +119,7 @@ export const FeedItemFundraise: FC<FeedItemFundraiseProps> = ({
           <>
             <ContentTypeBadge type="funding" />
             {isNonprofit && <TaxDeductibleBadge variant={badgeVariant} />}
-            {topics.map((topic) => (
-              <TopicAndJournalBadge
-                key={topic.id || topic.slug}
-                type="topic"
-                name={topic.name}
-                slug={topic.slug}
-                imageUrl={topic.imageUrl}
-              />
-            ))}
+            <TopicAndJournalBadges topics={topics} />
           </>
         }
       />

--- a/components/Fund/FundingSelector.tsx
+++ b/components/Fund/FundingSelector.tsx
@@ -12,17 +12,11 @@ import { Topic } from '@/types/topic';
 import { Field, Input, Label, Switch } from '@headlessui/react';
 import { ReviewStars } from '../Comment/lib/ReviewExtension';
 import { HubService } from '@/services/hub.service';
-
-export interface Hub {
-  id: string | number;
-  name: string;
-  description?: string;
-  color?: string;
-}
+import { IHub } from '@/types/hub';
 
 interface FundingSelectorProps {
-  selectedHubs: Hub[];
-  onHubsChange: (hubs: Hub[]) => void;
+  selectedHubs: IHub[];
+  onHubsChange: (hubs: IHub[]) => void;
   selectedVotes: number;
   onVotesChange: (votes: number) => void;
   selectedScore: number;
@@ -65,17 +59,17 @@ export function FundingSelector({
   }, []);
 
   // utility conversions
-  const hubsToOptions = (hubs: Hub[]): MultiSelectOption[] =>
+  const hubsToOptions = (hubs: IHub[]): MultiSelectOption[] =>
     hubs.map((hub) => ({ value: String(hub.id), label: hub.name }));
 
-  const topicsToHubs = (topics: Topic[]): Hub[] =>
+  const topicsToHubs = (topics: Topic[]): IHub[] =>
     topics.map((topic) => ({
       id: topic.id,
       name: topic.name,
       description: topic.description,
     }));
 
-  const optionsToHubs = (options: MultiSelectOption[]): Hub[] =>
+  const optionsToHubs = (options: MultiSelectOption[]): IHub[] =>
     options.map(
       (opt) =>
         selectedHubs.find((h) => String(h.id) === opt.value) || {

--- a/components/Fund/FundingSelector.tsx
+++ b/components/Fund/FundingSelector.tsx
@@ -177,14 +177,15 @@ export function FundingSelector({
             className="w-full border-0 SearchableMultiSelect-input"
           />
         </div>
-        <Field className="pt-2 pb-2 border-b border-gray-200 flex items-center justify-between">
-          <Label>Minimum Upvotes</Label>
-          <Input
-            type="number"
+        <Field className="pt-2 pb-2 border-b border-gray-200">
+          <Label>Minimum Upvotes: {selectedVotes}</Label>
+          <input
+            type="range"
             min="0"
+            max="100"
             value={selectedVotes}
             onChange={(e) => onVotesChange(Number(e.target.value))}
-            className="w-24 bg-transparent border-none p-1 text-sm outline-none"
+            className="w-full h-2"
           />
         </Field>
         <Field className="pt-2 pb-2 border-b border-gray-200 flex items-center justify-between">

--- a/components/Fund/FundingSelector.tsx
+++ b/components/Fund/FundingSelector.tsx
@@ -1,0 +1,246 @@
+'use client';
+
+import { useEffect, useState, useCallback, useRef } from 'react';
+import {
+  MultiSelectOption,
+  SearchableMultiSelect,
+} from '@/components/ui/form/SearchableMultiSelect';
+import { Badge } from '@/components/ui/Badge';
+import { ChevronDown, Filter } from 'lucide-react';
+import { BaseMenu } from '@/components/ui/form/BaseMenu';
+import { Topic } from '@/types/topic';
+import { Field, Input, Label, Switch } from '@headlessui/react';
+import { ReviewStars } from '../Comment/lib/ReviewExtension';
+import { HubService } from '@/services/hub.service';
+
+export interface Hub {
+  id: string | number;
+  name: string;
+  description?: string;
+  color?: string;
+}
+
+interface FundingSelectorProps {
+  selectedHubs: Hub[];
+  onHubsChange: (hubs: Hub[]) => void;
+  selectedVotes: number;
+  onVotesChange: (votes: number) => void;
+  selectedScore: number;
+  onScoreChange: (score: number) => void;
+  selectedVerifiedAuthorsOnly: boolean;
+  onVerifiedAuthorsOnlyChange: (verifiedOnly: boolean) => void;
+  selectedTaxDeductible: boolean;
+  onTaxDeductibleChange: (taxDeductible: boolean) => void;
+  selectedPreviouslyFunded: boolean;
+  onPreviouslyFundedChange: (previouslyFunded: boolean) => void;
+  error?: string | null;
+  hideSelectedItems?: boolean;
+}
+
+export function FundingSelector({
+  selectedHubs,
+  onHubsChange,
+  selectedVotes,
+  onVotesChange,
+  selectedScore,
+  onScoreChange,
+  selectedVerifiedAuthorsOnly,
+  onVerifiedAuthorsOnlyChange,
+  selectedTaxDeductible,
+  onTaxDeductibleChange,
+  selectedPreviouslyFunded,
+  onPreviouslyFundedChange,
+  error,
+  hideSelectedItems = false,
+}: FundingSelectorProps) {
+  const [allHubs, setAllHubs] = useState<Topic[]>([]);
+  const menuContentRef = useRef<HTMLDivElement>(null);
+
+  // fetch all hubs at mount
+  useEffect(() => {
+    (async () => {
+      const hubs = await HubService.getHubs({ excludeJournals: false });
+      setAllHubs(hubs);
+    })();
+  }, []);
+
+  // utility conversions
+  const hubsToOptions = (hubs: Hub[]): MultiSelectOption[] =>
+    hubs.map((hub) => ({ value: String(hub.id), label: hub.name }));
+
+  const topicsToHubs = (topics: Topic[]): Hub[] =>
+    topics.map((topic) => ({
+      id: topic.id,
+      name: topic.name,
+      description: topic.description,
+    }));
+
+  const optionsToHubs = (options: MultiSelectOption[]): Hub[] =>
+    options.map(
+      (opt) =>
+        selectedHubs.find((h) => String(h.id) === opt.value) || {
+          id: opt.value,
+          name: opt.label,
+        }
+    );
+
+  const allHubOptions = hubsToOptions(topicsToHubs(allHubs));
+
+  // Local search within allHubs
+  const filterHubs = useCallback(
+    async (query: string): Promise<MultiSelectOption[]> => {
+      if (!query) {
+        return hubsToOptions(topicsToHubs(allHubs));
+      }
+      const lowered = query.toLowerCase();
+      const filtered = allHubs.filter((hub) => hub.name.toLowerCase().includes(lowered));
+      return hubsToOptions(topicsToHubs(filtered));
+    },
+    [allHubs, selectedHubs]
+  );
+
+  const fetchHubs = useCallback(
+    async (query: string): Promise<MultiSelectOption[]> => {
+      try {
+        const topics = await HubService.suggestTopics(query);
+        const hubs = topicsToHubs(topics);
+        return hubsToOptions(hubs);
+      } catch (error) {
+        console.error('Error fetching topics:', error);
+        return [];
+      }
+    },
+    [selectedHubs]
+  );
+
+  const handleChange = (options: MultiSelectOption[]) => {
+    onHubsChange(optionsToHubs(options));
+  };
+
+  const CustomSelectedItems = () => (
+    <div className="flex flex-wrap gap-2 mt-2">
+      {selectedHubs.map((hub) => (
+        <Badge
+          key={hub.id}
+          variant="default"
+          className="flex items-center gap-1 px-3 py-1 rounded-sm text-sm cursor-pointer hover:bg-gray-200"
+          onClick={(e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            onHubsChange(selectedHubs.filter((h) => h.id !== hub.id));
+          }}
+        >
+          {hub.color && (
+            <div className="h-2 w-2 rounded-sm mr-1" style={{ backgroundColor: hub.color }} />
+          )}
+          <span>{hub.name}</span>
+        </Badge>
+      ))}
+    </div>
+  );
+
+  const filtersUsed =
+    selectedHubs.length +
+    (selectedVotes > 0 ? 1 : 0) +
+    (selectedScore > 0 ? 1 : 0) +
+    (selectedVerifiedAuthorsOnly ? 1 : 0) +
+    (selectedTaxDeductible ? 1 : 0) +
+    (selectedPreviouslyFunded ? 1 : 0);
+  const trigger = (
+    <button
+      className="flex items-center gap-2 border border-gray-200 bg-gray-50 hover:bg-gray-100 rounded-lg px-3 py-1.5 text-sm w-full"
+      type="button"
+    >
+      <Filter className="h-4 w-4 text-gray-500" />
+      <span className="text-gray-700">Filters</span>
+      {filtersUsed > 0 && (
+        <span className="text-xs font-semibold text-indigo-700 bg-indigo-100 rounded-full px-1.5">
+          {filtersUsed}
+        </span>
+      )}
+      <ChevronDown className="h-4 w-4 text-gray-500 ml-auto" />
+    </button>
+  );
+
+  return (
+    <BaseMenu
+      trigger={trigger}
+      align="start"
+      sideOffset={5}
+      className="overflow-visible border-none p-0 shadow-lg !w-[300px] max-w-[90vw]"
+      // open={menuOpen}
+      // onOpenChange={setMenuOpen}
+    >
+      <div className="p-2 w-full" ref={menuContentRef}>
+        <div className="pb-2 border-b border-gray-200">
+          <p>Topics</p>
+          <SearchableMultiSelect
+            value={hubsToOptions(selectedHubs)}
+            onChange={handleChange}
+            onAsyncSearch={filterHubs}
+            options={allHubOptions}
+            placeholder="Search for topics..."
+            minSearchLength={0}
+            error={error || undefined}
+            className="w-full border-0 SearchableMultiSelect-input"
+          />
+        </div>
+        <Field className="pt-2 pb-2 border-b border-gray-200 flex items-center justify-between">
+          <Label>Minimum Upvotes</Label>
+          <Input
+            type="number"
+            min="0"
+            value={selectedVotes}
+            onChange={(e) => onVotesChange(Number(e.target.value))}
+            className="w-24 bg-transparent border-none p-1 text-sm outline-none"
+          />
+        </Field>
+        <Field className="pt-2 pb-2 border-b border-gray-200 flex items-center justify-between">
+          <Label>Minimum Score</Label>
+          <ReviewStars
+            rating={selectedScore}
+            onRatingChange={onScoreChange}
+            isClearable={true}
+            label=""
+          />
+        </Field>
+        <Field className="pt-2 pb-2 border-b border-gray-200 flex items-center justify-between">
+          <Label>Verified Authors Only</Label>
+          <Switch
+            checked={selectedVerifiedAuthorsOnly}
+            onChange={onVerifiedAuthorsOnlyChange}
+            className={`group inline-flex h-6 w-11 items-center rounded-full transition ${selectedVerifiedAuthorsOnly ? 'bg-blue-600' : 'bg-gray-200'}`}
+          >
+            <span
+              className={`size-4 translate-x-1 rounded-full bg-white transition ${selectedVerifiedAuthorsOnly ? 'translate-x-6' : ''}`}
+            />
+          </Switch>
+        </Field>
+        <Field className="pt-2 pb-2 border-b border-gray-200 flex items-center justify-between">
+          <Label>Tax-Deductible</Label>
+          <Switch
+            checked={selectedTaxDeductible}
+            onChange={onTaxDeductibleChange}
+            className={`group inline-flex h-6 w-11 items-center rounded-full transition ${selectedTaxDeductible ? 'bg-blue-600' : 'bg-gray-200'}`}
+          >
+            <span
+              className={`size-4 translate-x-1 rounded-full bg-white transition ${selectedTaxDeductible ? 'translate-x-6' : ''}`}
+            />
+          </Switch>
+        </Field>
+        <Field className="pt-2 flex items-center justify-between">
+          <Label>Previously Funded</Label>
+          <Switch
+            checked={selectedPreviouslyFunded}
+            onChange={onPreviouslyFundedChange}
+            className={`group inline-flex h-6 w-11 items-center rounded-full transition ${selectedPreviouslyFunded ? 'bg-blue-600' : 'bg-gray-200'}`}
+          >
+            <span
+              className={`size-4 translate-x-1 rounded-full bg-white transition ${selectedPreviouslyFunded ? 'translate-x-6' : ''}`}
+            />
+          </Switch>
+        </Field>
+      </div>
+    </BaseMenu>
+  );
+}

--- a/components/Fund/FundingSelector.tsx
+++ b/components/Fund/FundingSelector.tsx
@@ -100,7 +100,7 @@ export function FundingSelector({
         const hubs = topicsToHubs(topics);
         return hubsToOptions(hubs);
       } catch (error) {
-        console.error('Error fetching topics:', error);
+        console.error('Error searching topics:', error);
         return [];
       }
     },
@@ -161,9 +161,7 @@ export function FundingSelector({
       trigger={trigger}
       align="start"
       sideOffset={5}
-      className="overflow-visible border-none p-0 shadow-lg !w-[300px] max-w-[90vw]"
-      // open={menuOpen}
-      // onOpenChange={setMenuOpen}
+      className="z-50 overflow-hidden rounded-lg border border-gray-200 bg-white p-1 shadow-md min-w-[8rem] w-[var(--trigger-width)] !w-[300px] max-w-[90vw]"
     >
       <div className="p-2 w-full" ref={menuContentRef}>
         <div className="pb-2 border-b border-gray-200">

--- a/components/Fund/MarketplaceTabs.tsx
+++ b/components/Fund/MarketplaceTabs.tsx
@@ -4,7 +4,7 @@ import { FC } from 'react';
 import { Tabs } from '@/components/ui/Tabs';
 import { useRouter } from 'next/navigation';
 
-export type MarketplaceTab = 'grants' | 'needs-funding' | 'previously-funded';
+export type MarketplaceTab = 'grants' | 'needs-funding';
 
 interface MarketplaceTabsProps {
   activeTab: MarketplaceTab;
@@ -28,10 +28,6 @@ export const MarketplaceTabs: FC<MarketplaceTabsProps> = ({
       id: 'needs-funding',
       label: 'Proposals',
     },
-    {
-      id: 'previously-funded',
-      label: 'Previously Funded',
-    },
   ];
 
   const handleTabChange = (tabId: string) => {
@@ -44,8 +40,6 @@ export const MarketplaceTabs: FC<MarketplaceTabsProps> = ({
       router.push('/fund/grants');
     } else if (tab === 'needs-funding') {
       router.push('/fund/needs-funding');
-    } else if (tab === 'previously-funded') {
-      router.push('/fund/previously-funded');
     }
 
     onTabChange(tab);

--- a/components/modals/QuestionEditModal.tsx
+++ b/components/modals/QuestionEditModal.tsx
@@ -7,11 +7,12 @@ import { Input } from '@/components/ui/form/Input';
 import { CommentEditor } from '@/components/Comment/CommentEditor';
 import { CommentContent } from '@/components/Comment/lib/types';
 import { SessionProvider, useSession } from 'next-auth/react';
-import { HubsSelector, Hub } from '@/app/paper/create/components/HubsSelector';
+import { HubsSelector } from '@/app/paper/create/components/HubsSelector';
 import { Work } from '@/types/work';
 import { PostService } from '@/services/post.service';
 import { toast } from 'react-hot-toast';
 import { useRouter } from 'next/navigation';
+import { IHub } from '@/types/hub';
 
 interface QuestionEditModalProps {
   isOpen: boolean;
@@ -27,7 +28,7 @@ export const QuestionEditModal = ({ isOpen, onClose, work }: QuestionEditModalPr
   const [title, setTitle] = useState(work.title);
   const [plainText, setPlainText] = useState<string>('');
   const [htmlContent, setHtmlContent] = useState<string>('');
-  const [selectedHubs, setSelectedHubs] = useState<Hub[]>([]);
+  const [selectedHubs, setSelectedHubs] = useState<IHub[]>([]);
 
   // Initialize hubs from work topics
   useEffect(() => {

--- a/components/ui/RightSidebarBanner.tsx
+++ b/components/ui/RightSidebarBanner.tsx
@@ -78,7 +78,7 @@ export const RightSidebarBanner: React.FC<RightSidebarBannerProps> = ({
           </li>
         ))}
       </ul>
-      <Button asChild className="w-full">
+      <Button className="w-full">
         <Link href={buttonLink}>{buttonText}</Link>
       </Button>
     </div>

--- a/components/ui/TopicAndJournalBadges.tsx
+++ b/components/ui/TopicAndJournalBadges.tsx
@@ -36,13 +36,15 @@ export default function TopicAndJournalBadges({ topics }: TopicAndJournalBadgesP
         imageUrl={firstTopic.imageUrl}
       />
       <Popover className="relative">
-        <PopoverButton className="relative rounded-full overflow-hidden flex items-center justify-center flex-shrink-0 h-8 w-8 focus:outline-none focus-visible:outline-none cursor-pointer text-primary-700 border border-primary-200 bg-primary-50 hover:bg-primary-100">
-          <Plus className="h-4 w-4" />
+        <PopoverButton className="relative rounded-full overflow-hidden flex items-center justify-center flex-shrink-0 border border-primary-200 bg-primary-50 hover:bg-primary-100 h-6 w-6 focus:outline-none focus-visible:outline-none cursor-pointer">
+          <span className="absolute inset-0 flex items-center justify-center font-medium text-indigo-700 text-sm">
+            <Plus className="h-4 w-4" />
+          </span>
         </PopoverButton>
         <PopoverPanel
           transition
           anchor="bottom"
-          className="z-10 flex flex-wrap gap-2 w-2/5 max-w-100 max-h-20 rounded-md bg-white p-2 mt-1 shadow-lg border border-gray-200"
+          className="z-50 flex flex-wrap gap-2 p-2 mt-1 rounded-lg bg-white border-none shadow-lg overflow-visible min-w-[8rem] !w-[300px] max-w-[60vw]"
         >
           {additionalTopics.map((topic) => (
             <TopicAndJournalBadge

--- a/components/ui/TopicAndJournalBadges.tsx
+++ b/components/ui/TopicAndJournalBadges.tsx
@@ -1,0 +1,60 @@
+import { Popover, PopoverButton, PopoverPanel } from '@headlessui/react';
+import { TopicAndJournalBadge } from './TopicAndJournalBadge';
+import { Topic } from '@/types/topic';
+import { Plus } from 'lucide-react';
+
+export interface TopicAndJournalBadgesProps {
+  topics: Topic[];
+}
+
+export default function TopicAndJournalBadges({ topics }: TopicAndJournalBadgesProps) {
+  if (!topics || topics.length === 0) {
+    return null; // No topics to display
+  }
+  const firstTopic = topics[0];
+  if (topics.length === 1) {
+    return (
+      <TopicAndJournalBadge
+        key={firstTopic.id || firstTopic.slug}
+        type="topic"
+        name={firstTopic.name}
+        slug={firstTopic.slug}
+        imageUrl={firstTopic.imageUrl}
+      />
+    );
+  }
+
+  const additionalTopics = topics.slice(1);
+
+  return (
+    <>
+      <TopicAndJournalBadge
+        key={firstTopic.id || firstTopic.slug}
+        type="topic"
+        name={firstTopic.name}
+        slug={firstTopic.slug}
+        imageUrl={firstTopic.imageUrl}
+      />
+      <Popover className="relative">
+        <PopoverButton className="relative rounded-full overflow-hidden flex items-center justify-center flex-shrink-0 h-8 w-8 focus:outline-none focus-visible:outline-none cursor-pointer text-primary-700 border border-primary-200 bg-primary-50 hover:bg-primary-100">
+          <Plus className="h-4 w-4" />
+        </PopoverButton>
+        <PopoverPanel
+          transition
+          anchor="bottom"
+          className="z-10 flex flex-wrap gap-2 w-2/5 max-w-100 max-h-20 rounded-md bg-white p-2 mt-1 shadow-lg border border-gray-200"
+        >
+          {additionalTopics.map((topic) => (
+            <TopicAndJournalBadge
+              key={topic.id || topic.slug}
+              type="topic"
+              name={topic.name}
+              slug={topic.slug}
+              imageUrl={topic.imageUrl}
+            />
+          ))}
+        </PopoverPanel>
+      </Popover>
+    </>
+  );
+}

--- a/hooks/useFeed.ts
+++ b/hooks/useFeed.ts
@@ -15,6 +15,7 @@ interface UseFeedOptions {
   fundraiseStatus?: 'OPEN' | 'CLOSED';
   createdBy?: number;
   ordering?: string;
+  filtering?: string;
   initialData?: {
     entries: FeedEntry[];
     hasMore: boolean;
@@ -66,7 +67,8 @@ export const useFeed = (activeTab: FeedTab | FundingTab, options: UseFeedOptions
       options.endpoint !== currentOptions.endpoint ||
       options.fundraiseStatus !== currentOptions.fundraiseStatus ||
       options.createdBy !== currentOptions.createdBy ||
-      options.ordering !== currentOptions.ordering;
+      options.ordering !== currentOptions.ordering ||
+      options.filtering !== currentOptions.filtering;
 
     if (relevantOptionsChanged) {
       setCurrentOptions(options);
@@ -88,6 +90,7 @@ export const useFeed = (activeTab: FeedTab | FundingTab, options: UseFeedOptions
         fundraiseStatus: options.fundraiseStatus,
         createdBy: options.createdBy,
         ordering: options.ordering,
+        filtering: options.filtering,
       });
       setEntries(result.entries);
       setHasMore(result.hasMore);
@@ -116,6 +119,7 @@ export const useFeed = (activeTab: FeedTab | FundingTab, options: UseFeedOptions
         fundraiseStatus: options.fundraiseStatus,
         createdBy: options.createdBy,
         ordering: options.ordering,
+        filtering: options.filtering,
       });
       setEntries((prev) => [...prev, ...result.entries]);
       setHasMore(result.hasMore);

--- a/next.config.js
+++ b/next.config.js
@@ -12,6 +12,11 @@ const nextConfig = {
       destination: '/journal',
       permanent: true,
     },
+    {
+      source: '/fund/previously-funded',
+      destination: '/fund/needs-funding',
+      permanent: true,
+    },
   ],
   headers: async () => [
     {

--- a/services/feed.service.ts
+++ b/services/feed.service.ts
@@ -22,6 +22,7 @@ export class FeedService {
     grantId?: number;
     createdBy?: number;
     ordering?: string;
+    filtering?: string;
   }): Promise<{ entries: FeedEntry[]; hasMore: boolean }> {
     const queryParams = new URLSearchParams();
     if (params?.page) queryParams.append('page', params.page.toString());
@@ -34,6 +35,7 @@ export class FeedService {
     if (params?.grantId) queryParams.append('grant_id', params.grantId.toString());
     if (params?.createdBy) queryParams.append('created_by', params.createdBy.toString());
     if (params?.ordering) queryParams.append('ordering', params.ordering);
+    if (params?.filtering) queryParams.append('filtering', params.filtering);
 
     // Determine which endpoint to use
     const basePath =

--- a/types/contribution.ts
+++ b/types/contribution.ts
@@ -6,13 +6,7 @@ import { transformBounty } from './bounty';
 import { Work } from './work';
 import { ContributionType } from '@/services/contribution.service';
 import { stripHtml } from '@/utils/stringUtils';
-
-export interface Hub {
-  id: ID;
-  name: string;
-  hub_image: string;
-  slug: string;
-}
+import { IHub } from './hub';
 
 export interface AuthorProfile {
   id: ID;
@@ -46,7 +40,7 @@ export interface Contribution {
   content_type: ContentType;
   created_by: User;
   created_date: string;
-  hubs: Hub[];
+  hubs: IHub[];
   item: ContributionItem;
 }
 
@@ -90,7 +84,7 @@ const getContentType = (contentType: string): FeedContentType => {
   }
 };
 
-const transformUnifiedDocumentToWork = ({ raw, hubs }: { raw: any; hubs: Hub[] }): Work => {
+const transformUnifiedDocumentToWork = ({ raw, hubs }: { raw: any; hubs: IHub[] }): Work => {
   const contentType =
     raw.unified_document?.document_type === 'PAPER'
       ? 'paper'
@@ -124,7 +118,7 @@ export const transformContributionToFeedEntry = ({
 }): FeedEntry => {
   const { content_type, created_by, created_date, hubs, item } = contribution;
 
-  const effectiveHubs: Hub[] = (hubs?.length ? hubs : item?.hubs?.length ? item.hubs : []).slice(
+  const effectiveHubs: IHub[] = (hubs?.length ? hubs : item?.hubs?.length ? item.hubs : []).slice(
     0,
     2
   );

--- a/types/feed.ts
+++ b/types/feed.ts
@@ -11,6 +11,7 @@ import { UserVoteType } from './reaction';
 import { User } from './user';
 import { stripHtml } from '@/utils/stringUtils';
 import { Tip } from './tip';
+import { Hub } from './hub';
 
 export type FeedActionType = 'contribute' | 'open' | 'publish' | 'post';
 
@@ -658,17 +659,23 @@ export const transformFeedEntry = (feedEntry: RawApiFeedEntry): FeedEntry => {
                 ? content_object.authors.map(transformAuthorProfile)
                 : [transformAuthorProfile(author)],
             institution: content_object.institution, // Populate institution
-            topics: content_object.hub
-              ? [
-                  content_object.hub.id
-                    ? transformTopic(content_object.hub)
-                    : {
-                        id: 0,
-                        name: content_object.hub.name || '',
-                        slug: content_object.hub.slug || '',
-                      },
-                ]
-              : [],
+            topics: content_object.hubs
+              ? (content_object.hubs as Array<Hub>).map((hub, idx) => ({
+                  id: hub.id || idx,
+                  name: hub.name || '',
+                  slug: hub.slug || '',
+                }))
+              : content_object.hub
+                ? [
+                    content_object.hub.id
+                      ? transformTopic(content_object.hub)
+                      : {
+                          id: 0,
+                          name: content_object.hub.name || '',
+                          slug: content_object.hub.slug || '',
+                        },
+                  ]
+                : [],
             createdBy: transformAuthorProfile(author),
             bounties: content_object.bounties
               ? content_object.bounties.map((bounty: any) =>

--- a/types/hub.ts
+++ b/types/hub.ts
@@ -6,3 +6,10 @@ export type Hub = {
   imageUrl?: string;
   description?: string;
 };
+
+export interface IHub {
+  id: string | number;
+  name: string;
+  description?: string;
+  color?: string;
+}


### PR DESCRIPTION
Addresses the front end requirements for [issue 405](https://github.com/ResearchHub/issues/issues/405).

https://www.researchhub.com/fund/needs-funding and https://www.researchhub.com/fund/previously-funded both rely in the same API endpoint with one changed URL parameter (`fundraise_status=OPEN` and `fundraise_status=CLOSED`, respectively).

We are now offering more filtering and sorting functionality and combining these tabs into one under `/fund/needs-funding`.

Video showing changes (there are no previously funded proposals in my data set)

[Screencast from 2025-09-16 09-25-57.webm](https://github.com/user-attachments/assets/3a39adff-66ce-4f61-bf8c-fc9483054f9b)


Filters and Sort drop downs
<img width="814" height="590" alt="image" src="https://github.com/user-attachments/assets/f928f5ed-0ab1-497b-843d-767198deda40" />

Filters expanded
<img width="814" height="1470" alt="Screenshot from 2025-09-16 09-14-21" src="https://github.com/user-attachments/assets/1c36ba81-719a-4872-85fb-31e68a50e8a2" />

Sort expanded
<img width="814" height="1470" alt="Screenshot from 2025-09-16 09-14-50" src="https://github.com/user-attachments/assets/37021141-3ab8-4349-a5a9-a589185eb66c" />

