### PR TITLE
[Expert Finder] - optional additional guidance on create search

### DIFF
--- a/app/expert-finder/library/[searchId]/components/SearchDetailHeader.tsx
+++ b/app/expert-finder/library/[searchId]/components/SearchDetailHeader.tsx
@@ -42,6 +42,15 @@ export function SearchDetailHeader({ search }: SearchDetailHeaderProps) {
         )}
       </div>
       {search.work && <RelatedWorkCard work={search.work} size="sm" />}
+      {search.additionalContext.trim() !== '' && (
+        <section
+          className="rounded-lg border border-gray-200 bg-white p-4 shadow-sm mt-4"
+          aria-label="Additional guidance for this search"
+        >
+          <h2 className="text-sm font-semibold text-gray-900 mb-2">Additional guidance</h2>
+          <p className="text-sm text-gray-700 whitespace-pre-wrap">{search.additionalContext}</p>
+        </section>
+      )}
     </>
   );
 }

--- a/app/expert-finder/library/new/components/AdvancedConfig.tsx
+++ b/app/expert-finder/library/new/components/AdvancedConfig.tsx
@@ -1,15 +1,16 @@
 'use client';
 
 import { useState, useCallback, useEffect } from 'react';
-import type { FieldErrors } from 'react-hook-form';
+import type { FieldErrors, UseFormRegister } from 'react-hook-form';
 import { ChevronDown, Settings } from 'lucide-react';
 import { Button } from '@/components/ui/Button';
 import { CollapsibleSection } from '@/components/ui/CollapsibleSection';
 import { Input } from '@/components/ui/form/Input';
+import { Textarea } from '@/components/ui/form/Textarea';
 import { Dropdown, DropdownItem, MultiSelectDropdown } from '@/components/ui/form/Dropdown';
 import type { ExpertSearchResult } from '@/types/expertFinder';
 import type { ContentType } from '@/types/work';
-import type { AdvancedConfigFormValues } from '../schema';
+import type { AdvancedConfigFormValues, ExpertFinderFormValues } from '../schema';
 import { EXPERT_COUNT_OPTIONS } from '../schema';
 import {
   EXPERTISE_LEVEL_OPTIONS,
@@ -37,6 +38,10 @@ interface AdvancedConfigProps {
   contentType?: ContentType;
   onRerunSelect: (search: ExpertSearchResult | null) => void;
   selectedSearchId: number | null;
+  additionalContextRegister: ReturnType<UseFormRegister<ExpertFinderFormValues>>;
+  additionalContextError?: string;
+  additionalContextCharCount: number;
+  additionalContextMaxLength: number;
 }
 
 export function AdvancedConfig({
@@ -47,6 +52,10 @@ export function AdvancedConfig({
   contentType,
   onRerunSelect,
   selectedSearchId,
+  additionalContextRegister,
+  additionalContextError,
+  additionalContextCharCount,
+  additionalContextMaxLength,
 }: AdvancedConfigProps) {
   const hideInputType = contentType !== 'paper';
   const [isExpanded, setIsExpanded] = useState(false);
@@ -91,6 +100,15 @@ export function AdvancedConfig({
             value={values.searchName ?? ''}
             onChange={(e) => onChange({ ...values, searchName: e.target.value })}
             helperText="Give this search a name to find it easily later."
+          />
+        </div>
+
+        <div className="min-w-0 md:!col-span-2">
+          <Textarea
+            label="Additional guidance (optional)"
+            helperText={`Steers how experts are identified for this search. ${additionalContextCharCount} / ${additionalContextMaxLength} characters`}
+            error={additionalContextError}
+            {...additionalContextRegister}
           />
         </div>
 

--- a/app/expert-finder/library/new/components/ExpertFinderForm.tsx
+++ b/app/expert-finder/library/new/components/ExpertFinderForm.tsx
@@ -18,6 +18,7 @@ import {
   type InputType,
   type Region,
   DEFAULT_REGION,
+  EXPERT_SEARCH_ADDITIONAL_CONTEXT_MAX_LENGTH,
   ExpertFinderService,
   EXPERTISE_LEVEL_ALL,
 } from '@/services/expertFinder.service';
@@ -42,6 +43,7 @@ function getAvailableInputTypes(work: Work | null): InputType[] {
 const defaultValues: ExpertFinderFormValues = {
   unifiedDocumentId: null,
   url: '',
+  additionalContext: '',
   advanced: {
     expertCount: 25,
     expertiseLevel: [],
@@ -80,6 +82,7 @@ export function ExpertFinderForm() {
 
   const urlValue = watch('url');
   const unifiedDocumentId = watch('unifiedDocumentId');
+  const additionalContextValue = watch('additionalContext');
 
   const [{ work: fetchedWork, isLoading: fetchWorkLoading, error: fetchWorkError }] =
     useWorkByUnifiedDocumentId(unifiedDocumentId);
@@ -168,6 +171,7 @@ export function ExpertFinderForm() {
         ...current,
         unifiedDocumentId: unifiedId,
         url: current.url,
+        additionalContext: search.additionalContext ?? current.additionalContext,
         advanced: {
           expertCount,
           expertiseLevel,
@@ -207,6 +211,8 @@ export function ExpertFinderForm() {
         .map((s) => s.trim())
         .filter(Boolean);
 
+      const trimmedAdditionalContext = data.additionalContext?.trim() ?? '';
+
       const payload: ExpertSearchCreatePayload = {
         unified_document_id: unifiedDocumentId,
         input_type: adv.inputType,
@@ -218,6 +224,7 @@ export function ExpertFinderForm() {
         },
         excluded_expert_names: excludedNames.length > 0 ? excludedNames : undefined,
         ...(adv.searchName?.trim() && { name: adv.searchName.trim() }),
+        ...(trimmedAdditionalContext && { additional_context: trimmedAdditionalContext }),
       };
 
       const response = await createSearch(payload);
@@ -293,6 +300,10 @@ export function ExpertFinderForm() {
               contentType={fetchedWork?.contentType}
               onRerunSelect={handleRerunSelect}
               selectedSearchId={selectedSearchId}
+              additionalContextRegister={register('additionalContext')}
+              additionalContextError={getFieldErrorMessage(errors.additionalContext)}
+              additionalContextCharCount={additionalContextValue?.length ?? 0}
+              additionalContextMaxLength={EXPERT_SEARCH_ADDITIONAL_CONTEXT_MAX_LENGTH}
             />
           )}
         />

--- a/app/expert-finder/library/new/schema.ts
+++ b/app/expert-finder/library/new/schema.ts
@@ -1,5 +1,10 @@
 import { z } from 'zod';
-import { ExpertiseLevel, InputType, Region } from '@/services/expertFinder.service';
+import {
+  ExpertiseLevel,
+  EXPERT_SEARCH_ADDITIONAL_CONTEXT_MAX_LENGTH,
+  InputType,
+  Region,
+} from '@/services/expertFinder.service';
 
 const INPUT_TYPES: InputType[] = ['abstract', 'pdf', 'full_content'];
 
@@ -42,6 +47,7 @@ export const expertFinderFormSchema = z
   .object({
     unifiedDocumentId: z.number().nullable().default(null),
     url: z.string().optional().default(''),
+    additionalContext: z.string().max(EXPERT_SEARCH_ADDITIONAL_CONTEXT_MAX_LENGTH).default(''),
     advanced: advancedConfigSchema,
   })
   .refine((data) => data.unifiedDocumentId != null, {

--- a/services/expertFinder.service.ts
+++ b/services/expertFinder.service.ts
@@ -59,6 +59,8 @@ export const REGION_OPTIONS: { value: Region; label: string }[] = [
 
 export const DEFAULT_REGION: Region = 'all_regions';
 
+export const EXPERT_SEARCH_ADDITIONAL_CONTEXT_MAX_LENGTH = 10_000;
+
 export function getRegionLabel(value: Region): string {
   return REGION_OPTIONS.find((o) => o.value === value)?.label ?? value;
 }
@@ -75,6 +77,7 @@ export interface ExpertSearchCreatePayload {
     state: string;
   };
   excluded_expert_names?: string[];
+  additional_context?: string;
 }
 
 // ── Email template kind (purpose) ───────────────────

--- a/types/expertFinder.ts
+++ b/types/expertFinder.ts
@@ -63,6 +63,7 @@ export interface ExpertSearchResult {
   updatedAt: string;
   completedAt: string | null;
   work: Work | null;
+  additionalContext: string;
   createdBy: CreatedByInfo | null;
 }
 
@@ -166,6 +167,7 @@ export const transformExpertSearch = createTransformer<any, ExpertSearchResult>(
   updatedAt: raw.updated_at ?? '',
   completedAt: raw.completed_at ?? null,
   work: raw.work ? transformUnifiedDocument(raw.work) : null,
+  additionalContext: raw.additional_context ?? '',
   createdBy: transformCreatedBy(raw.created_by),
 }));
 


### PR DESCRIPTION
## What?
- Adds an optional **“Additional guidance”** field on new expert search (under **Advanced**)
- 
<img width="935" height="736" alt="image" src="https://github.com/user-attachments/assets/a23b5851-089e-44fd-8e75-7bb0fad5f658" />
