### PR TITLE
Fix DAF contribution display in Recent Activity sidebar

### DIFF
--- a/components/Funding/ActivityCard.tsx
+++ b/components/Funding/ActivityCard.tsx
@@ -32,6 +32,7 @@ const DOC_ACTION_LABELS: Record<string, string> = {
   PREREGISTRATION: 'submitted proposal',
   POST: 'posted discussion',
   PAPER: 'published preprint',
+  USDFUNDRAISECONTRIBUTION: 'contributed to',
 };
 
 const CONTENT_TYPE_MAP: Record<string, ContentType> = {
@@ -47,6 +48,14 @@ function getActionLabel(entry: FeedEntry): string {
     return COMMENT_ACTION_LABELS[comment?.commentType] || 'commented on';
   }
   if (entry.contentType === 'BOUNTY') return 'contributed to';
+  
+  if (entry.contentType === 'POST') {
+    const post = entry.content as FeedPostContent;
+    if (post.postType === 'USDFUNDRAISECONTRIBUTION') {
+      return DOC_ACTION_LABELS['USDFUNDRAISECONTRIBUTION'] || 'contributed to';
+    }
+  }
+  
   return DOC_ACTION_LABELS[entry.contentType] || 'contributed';
 }
 
@@ -66,6 +75,24 @@ function getEntryMeta(entry: FeedEntry) {
   }
 
   const titled = content as FeedPostContent | FeedPaperContent | FeedGrantContent;
+  
+  if (entry.contentType === 'POST') {
+    const post = content as FeedPostContent;
+    if (post.postType === 'USDFUNDRAISECONTRIBUTION' && post.fundraise) {
+      return {
+        title: post.fundraise.postTitle || titled.title,
+        author,
+        href: post.fundraise.postId && post.fundraise.postSlug
+          ? buildWorkUrl({
+              id: post.fundraise.postId,
+              slug: post.fundraise.postSlug,
+              contentType: 'preregistration',
+            })
+          : undefined,
+      };
+    }
+  }
+  
   return {
     title: titled.title,
     author,

--- a/types/feed.ts
+++ b/types/feed.ts
@@ -788,60 +788,8 @@ export const transformFeedEntry = (feedEntry: RawApiFeedEntry): FeedEntry => {
       break;
 
     case 'RESEARCHHUBPOST':
-      // Check if it's a fundraise contribution (DAF contribution)
-      if (content_object.type === 'USDFUNDRAISECONTRIBUTION' && content_object?.fundraise) {
-        contentType = 'POST';
-        try {
-          const postEntry: FeedPostContent = {
-            id: content_object.id,
-            unifiedDocumentId: getUnifiedDocumentId(content_object),
-            contentType: 'POST',
-            postType: content_object.type,
-            createdDate: action_date || content_object.created_date,
-            textPreview: content_object.renderable_text || '',
-            slug: content_object.slug || '',
-            title: stripHtml(content_object.title || content_object.fundraise.post_title || 'Fundraise Contribution'),
-            previewImage: content_object.image_url || content_object.fundraise.post_image || '',
-            authors:
-              content_object.authors && content_object.authors.length > 0
-                ? content_object.authors.map(transformAuthorProfile)
-                : [transformAuthorProfile(author)],
-            topics: content_object.hub
-              ? [
-                  content_object.hub.id
-                    ? transformTopic(content_object.hub)
-                    : {
-                        id: 0,
-                        name: content_object.hub.name || '',
-                        slug: content_object.hub.slug || '',
-                      },
-                ]
-              : [],
-            createdBy: transformAuthorProfile(author),
-            category: content_object.category ? transformTopic(content_object.category) : undefined,
-            subcategory: content_object.subcategory
-              ? transformTopic(content_object.subcategory)
-              : undefined,
-            bounties: content_object.bounties
-              ? content_object.bounties.map((bounty: any) =>
-                  transformBounty(bounty, { ignoreBaseAmount: true })
-                )
-              : [],
-            reviews: content_object.reviews
-              ? content_object.reviews.map((review: any) => ({
-                  id: review.id,
-                  score: review.score,
-                  author: transformAuthorProfile(review.author),
-                }))
-              : [],
-            fundraise: transformFundraise(content_object.fundraise),
-          };
-          content = postEntry;
-        } catch (error) {
-          console.error('Error transforming USDFUNDRAISECONTRIBUTION:', error);
-          throw error;
-        }
-      } else if (content_object.type === 'GRANT' && content_object?.grant) {
+      // Check if it's a grant
+      if (content_object.type === 'GRANT' && content_object?.grant) {
         // Add this new case for GRANT content
         contentType = 'GRANT';
         try {
@@ -916,10 +864,20 @@ export const transformFeedEntry = (feedEntry: RawApiFeedEntry): FeedEntry => {
         try {
           // Extract the necessary data from content_object
           const isPreregistration = content_object.type === 'PREREGISTRATION';
+          const isDAFContribution = content_object.type === 'USDFUNDRAISECONTRIBUTION';
 
           if (isPreregistration) {
             contentType = 'PREREGISTRATION';
           }
+
+          // For DAF contributions, use fundraise post title/image if available
+          const title = isDAFContribution && content_object.fundraise?.post_title
+            ? content_object.fundraise.post_title
+            : content_object.title || '';
+          
+          const previewImage = isDAFContribution && content_object.fundraise?.post_image
+            ? content_object.fundraise.post_image
+            : content_object.image_url || '';
 
           // Create a FeedPostEntry object
           const postEntry: FeedPostContent = {
@@ -930,8 +888,8 @@ export const transformFeedEntry = (feedEntry: RawApiFeedEntry): FeedEntry => {
             createdDate: action_date || content_object.created_date,
             textPreview: content_object.renderable_text || '',
             slug: content_object.slug || '',
-            title: stripHtml(content_object.title || ''),
-            previewImage: content_object.image_url || '',
+            title: stripHtml(title),
+            previewImage,
             authors:
               content_object.authors && content_object.authors.length > 0
                 ? content_object.authors.map(transformAuthorProfile)
@@ -967,8 +925,8 @@ export const transformFeedEntry = (feedEntry: RawApiFeedEntry): FeedEntry => {
               : [],
           };
 
-          // Add fundraise data if it's a PREREGISTRATION and has fundraise data
-          if (isPreregistration && content_object.fundraise) {
+          // Add fundraise data if it's a PREREGISTRATION or DAF contribution with fundraise data
+          if ((isPreregistration || isDAFContribution) && content_object.fundraise) {
             try {
               postEntry.fundraise = transformFundraise(content_object.fundraise);
             } catch (fundraiseError) {

--- a/types/feed.ts
+++ b/types/feed.ts
@@ -788,8 +788,60 @@ export const transformFeedEntry = (feedEntry: RawApiFeedEntry): FeedEntry => {
       break;
 
     case 'RESEARCHHUBPOST':
-      // Check if it's a grant
-      if (content_object.type === 'GRANT' && content_object?.grant) {
+      // Check if it's a fundraise contribution (DAF contribution)
+      if (content_object.type === 'USDFUNDRAISECONTRIBUTION' && content_object?.fundraise) {
+        contentType = 'POST';
+        try {
+          const postEntry: FeedPostContent = {
+            id: content_object.id,
+            unifiedDocumentId: getUnifiedDocumentId(content_object),
+            contentType: 'POST',
+            postType: content_object.type,
+            createdDate: action_date || content_object.created_date,
+            textPreview: content_object.renderable_text || '',
+            slug: content_object.slug || '',
+            title: stripHtml(content_object.title || content_object.fundraise.post_title || 'Fundraise Contribution'),
+            previewImage: content_object.image_url || content_object.fundraise.post_image || '',
+            authors:
+              content_object.authors && content_object.authors.length > 0
+                ? content_object.authors.map(transformAuthorProfile)
+                : [transformAuthorProfile(author)],
+            topics: content_object.hub
+              ? [
+                  content_object.hub.id
+                    ? transformTopic(content_object.hub)
+                    : {
+                        id: 0,
+                        name: content_object.hub.name || '',
+                        slug: content_object.hub.slug || '',
+                      },
+                ]
+              : [],
+            createdBy: transformAuthorProfile(author),
+            category: content_object.category ? transformTopic(content_object.category) : undefined,
+            subcategory: content_object.subcategory
+              ? transformTopic(content_object.subcategory)
+              : undefined,
+            bounties: content_object.bounties
+              ? content_object.bounties.map((bounty: any) =>
+                  transformBounty(bounty, { ignoreBaseAmount: true })
+                )
+              : [],
+            reviews: content_object.reviews
+              ? content_object.reviews.map((review: any) => ({
+                  id: review.id,
+                  score: review.score,
+                  author: transformAuthorProfile(review.author),
+                }))
+              : [],
+            fundraise: transformFundraise(content_object.fundraise),
+          };
+          content = postEntry;
+        } catch (error) {
+          console.error('Error transforming USDFUNDRAISECONTRIBUTION:', error);
+          throw error;
+        }
+      } else if (content_object.type === 'GRANT' && content_object?.grant) {
         // Add this new case for GRANT content
         contentType = 'GRANT';
         try {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem
DAF (Donor-Advised Fund) contributions were displaying incorrectly in the Recent Activity sidebar on the `/fund` page. Instead of showing a properly formatted entry like "Tyler Diorio contributed to [Fundraise Name]", they were showing the raw content type: "Tyler Diorio posted discussion USDFUNDRAISECONTRIBUTION #8".

## Root Cause
The `USDFUNDRAISECONTRIBUTION` content type from the backend API was not being handled explicitly in the frontend code. It was falling through to the default case in the feed transformation logic, which generated a generic title using the raw content_type string.

## Solution
Added specific handling for `USDFUNDRAISECONTRIBUTION` posts in three places:

### 1. ActivityCard Component (`components/Funding/ActivityCard.tsx`)
- Added `'contributed to'` action label for USDFUNDRAISECONTRIBUTION posts
- Updated `getActionLabel()` to check for USDFUNDRAISECONTRIBUTION post type
- Updated `getEntryMeta()` to use the associated fundraise's title and link when available

### 2. Feed Transformation (`types/feed.ts`)
- Added explicit case handling for USDFUNDRAISECONTRIBUTION in the `transformFeedEntry()` function
- Extracts fundraise data when available
- Uses the fundraise's post title instead of generating a generic title

## Testing
- ✅ Code review confirms the logic is correct
- ⚠️ Unable to test visually in development environment due to lack of DAF contribution test data
- Will need verification in staging/production where DAF contributions exist

## Impact
- Improves UX by displaying human-readable contribution messages
- Maintains consistency with how other activity types are displayed
- Links properly to the associated fundraise post

Fixes #[issue-number-if-available]

Relates to feedback from Slack: https://researchhub.slack.com/archives/[channel-id]/p[timestamp]
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://researchhubfoundation.slack.com/archives/C0897LR58B1/p1773705032385689?thread_ts=1773705032.385689&cid=C0897LR58B1)

<div><a href="https://cursor.com/agents/bc-7aaf93f2-66c8-53ec-9314-f8d544213c0c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7aaf93f2-66c8-53ec-9314-f8d544213c0c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

