### PR TITLE
Add security settings

### DIFF
--- a/app/layouts/topbar/pageRoutes.tsx
+++ b/app/layouts/topbar/pageRoutes.tsx
@@ -6,7 +6,7 @@ import {
   faGrid3 as faGrid3Light,
   faMagnifyingGlass,
 } from '@fortawesome/pro-light-svg-icons';
-import { ChartNoAxesColumnIncreasing, Shield, Hash, Users, Activity } from 'lucide-react';
+import { ChartNoAxesColumnIncreasing, Shield, Hash, Users, Activity, Settings } from 'lucide-react';
 import Image from 'next/image';
 import { Icon } from '@/components/ui/icons';
 import { getTopicEmoji } from '@/components/Topic/TopicEmojis';
@@ -35,6 +35,7 @@ export const ROOT_NAVIGATION_PATHS = new Set([
   '/browse',
   '/leaderboard',
   '/lists',
+  '/settings',
 ]);
 
 export const isRootNavigationPage = (pathname: string): boolean =>
@@ -142,6 +143,13 @@ const ROUTE_RULES: RouteRule[] = [
     getInfo: () => ({
       title: 'Activity',
       icon: <Activity size={24} className="text-gray-900" />,
+    }),
+  },
+  {
+    match: (p) => p === '/settings' || p.startsWith('/settings/'),
+    getInfo: () => ({
+      title: 'Settings',
+      icon: <Settings size={24} className="text-gray-900" />,
     }),
   },
   {

--- a/app/settings/components/SecuritySection.tsx
+++ b/app/settings/components/SecuritySection.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react';
 import { AuthService } from '@/services/auth.service';
 import type { MfaStatusApiResponse } from '@/services/types';
 import { formatDate } from '@/utils/date';
+import { Badge } from '@/components/ui/Badge';
 
 export function SecuritySection() {
   const [status, setStatus] = useState<MfaStatusApiResponse | null>(null);
@@ -47,17 +48,17 @@ export function SecuritySection() {
       ) : error ? (
         <div className="text-sm text-red-600">{error}</div>
       ) : status?.mfa_enabled ? (
-        <div className="text-sm text-gray-700">
-          Enabled
+        <div className="flex items-center gap-2 text-sm">
+          <Badge className="border-green-700 bg-white text-green-700">Enabled</Badge>
           {status.created_at && (
-            <span className="text-gray-400"> - Registered on {formatDate(status.created_at)}</span>
+            <span className="text-gray-400">Registered on {formatDate(status.created_at)}</span>
           )}
           {status.last_used_at && (
-            <span className="text-gray-400"> | Last used on {formatDate(status.last_used_at)}</span>
+            <span className="text-gray-400">| Last used on {formatDate(status.last_used_at)}</span>
           )}
         </div>
       ) : (
-        <div className="text-sm text-gray-700">Not enabled.</div>
+        <Badge className="border-red-700 bg-white text-red-700">Not enabled</Badge>
       )}
     </section>
   );

--- a/app/settings/components/SecuritySection.tsx
+++ b/app/settings/components/SecuritySection.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { AuthService } from '@/services/auth.service';
+import type { MfaStatusApiResponse } from '@/services/types';
+import { formatDate } from '@/utils/date';
+
+export function SecuritySection() {
+  const [status, setStatus] = useState<MfaStatusApiResponse | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const data = await AuthService.getMfaStatus();
+        if (!cancelled) {
+          setStatus(data);
+        }
+      } catch {
+        if (!cancelled) {
+          setError('Failed to load security settings');
+        }
+      } finally {
+        if (!cancelled) {
+          setIsLoading(false);
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return (
+    <section className="rounded-lg border border-gray-200 bg-white p-6">
+      <header className="mb-4">
+        <h2 className="text-lg font-semibold text-gray-900">Two-factor authentication</h2>
+        <p className="text-sm text-gray-500">
+          Add an extra layer of security by requiring a one-time code at sign-in.
+        </p>
+      </header>
+
+      {isLoading ? (
+        <div className="text-sm text-gray-500">Loading...</div>
+      ) : error ? (
+        <div className="text-sm text-red-600">{error}</div>
+      ) : status?.mfa_enabled ? (
+        <div className="text-sm text-gray-700">
+          Enabled
+          {status.created_at && (
+            <span className="text-gray-400"> - Registered on {formatDate(status.created_at)}</span>
+          )}
+          {status.last_used_at && (
+            <span className="text-gray-400"> | Last used on {formatDate(status.last_used_at)}</span>
+          )}
+        </div>
+      ) : (
+        <div className="text-sm text-gray-700">Not enabled.</div>
+      )}
+    </section>
+  );
+}

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -1,0 +1,14 @@
+'use client';
+
+import { PageLayout } from '@/app/layouts/PageLayout';
+import { SecuritySection } from './components/SecuritySection';
+
+export default function SettingsPage() {
+  return (
+    <PageLayout rightSidebar={false}>
+      <div className="max-w-3xl mx-auto">
+        <SecuritySection />
+      </div>
+    </PageLayout>
+  );
+}

--- a/components/menus/UserMenu.tsx
+++ b/components/menus/UserMenu.tsx
@@ -1,6 +1,15 @@
 'use client';
 
-import { User as UserIcon, LogOut, BadgeCheck, Bell, Shield, UserPlus, Search } from 'lucide-react';
+import {
+  User as UserIcon,
+  LogOut,
+  BadgeCheck,
+  Bell,
+  Shield,
+  UserPlus,
+  Search,
+  Settings,
+} from 'lucide-react';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faBookmark } from '@fortawesome/free-regular-svg-icons';
 import { faPen } from '@fortawesome/free-solid-svg-icons';
@@ -13,6 +22,7 @@ import { VerifiedBadge } from '@/components/ui/VerifiedBadge';
 import { SwipeableDrawer } from '@/components/ui/SwipeableDrawer';
 import { ResearchCoinIcon } from '@/components/ui/icons/ResearchCoinIcon';
 import Link from 'next/link';
+import { useSearchParams } from 'next/navigation';
 import { AuthSharingService } from '@/services/auth-sharing.service';
 import { navigateToAuthorProfile } from '@/utils/navigation';
 import { Button } from '@/components/ui/Button';
@@ -41,6 +51,8 @@ export default function UserMenu({
   const [internalMenuOpen, setInternalMenuOpen] = useState(false);
   const [isMobile, setIsMobile] = useState(false);
   const { openVerificationModal } = useVerification();
+  const searchParams = useSearchParams();
+  const showSettingsLink = searchParams?.has('security') ?? false;
   // Use controlled or uncontrolled menu state
   const menuOpenState = isMenuOpen !== undefined ? isMenuOpen : internalMenuOpen;
   const setMenuOpenState = (open: boolean) => {
@@ -226,6 +238,17 @@ export default function UserMenu({
             </div>
           </div>
         </Link>
+
+        {showSettingsLink && (
+          <Link href="/settings" className="block" onClick={() => setMenuOpenState(false)}>
+            <div className="px-6 py-2 hover:bg-gray-50">
+              <div className="flex items-center">
+                <Settings className="h-5 w-5 mr-3 text-gray-500" />
+                <span className="text-sm text-gray-700">Settings</span>
+              </div>
+            </div>
+          </Link>
+        )}
 
         {!user.isVerified && (
           <div
@@ -414,6 +437,17 @@ export default function UserMenu({
                 </div>
               </div>
             </Link>
+
+            {showSettingsLink && (
+              <Link href="/settings" className="block" onClick={() => setMenuOpenState(false)}>
+                <div className="w-full px-4 py-2 hover:bg-gray-50">
+                  <div className="flex items-center">
+                    <Settings className="h-5 w-5 mr-3 text-gray-500" />
+                    <span className="text-sm text-gray-700">Settings</span>
+                  </div>
+                </div>
+              </Link>
+            )}
 
             {!user.isVerified && (
               <BaseMenuItem onClick={() => openVerificationModal()} className="w-full px-4 py-2">

--- a/components/menus/UserMenu.tsx
+++ b/components/menus/UserMenu.tsx
@@ -52,7 +52,7 @@ export default function UserMenu({
   const [isMobile, setIsMobile] = useState(false);
   const { openVerificationModal } = useVerification();
   const searchParams = useSearchParams();
-  const showSettingsLink = searchParams?.has('security') ?? false;
+  const showSettingsLink = searchParams?.has('ff-settings') ?? false;
   // Use controlled or uncontrolled menu state
   const menuOpenState = isMenuOpen !== undefined ? isMenuOpen : internalMenuOpen;
   const setMenuOpenState = (open: boolean) => {


### PR DESCRIPTION
- Adds a new settings user menu entry (behind `ff-settings` querystring-based feature flag).
- Add a new settings page and component initially showing the user's MFA settings.

When enabled:
<img width="1160" height="288" alt="image" src="https://github.com/user-attachments/assets/6ef4c621-2580-435a-a69a-b4fbabd0fb2c" />

When not enabled:
<img width="1150" height="244" alt="image" src="https://github.com/user-attachments/assets/0ff011a4-3caa-4782-a952-7017164da8ae" />
