### PR TITLE
Add internal PDF URL field to documents

### DIFF
--- a/components/work/WorkDocument.tsx
+++ b/components/work/WorkDocument.tsx
@@ -121,38 +121,44 @@ export const WorkDocument = ({ work, metadata, defaultTab = 'paper' }: WorkDocum
             )}
 
             {/* PDF Viewer */}
-            {work.formats.find((format) => format.type === 'PDF')?.url && !pdfUnavailable && (
-              <div className="bg-white rounded-lg shadow-sm border mb-6 relative">
-                {work.pdfCopyrightAllowsDisplay ? (
-                  <DocumentViewer
-                    url={work.formats.find((format) => format.type === 'PDF')?.url || ''}
-                    className="min-h-[800px]"
-                    onPdfUnavailable={() => setPdfUnavailable(true)}
-                  />
-                ) : (
-                  <div className="p-8 text-center">
-                    <FlaskConicalOff className="h-10 w-10 text-primary-400 mx-auto mb-4" />
-                    <h3 className="text-lg font-medium mb-2">Content is restricted</h3>
-                    <p className="text-gray-600 mb-4">
-                      This paper's license is marked as closed access or non-commercial and cannot
-                      be viewed on ResearchHub.
-                    </p>
-                    <Button
-                      variant="secondary"
-                      onClick={() =>
-                        window.open(
-                          work.doi ? `https://doi.org/${work.doi}` : '#',
-                          '_blank',
-                          'noopener,noreferrer'
-                        )
-                      }
-                    >
-                      Visit External Site
-                    </Button>
+            {(() => {
+              const pdfFormat = work.formats.find((format) => format.type === 'PDF');
+              return (
+                pdfFormat?.url &&
+                !pdfUnavailable && (
+                  <div className="bg-white rounded-lg shadow-sm border mb-6 relative">
+                    {work.pdfCopyrightAllowsDisplay ? (
+                      <DocumentViewer
+                        url={pdfFormat.internalUrl || pdfFormat.url}
+                        className="min-h-[800px]"
+                        onPdfUnavailable={() => setPdfUnavailable(true)}
+                      />
+                    ) : (
+                      <div className="p-8 text-center">
+                        <FlaskConicalOff className="h-10 w-10 text-primary-400 mx-auto mb-4" />
+                        <h3 className="text-lg font-medium mb-2">Content is restricted</h3>
+                        <p className="text-gray-600 mb-4">
+                          This paper's license is marked as closed access or non-commercial and
+                          cannot be viewed on ResearchHub.
+                        </p>
+                        <Button
+                          variant="secondary"
+                          onClick={() =>
+                            window.open(
+                              work.doi ? `https://doi.org/${work.doi}` : '#',
+                              '_blank',
+                              'noopener,noreferrer'
+                            )
+                          }
+                        >
+                          Visit External Site
+                        </Button>
+                      </div>
+                    )}
                   </div>
-                )}
-              </div>
-            )}
+                )
+              );
+            })()}
           </>
         );
       case 'reviews':

--- a/types/work.ts
+++ b/types/work.ts
@@ -51,6 +51,10 @@ export type DocumentVersion = {
 export interface FormatType {
   type: string;
   url: string;
+  /**
+   * This is a proxied URL for internal use (e.g., to avoid CORS issues when rendering PDFs).
+   */
+  internalUrl?: string;
 }
 
 export interface Enrichment {
@@ -208,12 +212,23 @@ export const transformWork = createTransformer<any, Work>((raw) => {
           ]
         : [],
     formats: raw.pdf_url
-      ? [...(raw.formats || []), { type: 'PDF', url: ProxyService.generateProxyUrl(raw.pdf_url) }]
+      ? [
+          ...(raw.formats || []),
+          {
+            type: 'PDF',
+            url: raw.pdf_url,
+            internalUrl: ProxyService.generateProxyUrl(raw.pdf_url),
+          },
+        ]
       : raw.file
-        ? [...(raw.formats || []), { type: 'PDF', url: ProxyService.generateProxyUrl(raw.file) }]
+        ? [
+            ...(raw.formats || []),
+            { type: 'PDF', url: raw.file, internalUrl: ProxyService.generateProxyUrl(raw.file) },
+          ]
         : (raw.formats || []).map((format: FormatType) => ({
             ...format,
-            url: format.type === 'PDF' ? ProxyService.generateProxyUrl(format.url) : format.url,
+            internalUrl:
+              format.type === 'PDF' ? ProxyService.generateProxyUrl(format.url) : undefined,
           })),
     license: raw.pdf_license,
     pdfCopyrightAllowsDisplay: raw.pdf_copyright_allows_display,


### PR DESCRIPTION
- Add a new `internalUrl` field to store the proxied PDF URL.
- Use the existing `url` field for the original PDF URL (i.e., the direct preprint server URL).
- Use the `internalUrl` in the PDF viewer component to avoid CORS issues.
- Use the original URL for the download link.

**Note**: If PDF fetching fails, the abstract will be displayed (implemented in a previous PR), but the user will still be able to use the (un-proxied) PDF link.

<img width="1371" height="872" alt="image" src="https://github.com/user-attachments/assets/2f45eb4e-fb90-41ed-9d73-ff56a9576bf3" />
