### PR TITLE
Respect CurrencyToggle within ContributeToFundraiseModal

### DIFF
--- a/components/modals/BalanceInfo.tsx
+++ b/components/modals/BalanceInfo.tsx
@@ -1,6 +1,9 @@
 'use client';
 
 import { useUser } from '@/contexts/UserContext';
+import { useCurrencyPreference } from '@/contexts/CurrencyPreferenceContext';
+import { useExchangeRate } from '@/contexts/ExchangeRateContext';
+import { formatCurrency } from '@/utils/currency';
 
 interface BalanceInfoProps {
   amount: number;
@@ -14,19 +17,37 @@ export function BalanceInfo({
   includeLockedBalance = false,
 }: BalanceInfoProps) {
   const { user } = useUser();
+  const { showUSD } = useCurrencyPreference();
+  const { exchangeRate } = useExchangeRate();
   const userBalance = user?.balance || 0;
   const lockedBalance = user?.lockedBalance || 0;
   const totalAvailableBalance = includeLockedBalance ? userBalance + lockedBalance : userBalance;
+
+  const useUsd = showUSD && exchangeRate > 0;
+  const primary = formatCurrency({ amount: totalAvailableBalance, showUSD: useUsd, exchangeRate });
+  const secondary =
+    exchangeRate > 0
+      ? formatCurrency({ amount: totalAvailableBalance, showUSD: !useUsd, exchangeRate })
+      : undefined;
+
+  const deficit = amount - totalAvailableBalance;
+  const deficitFormatted =
+    deficit > 0 ? formatCurrency({ amount: deficit, showUSD: useUsd, exchangeRate }) : undefined;
 
   return (
     <div className="bg-gray-50 rounded-lg p-4 border border-gray-200">
       <div className="flex justify-between items-center">
         <span className="text-sm text-gray-600">Current RSC Balance:</span>
-        <span className="text-sm font-medium">{totalAvailableBalance.toLocaleString()} RSC</span>
+        <span className="text-sm font-medium">{useUsd ? `${primary} USD` : `${primary} RSC`}</span>
       </div>
-      {showWarning && (
+      {secondary && (
+        <div className="mt-1 text-xs text-gray-500 text-right">
+          ≈ {useUsd ? `${secondary} RSC` : `${secondary} USD`}
+        </div>
+      )}
+      {showWarning && deficitFormatted && (
         <div className="mt-1 text-sm text-orange-600">
-          {`You need ${(amount - totalAvailableBalance).toLocaleString()} RSC more for this contribution`}
+          {`You need ${useUsd ? `${deficitFormatted} USD` : `${deficitFormatted} RSC`} more for this contribution`}
         </div>
       )}
     </div>

--- a/components/modals/BalanceInfo.tsx
+++ b/components/modals/BalanceInfo.tsx
@@ -34,20 +34,26 @@ export function BalanceInfo({
   const deficitFormatted =
     deficit > 0 ? formatCurrency({ amount: deficit, showUSD: useUsd, exchangeRate }) : undefined;
 
+  const primaryUnit = useUsd ? 'USD' : 'RSC';
+  const primaryWithUnit = `${primary} ${primaryUnit}`;
+
+  const secondaryUnit = useUsd ? 'RSC' : 'USD';
+  const secondaryWithUnit = secondary ? `${secondary} ${secondaryUnit}` : undefined;
+
+  const deficitWithUnit = deficitFormatted ? `${deficitFormatted} ${primaryUnit}` : undefined;
+
   return (
     <div className="bg-gray-50 rounded-lg p-4 border border-gray-200">
       <div className="flex justify-between items-center">
         <span className="text-sm text-gray-600">Current RSC Balance:</span>
-        <span className="text-sm font-medium">{useUsd ? `${primary} USD` : `${primary} RSC`}</span>
+        <span className="text-sm font-medium">{primaryWithUnit}</span>
       </div>
-      {secondary && (
-        <div className="mt-1 text-xs text-gray-500 text-right">
-          ≈ {useUsd ? `${secondary} RSC` : `${secondary} USD`}
-        </div>
+      {secondaryWithUnit && (
+        <div className="mt-1 text-xs text-gray-500 text-right">≈ {secondaryWithUnit}</div>
       )}
-      {showWarning && deficitFormatted && (
+      {showWarning && deficitWithUnit && (
         <div className="mt-1 text-sm text-orange-600">
-          {`You need ${useUsd ? `${deficitFormatted} USD` : `${deficitFormatted} RSC`} more for this contribution`}
+          {`You need ${deficitWithUnit} more for this contribution`}
         </div>
       )}
     </div>

--- a/components/modals/ContributeToFundraiseModal.tsx
+++ b/components/modals/ContributeToFundraiseModal.tsx
@@ -179,7 +179,7 @@ export function ContributeToFundraiseModal({
     const rawValue = e.target.value.replace(/[^0-9.]/g, '');
     const numValue = parseFloat(rawValue);
 
-    if (isNaN(numValue)) {
+    if (Number.isNaN(numValue)) {
       setInputAmountRsc(0);
       setAmountError('Please enter a valid amount');
       return;
@@ -208,12 +208,16 @@ export function ContributeToFundraiseModal({
     return displayValueNum.toLocaleString(undefined, { maximumFractionDigits: 2 });
   };
 
-  const secondaryText =
-    exchangeRate > 0
-      ? useUsd
-        ? `≈ ${formatCurrency({ amount: inputAmountRsc, showUSD: false, exchangeRate })} RSC`
-        : `≈ ${formatCurrency({ amount: inputAmountRsc, showUSD: true, exchangeRate })} USD`
-      : undefined;
+  let secondaryText: string | undefined;
+  if (exchangeRate > 0) {
+    const otherFormatted = formatCurrency({
+      amount: inputAmountRsc,
+      showUSD: !useUsd,
+      exchangeRate,
+    });
+    const secondaryUnit = useUsd ? 'RSC' : 'USD';
+    secondaryText = `≈ ${otherFormatted} ${secondaryUnit}`;
+  }
 
   const handleContribute = async () => {
     try {


### PR DESCRIPTION
### Issue
USD toggle doesn't change RSC presentation in the contribution modal - funder didn't know how much USD he was going to fund since it was only presented as RSC

## After
<img width="1509" height="756" alt="Screenshot 2025-11-13 at 10 15 07 AM" src="https://github.com/user-attachments/assets/965df727-710b-49df-86c5-1529cff9e57c" />
<img width="1510" height="759" alt="Screenshot 2025-11-13 at 10 15 22 AM" src="https://github.com/user-attachments/assets/371e09df-8e7e-43e4-bf54-f41c6190235b" />


## Before
<img width="1505" height="792" alt="Screenshot 2025-11-13 at 10 15 55 AM" src="https://github.com/user-attachments/assets/82bc4dc2-1c19-4806-9e3d-abefe025751d" />
<img width="1506" height="792" alt="Screenshot 2025-11-13 at 10 16 06 AM" src="https://github.com/user-attachments/assets/6c88edc8-0951-47a9-9640-d1bc46d4c034" />
