### PR TITLE
Change to rolling deadline on rfp

### DIFF
--- a/components/Grant/GrantInfo.tsx
+++ b/components/Grant/GrantInfo.tsx
@@ -4,13 +4,13 @@ import { FC } from 'react';
 import { CurrencyBadge } from '@/components/ui/CurrencyBadge';
 import { Button } from '@/components/ui/Button';
 import { AvatarStack } from '@/components/ui/AvatarStack';
-import { formatDate, isDeadlineInFuture } from '@/utils/date';
+import { isDeadlineInFuture } from '@/utils/date';
 import { FeedGrantContent } from '@/types/feed';
 import { useRouter } from 'next/navigation';
 import { colors } from '@/app/styles/colors';
 import { StatusCard } from '@/components/ui/StatusCard';
 import { useCurrencyPreference } from '@/contexts/CurrencyPreferenceContext';
-import { Clock } from 'lucide-react';
+import { RollingDeadlineInfo } from '@/components/work/components/RollingDeadlineInfo';
 
 interface GrantInfoProps {
   grant: FeedGrantContent;
@@ -28,7 +28,6 @@ export const GrantInfo: FC<GrantInfoProps> = ({ grant, className, onFeedItemClic
   const isActive =
     grant.grant?.status === 'OPEN' &&
     (grant.grant?.endDate ? isDeadlineInFuture(grant.grant?.endDate) : true);
-  const deadline = grant.grant.endDate ? formatDate(grant.grant.endDate) : undefined;
 
   const applicants =
     grant.grant.applicants?.map((applicant) => ({
@@ -90,13 +89,8 @@ export const GrantInfo: FC<GrantInfoProps> = ({ grant, className, onFeedItemClic
             shorten={false}
           />
 
-          {/* Close date */}
-          {deadline && isActive && (
-            <div className="hidden sm:!flex items-center gap-1.5 text-xs text-gray-500">
-              <Clock size={14} className="text-gray-400" />
-              <span className="whitespace-nowrap">Closes {deadline}</span>
-            </div>
-          )}
+          {/* Rolling deadline */}
+          {isActive && <RollingDeadlineInfo variant="compact" className="hidden sm:!inline-flex" />}
 
           {/* Status badges */}
           {isActive && (

--- a/components/Grant/GrantInfo.tsx
+++ b/components/Grant/GrantInfo.tsx
@@ -89,9 +89,6 @@ export const GrantInfo: FC<GrantInfoProps> = ({ grant, className, onFeedItemClic
             shorten={false}
           />
 
-          {/* Rolling deadline */}
-          {isActive && <RollingDeadlineInfo variant="compact" className="hidden sm:!inline-flex" />}
-
           {/* Status badges */}
           {isActive && (
             <span className="text-xs font-medium text-primary-700 bg-primary-100 px-2 py-0.5 rounded-full">
@@ -103,6 +100,9 @@ export const GrantInfo: FC<GrantInfoProps> = ({ grant, className, onFeedItemClic
               Closed
             </span>
           )}
+
+          {/* Rolling deadline */}
+          {isActive && <RollingDeadlineInfo variant="compact" className="hidden sm:!inline-flex" />}
 
           {/* Applicants section */}
           {applicantCount > 0 && (

--- a/components/work/GrantDocument.tsx
+++ b/components/work/GrantDocument.tsx
@@ -10,8 +10,8 @@ import { CommentFeed } from '@/components/Comment/CommentFeed';
 import { GrantApplications } from './GrantApplications';
 import { format } from 'date-fns';
 import { PostBlockEditor } from './PostBlockEditor';
-import { formatDeadline, isDeadlineInFuture } from '@/utils/date';
-import { isExpiringSoon } from '@/components/Bounty/lib/bountyUtil';
+import { isDeadlineInFuture } from '@/utils/date';
+import { RollingDeadlineInfo } from './components/RollingDeadlineInfo';
 
 interface GrantDocumentProps {
   work: Work;
@@ -86,9 +86,6 @@ export const GrantDocument = ({
     work.note?.post?.grant?.status === 'OPEN' &&
     (work.note?.post?.grant?.endDate ? isDeadlineInFuture(work.note?.post?.grant?.endDate) : true);
 
-  // Show countdown when grant expires within 24 hours
-  const expiringSoon = isExpiringSoon(work.note?.post?.grant?.endDate, 1);
-
   return (
     <div>
       <PageHeader title={work.title} className="text-2xl md:!text-3xl mt-2" />
@@ -125,23 +122,8 @@ export const GrantDocument = ({
                 <span>{isActive ? 'Accepting Applications' : 'Closed'}</span>
               </div>
 
-              {/* Deadline and countdown - stack on mobile */}
-              {endDate && isActive && (
-                <div className="space-y-1 md:space-y-0 md:flex md:items-center md:gap-2">
-                  <span className="text-sm text-gray-600">
-                    Closes {format(endDate, 'MMMM d, yyyy')} at {format(endDate, 'h:mm a')}
-                  </span>
-                  {/* Show countdown when expiring soon */}
-                  {expiringSoon && work.note?.post?.grant?.endDate && (
-                    <>
-                      <div className="hidden md:block h-4 w-px bg-gray-300" />
-                      <span className="text-sm text-amber-600 font-medium block md:inline">
-                        {formatDeadline(work.note.post.grant.endDate)}
-                      </span>
-                    </>
-                  )}
-                </div>
-              )}
+              {/* Rolling deadline for open grants */}
+              {isActive && <RollingDeadlineInfo />}
 
               {/* Closed grant deadline */}
               {!isActive && endDate && (

--- a/components/work/GrantDocument.tsx
+++ b/components/work/GrantDocument.tsx
@@ -123,7 +123,7 @@ export const GrantDocument = ({
               </div>
 
               {/* Rolling deadline for open grants */}
-              {isActive && <RollingDeadlineInfo />}
+              {isActive && <RollingDeadlineInfo iconPosition="left" />}
 
               {/* Closed grant deadline */}
               {!isActive && endDate && (

--- a/components/work/components/GrantStatusSection.tsx
+++ b/components/work/components/GrantStatusSection.tsx
@@ -4,6 +4,7 @@ import { Work } from '@/types/work';
 import { format } from 'date-fns';
 import { Clock } from 'lucide-react';
 import { isDeadlineInFuture } from '@/utils/date';
+import { RollingDeadlineInfo } from './RollingDeadlineInfo';
 
 interface GrantStatusSectionProps {
   work: Work;
@@ -37,17 +38,8 @@ export const GrantStatusSection = ({ work }: GrantStatusSectionProps) => {
         />
         <span>{isActive ? 'Accepting Applications' : 'Closed'}</span>
       </div>
-      {/* Deadline information for open grants */}
-      {isActive && (
-        <div className="text-sm text-gray-600 mt-1">
-          <div className="flex items-center gap-1">
-            <Clock size={14} className="text-gray-500" />
-            <span>
-              Closes {format(endDate, 'MMMM d, yyyy')} at {format(endDate, 'h:mm a')}
-            </span>
-          </div>
-        </div>
-      )}
+      {/* Rolling deadline for open grants */}
+      {isActive && <RollingDeadlineInfo className="mt-1" />}
       {!isActive && (
         <div className="flex items-center gap-1 text-sm text-gray-600 mt-1">
           <Clock size={14} className="text-gray-500" />

--- a/components/work/components/GrantStatusSection.tsx
+++ b/components/work/components/GrantStatusSection.tsx
@@ -39,7 +39,7 @@ export const GrantStatusSection = ({ work }: GrantStatusSectionProps) => {
         <span>{isActive ? 'Accepting Applications' : 'Closed'}</span>
       </div>
       {/* Rolling deadline for open grants */}
-      {isActive && <RollingDeadlineInfo className="mt-1" />}
+      {isActive && <RollingDeadlineInfo className="mt-1" iconPosition="left" />}
       {!isActive && (
         <div className="flex items-center gap-1 text-sm text-gray-600 mt-1">
           <Clock size={14} className="text-gray-500" />

--- a/components/work/components/RollingDeadlineInfo.tsx
+++ b/components/work/components/RollingDeadlineInfo.tsx
@@ -7,11 +7,11 @@ import { cn } from '@/utils/styles';
 interface RollingDeadlineInfoProps {
   className?: string;
   variant?: 'default' | 'compact';
+  iconPosition?: 'left' | 'right';
 }
 
 const tooltipContent = (
   <div className="text-left space-y-1">
-    <p className="text-sm text-gray-700">This grant has a rolling deadline.</p>
     <p className="text-sm text-gray-700">
       Applications are reviewed on an ongoing basis and may be funded at any time.
     </p>
@@ -21,8 +21,21 @@ const tooltipContent = (
 export const RollingDeadlineInfo = ({
   className,
   variant = 'default',
+  iconPosition = 'right',
 }: RollingDeadlineInfoProps) => {
   const isCompact = variant === 'compact';
+  const infoTrigger = (
+    <Tooltip content={tooltipContent} position="top" width="w-72" wrapperClassName="h-auto">
+      <button
+        type="button"
+        aria-label="Learn more about rolling deadlines"
+        onClick={(e) => e.stopPropagation()}
+        className="inline-flex items-center justify-center text-gray-400 hover:text-gray-600 transition-colors"
+      >
+        <Info size={isCompact ? 14 : 16} />
+      </button>
+    </Tooltip>
+  );
 
   return (
     <div
@@ -32,17 +45,9 @@ export const RollingDeadlineInfo = ({
         className
       )}
     >
+      {iconPosition === 'left' && infoTrigger}
       <span className="whitespace-nowrap">Rolling Deadline</span>
-      <Tooltip content={tooltipContent} position="top" width="w-72" wrapperClassName="h-auto">
-        <button
-          type="button"
-          aria-label="Learn more about rolling deadlines"
-          onClick={(e) => e.stopPropagation()}
-          className="inline-flex items-center justify-center text-gray-400 hover:text-gray-600 transition-colors"
-        >
-          <Info size={isCompact ? 14 : 16} />
-        </button>
-      </Tooltip>
+      {iconPosition === 'right' && infoTrigger}
     </div>
   );
 };

--- a/components/work/components/RollingDeadlineInfo.tsx
+++ b/components/work/components/RollingDeadlineInfo.tsx
@@ -1,0 +1,48 @@
+'use client';
+
+import { Info } from 'lucide-react';
+import { Tooltip } from '@/components/ui/Tooltip';
+import { cn } from '@/utils/styles';
+
+interface RollingDeadlineInfoProps {
+  className?: string;
+  variant?: 'default' | 'compact';
+}
+
+const tooltipContent = (
+  <div className="text-left space-y-1">
+    <p className="text-sm text-gray-700">This grant has a rolling deadline.</p>
+    <p className="text-sm text-gray-700">
+      Applications are reviewed on an ongoing basis and may be funded at any time.
+    </p>
+  </div>
+);
+
+export const RollingDeadlineInfo = ({
+  className,
+  variant = 'default',
+}: RollingDeadlineInfoProps) => {
+  const isCompact = variant === 'compact';
+
+  return (
+    <div
+      className={cn(
+        'inline-flex items-center text-gray-500',
+        isCompact ? 'gap-1.5 text-xs' : 'gap-2 text-sm',
+        className
+      )}
+    >
+      <span className="whitespace-nowrap">Rolling Deadline</span>
+      <Tooltip content={tooltipContent} position="top" width="w-72" wrapperClassName="h-auto">
+        <button
+          type="button"
+          aria-label="Learn more about rolling deadlines"
+          onClick={(e) => e.stopPropagation()}
+          className="inline-flex items-center justify-center text-gray-400 hover:text-gray-600 transition-colors"
+        >
+          <Info size={isCompact ? 14 : 16} />
+        </button>
+      </Tooltip>
+    </div>
+  );
+};


### PR DESCRIPTION
### Issue:
Users are messaging mods frequently asking about the Year 2099 deadlines for RFP's

### Proposed Solution:
We should update this to just use terminology like "Rolling Deadline" 




<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk UI-only change that adjusts how grant/RFP deadlines are communicated; no changes to application status logic or data handling.
> 
> **Overview**
> Updates grant/RFP UI to **stop showing specific “Closes {date}” deadlines for open grants** and instead display a consistent *“Rolling Deadline”* indicator.
> 
> Introduces a reusable `RollingDeadlineInfo` component (label + info tooltip) and wires it into the feed card (`GrantInfo`), grant document header (`GrantDocument`), and status section (`GrantStatusSection`), removing the prior close-date and “expiring soon” countdown messaging.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3bd341ab1c69eee4d621eb050f44c825af46a92b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->