### PR TITLE
Remove prefilled fields for the Persona verification

### DIFF
--- a/components/modals/Verification/VerificationWithPersonaStep.tsx
+++ b/components/modals/Verification/VerificationWithPersonaStep.tsx
@@ -82,10 +82,6 @@ export function VerificationWithPersonaStep({
           environmentId={process.env.NEXT_PUBLIC_PERSONA_ENVIRONMENT_ID}
           templateId={process.env.NEXT_PUBLIC_PERSONA_TEMPLATE_ID}
           referenceId={`${user.id}`}
-          fields={{
-            nameFirst: user.firstName || '',
-            nameLast: user.lastName || '',
-          }}
           onReady={() => {
             setIsPersonaLoaded(true);
           }}


### PR DESCRIPTION
The name fields are optional and not required for the purpose of verifying identities.

See: https://docs.withpersona.com/inquiry-fields#prefilling-inquiry-fields