### PR TITLE
fix: Use the correct environment-specific CORS proxy URL

### DIFF
--- a/services/proxy.service.ts
+++ b/services/proxy.service.ts
@@ -1,8 +1,5 @@
 const getBaseUrl = (): string => {
-  if (process.env.REACT_APP_ENV === 'staging') {
-    return 'https://proxy.staging.researchhub.com';
-  }
-  if (process.env.NODE_ENV === 'production') {
+  if (process.env.VERCEL_ENV === 'production') {
     return 'https://proxy.prod.researchhub.com';
   }
   return 'https://proxy.staging.researchhub.com';


### PR DESCRIPTION
Currently the staging environment uses production's CORS proxy URL.