### PR TITLE
BugFix: Bounty Count not including bounties in Assessment 

### DIFF
--- a/components/Bounty/lib/bountyUtil.ts
+++ b/components/Bounty/lib/bountyUtil.ts
@@ -36,12 +36,12 @@ export const isActiveBounty = (bounty: Bounty): boolean => {
 };
 
 /**
- * Filters an array of bounties to only include open bounties
+ * Filters an array of bounties to only include active bounties (OPEN or ASSESSMENT)
  * @param bounties Array of bounties to filter
- * @returns Array of open bounties
+ * @returns Array of active bounties
  */
-export const getOpenBounties = (bounties: Bounty[]): Bounty[] => {
-  return bounties.filter(isOpenBounty);
+export const getActiveBounties = (bounties: Bounty[]): Bounty[] => {
+  return bounties.filter(isActiveBounty);
 };
 
 /**
@@ -54,12 +54,12 @@ export const getClosedBounties = (bounties: Bounty[]): Bounty[] => {
 };
 
 /**
- * Counts the number of open bounties in an array
+ * Counts the number of active bounties (OPEN or ASSESSMENT) in an array
  * @param bounties Array of bounties to count
- * @returns Number of open bounties
+ * @returns Number of active bounties
  */
-export const countOpenBounties = (bounties: Bounty[]): number => {
-  return getOpenBounties(bounties).length;
+export const countActiveBounties = (bounties: Bounty[]): number => {
+  return getActiveBounties(bounties).length;
 };
 
 /**
@@ -78,15 +78,6 @@ export const countClosedBounties = (bounties: Bounty[]): number => {
  */
 export const calculateTotalBountyAmount = (bounties: Bounty[]): number => {
   return bounties.reduce((sum, bounty) => sum + parseFloat(bounty.amount), 0);
-};
-
-/**
- * Calculates the total amount of open bounties in an array
- * @param bounties Array of bounties to sum
- * @returns Total amount of open bounties as a number
- */
-export const calculateOpenBountiesAmount = (bounties: Bounty[]): number => {
-  return getOpenBounties(bounties).reduce((sum, bounty) => sum + parseFloat(bounty.amount), 0);
 };
 
 /**

--- a/components/banners/EarningOpportunityBanner.tsx
+++ b/components/banners/EarningOpportunityBanner.tsx
@@ -5,7 +5,7 @@ import { useCurrencyPreference } from '@/contexts/CurrencyPreferenceContext';
 import { useExchangeRate } from '@/contexts/ExchangeRateContext';
 import { CurrencyBadge } from '@/components/ui/CurrencyBadge';
 import { Button } from '@/components/ui/Button';
-import { getOpenBounties, getTotalBountyDisplayAmount } from '@/components/Bounty/lib/bountyUtil';
+import { getActiveBounties, getTotalBountyDisplayAmount } from '@/components/Bounty/lib/bountyUtil';
 import { buildWorkUrl } from '@/utils/url';
 import { useRouter } from 'next/navigation';
 import { Work } from '@/types/work';
@@ -27,16 +27,19 @@ export const EarningOpportunityBanner = ({
   const { exchangeRate, isLoading: isExchangeRateLoading } = useExchangeRate();
   const router = useRouter();
 
-  // Don't show banner if no open bounties
-  if (!metadata.bounties || metadata.openBounties === 0) {
+  // Don't show banner if no active bounties
+  if (!metadata.bounties || metadata.activeBounties === 0) {
     return null;
   }
 
   // Calculate display amount (handles Foundation bounties with flat $150 USD)
-  const openBounties = useMemo(() => getOpenBounties(metadata.bounties || []), [metadata.bounties]);
+  const activeBounties = useMemo(
+    () => getActiveBounties(metadata.bounties || []),
+    [metadata.bounties]
+  );
   const { amount: displayAmount } = useMemo(
-    () => getTotalBountyDisplayAmount(openBounties, exchangeRate, showUSD),
-    [openBounties, exchangeRate, showUSD]
+    () => getTotalBountyDisplayAmount(activeBounties, exchangeRate, showUSD),
+    [activeBounties, exchangeRate, showUSD]
   );
 
   // Check if we can display the bounty amount (exchange rate loaded if USD preferred)
@@ -104,7 +107,7 @@ export const EarningOpportunityBanner = ({
             }}
             size="sm"
             className="flex-shrink-0 bg-orange-500 hover:bg-orange-600 text-white font-medium shadow-sm group-hover:shadow transition-all duration-200 text-xs px-3"
-            aria-label={`View ${metadata.openBounties} available ${metadata.openBounties === 1 ? 'bounty' : 'bounties'}`}
+            aria-label={`View ${metadata.activeBounties} available ${metadata.activeBounties === 1 ? 'bounty' : 'bounties'}`}
           >
             View
           </Button>
@@ -150,7 +153,7 @@ export const EarningOpportunityBanner = ({
             }}
             size="sm"
             className="w-full mt-3 bg-orange-500 hover:bg-orange-600 text-white font-medium shadow-sm group-hover:shadow transition-all duration-200"
-            aria-label={`View ${metadata.openBounties} available ${metadata.openBounties === 1 ? 'bounty' : 'bounties'}`}
+            aria-label={`View ${metadata.activeBounties} available ${metadata.activeBounties === 1 ? 'bounty' : 'bounties'}`}
           >
             View Bounties
           </Button>

--- a/components/work/WorkTabs.tsx
+++ b/components/work/WorkTabs.tsx
@@ -14,7 +14,7 @@ import { useCurrencyPreference } from '@/contexts/CurrencyPreferenceContext';
 import { useExchangeRate } from '@/contexts/ExchangeRateContext';
 import Icon from '@/components/ui/icons/Icon';
 import { ResearchCoinIcon } from '@/components/ui/icons/ResearchCoinIcon';
-import { getOpenBounties, getTotalBountyDisplayAmount } from '@/components/Bounty/lib/bountyUtil';
+import { getActiveBounties, getTotalBountyDisplayAmount } from '@/components/Bounty/lib/bountyUtil';
 import { formatCurrency } from '@/utils/currency';
 import { colors } from '@/app/styles/colors';
 
@@ -53,16 +53,19 @@ export const WorkTabs = ({
     return score.toFixed(1);
   };
 
-  const openBounties = useMemo(() => getOpenBounties(metadata.bounties || []), [metadata.bounties]);
+  const activeBounties = useMemo(
+    () => getActiveBounties(metadata.bounties || []),
+    [metadata.bounties]
+  );
   const { amount: totalBountyAmount } = useMemo(
-    () => getTotalBountyDisplayAmount(openBounties, exchangeRate, showUSD),
-    [openBounties, exchangeRate, showUSD]
+    () => getTotalBountyDisplayAmount(activeBounties, exchangeRate, showUSD),
+    [activeBounties, exchangeRate, showUSD]
   );
 
   const canDisplayBountyAmount =
     !showUSD || (showUSD && !isExchangeRateLoading && exchangeRate > 0);
 
-  const hasOpenBounties = openBounties.length > 0;
+  const hasActiveBounties = activeBounties.length > 0;
 
   const hasResearchHubJournalVersions = useMemo(() => {
     return (work.versions || []).some((version) => version.isResearchHubJournal);
@@ -236,7 +239,7 @@ export const WorkTabs = ({
                 : 'bg-gray-100 text-gray-600'
             }`}
           >
-            {hasOpenBounties && canDisplayBountyAmount ? (
+            {hasActiveBounties && canDisplayBountyAmount ? (
               <>
                 {!showUSD && (
                   <ResearchCoinIcon

--- a/services/metadata.service.ts
+++ b/services/metadata.service.ts
@@ -5,7 +5,7 @@ import { transformAuthorProfile } from '@/types/authorProfile';
 import { ContentMetrics } from '@/types/metrics';
 import { Fundraise, transformFundraise } from '@/types/funding';
 import { Bounty, transformBounty } from '@/types/bounty';
-import { countOpenBounties, countClosedBounties } from '@/components/Bounty/lib/bountyUtil';
+import { countActiveBounties, countClosedBounties } from '@/components/Bounty/lib/bountyUtil';
 
 export interface WorkMetadata {
   id: number;
@@ -14,7 +14,7 @@ export interface WorkMetadata {
   metrics: ContentMetrics;
   fundraising?: Fundraise;
   bounties: Bounty[];
-  openBounties: number;
+  activeBounties: number;
   closedBounties: number;
 }
 
@@ -25,8 +25,7 @@ function transformWorkMetadata(response: any): WorkMetadata {
   // Transform bounties if they exist using the existing transformer
   const bounties = document.bounties?.map((bounty: any) => transformBounty(bounty)) || [];
 
-  // Calculate open and closed bounty counts using utility functions
-  const openBounties = countOpenBounties(bounties);
+  const activeBounties = countActiveBounties(bounties);
   const closedBounties = countClosedBounties(bounties);
 
   return {
@@ -46,7 +45,7 @@ function transformWorkMetadata(response: any): WorkMetadata {
     },
     fundraising: response.fundraise ? transformFundraise(response.fundraise) : undefined,
     bounties: bounties,
-    openBounties,
+    activeBounties,
     closedBounties,
   };
 }

--- a/store/grantStore.ts
+++ b/store/grantStore.ts
@@ -196,7 +196,7 @@ const mockGrant1: GrantWithMetadata = {
       updatedDate: new Date().toISOString(),
     },
     bounties: [],
-    openBounties: 0,
+    activeBounties: 0,
     closedBounties: 0,
   },
 };
@@ -372,7 +372,7 @@ const mockGrant2: GrantWithMetadata = {
       updatedDate: new Date().toISOString(),
     },
     bounties: [],
-    openBounties: 0,
+    activeBounties: 0,
     closedBounties: 0,
   },
 };


### PR DESCRIPTION
## Overview ##

This PR includes a bug fix to utilise all active bounties (OPEN + ASSESSMENT), rather than just OPEN for the count and totals located on work pages.  It also removes the unused `calculateOpenBountiesAmount` const.

## Screenshot ##

<img width="859" height="654" alt="image" src="https://github.com/user-attachments/assets/cdf82b7e-827a-4449-82da-e57d2ad668bd" />
