### PR TITLE
Updating several site links for consolidation

### DIFF
--- a/components/Earn/EarnHeroBanner.tsx
+++ b/components/Earn/EarnHeroBanner.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react';
 import { HeroHeader } from '@/components/ui/HeroHeader';
 import { Button } from '@/components/ui/Button';
 import { BaseModal } from '@/components/ui/BaseModal';
-import { Search, FileText, Coins, ExternalLink, BookOpen, ClipboardList } from 'lucide-react';
+import { Search, FileText, Coins, ExternalLink, BookOpen } from 'lucide-react';
 
 const steps = [
   {
@@ -69,7 +69,7 @@ export function EarnHeroBanner() {
           <h3 className="text-sm font-semibold text-gray-900 mb-4">Resources</h3>
           <div className="space-y-3">
             <a
-              href="https://blog.researchhub.foundation/peer-reviewing-on-researchhub/"
+              href="https://docs.researchhub.com/researchhub-foundation/programs-and-initiatives/peer-review-program/peer-review-guidelines"
               target="_blank"
               rel="noopener noreferrer"
               className="flex items-center justify-between gap-3 text-sm text-blue-600 hover:text-blue-700 transition-colors"
@@ -77,18 +77,6 @@ export function EarnHeroBanner() {
               <span className="flex items-center gap-2.5">
                 <BookOpen size={16} className="flex-shrink-0" />
                 Peer Review Walkthrough
-              </span>
-              <ExternalLink size={14} className="flex-shrink-0 text-gray-400" />
-            </a>
-            <a
-              href="https://drive.google.com/file/d/1t7NpL39ghnBY9ImWjuunbc6gzmzrhqUt/view?ref=blog.researchhub.foundation"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="flex items-center justify-between gap-3 text-sm text-blue-600 hover:text-blue-700 transition-colors"
-            >
-              <span className="flex items-center gap-2.5">
-                <ClipboardList size={16} className="flex-shrink-0" />
-                Peer Review Guidelines (Preprint)
               </span>
               <ExternalLink size={14} className="flex-shrink-0 text-gray-400" />
             </a>

--- a/components/Journal/RHJRightSidebar.tsx
+++ b/components/Journal/RHJRightSidebar.tsx
@@ -11,7 +11,7 @@ interface RHJRightSidebarProps {
 
 const quickLinks = [
   {
-    href: 'https://drive.google.com/file/d/1qKlGnNSA-98kg-RhmTFKYVB85X0PJWYr/view?usp=sharing',
+    href: 'https://docs.researchhub.com/researchhub-foundation/programs-and-initiatives/researchhub-journal-rhj/author-guidelines',
     text: 'Author Guidelines',
     icon: Feather,
   },

--- a/components/landing/LandingPageFooter.tsx
+++ b/components/landing/LandingPageFooter.tsx
@@ -42,11 +42,11 @@ export function LandingPageFooter() {
     },
     {
       label: 'Get paid to peer review',
-      href: 'https://airtable.com/apptLQP8XMy1kaiID/pag5tkxt0V18Xobje/form',
+      href: '/earn',
     },
     {
-      label: 'Author guidelines',
-      href: 'https://drive.google.com/file/d/1qKlGnNSA-98kg-RhmTFKYVB85X0PJWYr/view?usp=sharing',
+      label: 'About the Journal',
+      href: 'https://docs.researchhub.com/researchhub-foundation/programs-and-initiatives/researchhub-journal-rhj',
     },
   ];
 


### PR DESCRIPTION
## Overview ##

This PR updates several site links to consolidate a few links for SEO.

1. In the footer of the landing page "Get paid to peer review" now links to the Earn page,  "Author guidelines" renamed to "About the Journal" and now redirect to: https://docs.researchhub.com/researchhub-foundation/programs-and-initiatives/researchhub-journal-rhj
2. In the Earn tab "Learn More" removed the second hyperlink  and the "Peer Review Walkthrough" now links to: https://docs.researchhub.com/researchhub-foundation/programs-and-initiatives/peer-review-program/peer-review-guidelines
3. In the Journal tab on the right sidebar, updated  "Author Guidelines" to go to: https://docs.researchhub.com/researchhub-foundation/programs-and-initiatives/researchhub-journal-rhj/author-guidelines
