### PR TITLE
Fix closing date inconsistency

### DIFF
--- a/components/Feed/items/FeedItemGrant.tsx
+++ b/components/Feed/items/FeedItemGrant.tsx
@@ -22,7 +22,6 @@ import { useRouter } from 'next/navigation';
 import Icon from '@/components/ui/icons/Icon';
 import { formatDeadline, isDeadlineInFuture } from '@/utils/date';
 import { isExpiringSoon } from '@/components/Bounty/lib/bountyUtil';
-import dayjs from 'dayjs';
 
 // Grant-specific content type that extends the feed entry structure
 export interface FeedGrantContent {

--- a/components/work/GrantDocument.tsx
+++ b/components/work/GrantDocument.tsx
@@ -9,7 +9,6 @@ import { WorkTabs, TabType } from './WorkTabs';
 import { CommentFeed } from '@/components/Comment/CommentFeed';
 import { GrantApplications } from './GrantApplications';
 import { format } from 'date-fns';
-import dayjs from 'dayjs';
 import { PostBlockEditor } from './PostBlockEditor';
 import { formatDeadline, isDeadlineInFuture } from '@/utils/date';
 import { isExpiringSoon } from '@/components/Bounty/lib/bountyUtil';

--- a/components/work/components/GrantStatusSection.tsx
+++ b/components/work/components/GrantStatusSection.tsx
@@ -3,7 +3,6 @@
 import { Work } from '@/types/work';
 import { format } from 'date-fns';
 import { Clock } from 'lucide-react';
-import dayjs from 'dayjs';
 import { isDeadlineInFuture } from '@/utils/date';
 
 interface GrantStatusSectionProps {


### PR DESCRIPTION
Paper page using a different closing date calculation compared to the feed card.

**Before** - The status on the feed card is closed, and the date/time within the paper page has elapsed but its still showing "Accepting Applications"

<img width="803" height="377" alt="image" src="https://github.com/user-attachments/assets/436157dd-4cdf-40cc-a25b-8eb8e98f0dd1" />
<img width="803" height="377" alt="image" src="https://github.com/user-attachments/assets/2f233b38-a285-4eb7-a67c-d1435e8bcd93" />

**After** - The status on the feed card and paper page use the same calculation, so they all close at the same time
<img width="823" height="284" alt="image" src="https://github.com/user-attachments/assets/d60ef9fc-1f14-407c-850b-0faec65225af" />
<img width="823" height="322" alt="image" src="https://github.com/user-attachments/assets/bdd40f1c-eeea-478d-8f7a-00e38cc1de62" />
