### PR TITLE
fix: display flat $150 USD for RHF peer-review bounty notifications

### DIFF
--- a/components/Notification/NotificationItem.tsx
+++ b/components/Notification/NotificationItem.tsx
@@ -6,6 +6,7 @@ import {
   getHubDetailsFromNotification,
   formatNavigationUrl,
   getRSCAmountFromNotification,
+  getBountyForYouUsdOverride,
 } from './lib/formatNotification';
 import { Avatar } from '@/components/ui/Avatar';
 import { Icon } from '@/components/ui/icons/Icon';
@@ -32,6 +33,7 @@ export function NotificationItem({ notification }: NotificationItemProps) {
   const formattedNavigationUrl = formatNavigationUrl(notification);
   const hasNavigationUrl = !!formattedNavigationUrl && formattedNavigationUrl.trim() !== '';
   const rscAmount = getRSCAmountFromNotification(notification);
+  const bountyForYouUsdOverride = getBountyForYouUsdOverride(notification);
 
   const hubDetails = getHubDetailsFromNotification(notification);
 
@@ -86,10 +88,12 @@ export function NotificationItem({ notification }: NotificationItemProps) {
         {rscAmount && (
           <div className="inline-block">
             <CurrencyBadge
-              amount={rscAmount}
+              amount={bountyForYouUsdOverride !== null ? bountyForYouUsdOverride : rscAmount}
               size="xs"
               variant={isReceivedRSC ? 'received' : 'badge'}
               showText
+              isUSD={bountyForYouUsdOverride !== null}
+              skipConversion={bountyForYouUsdOverride !== null}
               className="py-0.5"
             />
           </div>

--- a/components/Notification/lib/formatNotification.ts
+++ b/components/Notification/lib/formatNotification.ts
@@ -1,6 +1,7 @@
 import { type IconName } from '@/components/ui/icons/Icon';
 import { Notification } from '@/types/notification';
 import { formatUsdValue, formatRSC } from '@/utils/number';
+import { FOUNDATION_BOUNTY_FLAT_USD } from '@/config/constants';
 
 export interface NotificationTypeInfo {
   icon: IconName;
@@ -280,6 +281,20 @@ function getBountyTypeAction(bountyType: string): string {
   }
 }
 
+/**
+ * Check if a BOUNTY_FOR_YOU notification should display the flat Foundation bounty amount
+ * (applies to peer-review bounties)
+ */
+export function getBountyForYouUsdOverride(notification: Notification): number | null {
+  if (notification.type === 'BOUNTY_FOR_YOU') {
+    const bountyType = notification.extra?.bounty_type || '';
+    if (bountyType.toUpperCase() === 'REVIEW') {
+      return FOUNDATION_BOUNTY_FLAT_USD;
+    }
+  }
+  return null;
+}
+
 export function formatNotificationMessage(
   notification: Notification,
   exchangeRate: number = 0,
@@ -300,10 +315,12 @@ export function formatNotificationMessage(
       return `${userName} awarded you RSC for your work on "${truncatedTitle}"`;
 
     case 'BOUNTY_FOR_YOU': {
-      const amount = notification.extra?.amount || '0';
       const bountyType = notification.extra?.bounty_type || '';
       const bountyTypeAction = getBountyTypeAction(bountyType);
-      const usdValue = formatUsdValue(amount, exchangeRate);
+      const usdOverride = getBountyForYouUsdOverride(notification);
+      const usdValue = usdOverride !== null
+        ? `$${usdOverride} USD`
+        : formatUsdValue(notification.extra?.amount || '0', exchangeRate);
       return `Your expertise is needed! Earn ${usdValue} for ${bountyTypeAction} "${truncatedTitle}"`;
     }
 


### PR DESCRIPTION
## Summary
Adjusts bounty notification display so RHF-sponsored peer review bounty prompts show a flat `$150 USD` amount instead of derived variable amounts.

## Changes
- Add `getBountyForYouUsdOverride` function to check if notification is a peer-review bounty (`BOUNTY_FOR_YOU` + `bounty_type: REVIEW`)
- Use the flat amount from `FOUNDATION_BOUNTY_FLAT_USD` (150) when override applies
- Apply the override in `formatNotificationMessage` to show `$150 USD` in the message
- Apply the same override in `NotificationItem.tsx` CurrencyBadge with `isUSD` and `skipConversion` props to ensure message and badge stay consistent

## Files Modified
- `components/Notification/lib/formatNotification.ts` - Added import, new function, and updated BOUNTY_FOR_YOU case
- `components/Notification/NotificationItem.tsx` - Added import and updated CurrencyBadge props

## Testing
- Local lint/type checks not available due to environment limitations (as noted in original PR)
- Changes follow existing patterns in the codebase (similar to how `FOUNDATION_BOUNTY_FLAT_USD` is used in bountyUtil.ts)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI formatting change limited to `BOUNTY_FOR_YOU` peer-review notifications; main risk is inconsistent currency display if the override logic misfires on unexpected `extra.bounty_type` values.
> 
> **Overview**
> **Peer-review bounty notifications now show a flat Foundation amount.** For `BOUNTY_FOR_YOU` notifications with `bounty_type: REVIEW`, the message formatter uses `FOUNDATION_BOUNTY_FLAT_USD` (150) instead of deriving USD from the notification amount and exchange rate.
> 
> **Badge display is kept consistent with the message.** `NotificationItem` applies the same override to `CurrencyBadge`, forcing USD display and bypassing conversion (`skipConversion`) when the flat amount is used.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2298d93f27fa2ecc02aade95cb61a68407ed8acc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->