### PR TITLE
Add modal for enabling MFA

### DIFF
--- a/app/settings/components/EnableMfaModal.tsx
+++ b/app/settings/components/EnableMfaModal.tsx
@@ -54,7 +54,7 @@ export function EnableMfaModal({ isOpen, onClose, onSuccess }: EnableMfaModalPro
     };
   }, [isOpen]);
 
-  const handleVerify = async (e: React.FormEvent) => {
+  const handleVerify = async (e: React.SyntheticEvent<HTMLFormElement>) => {
     e.preventDefault();
     if (!setupData) return;
 

--- a/app/settings/components/EnableMfaModal.tsx
+++ b/app/settings/components/EnableMfaModal.tsx
@@ -18,7 +18,7 @@ interface EnableMfaModalProps {
 
 type Step = 'setup' | 'recovery';
 
-export function EnableMfaModal({ isOpen, onClose, onSuccess }: EnableMfaModalProps) {
+export function EnableMfaModal({ isOpen, onClose, onSuccess }: Readonly<EnableMfaModalProps>) {
   const [step, setStep] = useState<Step>('setup');
   const [setupData, setSetupData] = useState<MfaTotpActivateInitApiResponse | null>(null);
   const [code, setCode] = useState('');

--- a/app/settings/components/EnableMfaModal.tsx
+++ b/app/settings/components/EnableMfaModal.tsx
@@ -1,0 +1,195 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Copy } from 'lucide-react';
+import { QRCodeSVG } from 'qrcode.react';
+import { toast } from 'react-hot-toast';
+import { BaseModal } from '@/components/ui/BaseModal';
+import { Button } from '@/components/ui/Button';
+import { AuthService } from '@/services/auth.service';
+import { ApiError } from '@/services/types/api';
+import type { MfaTotpActivateInitApiResponse } from '@/services/types';
+
+interface EnableMfaModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSuccess: () => void;
+}
+
+type Step = 'setup' | 'recovery';
+
+export function EnableMfaModal({ isOpen, onClose, onSuccess }: EnableMfaModalProps) {
+  const [step, setStep] = useState<Step>('setup');
+  const [setupData, setSetupData] = useState<MfaTotpActivateInitApiResponse | null>(null);
+  const [code, setCode] = useState('');
+  const [recoveryCodes, setRecoveryCodes] = useState<string[]>([]);
+  const [isInitLoading, setIsInitLoading] = useState(false);
+  const [isVerifying, setIsVerifying] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!isOpen) {
+      setStep('setup');
+      setSetupData(null);
+      setCode('');
+      setRecoveryCodes([]);
+      setError(null);
+      return;
+    }
+
+    let cancelled = false;
+    setIsInitLoading(true);
+    (async () => {
+      try {
+        const data = await AuthService.initMfaSetup();
+        if (!cancelled) setSetupData(data);
+      } catch {
+        if (!cancelled) setError('Failed to start MFA setup. Please try again.');
+      } finally {
+        if (!cancelled) setIsInitLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [isOpen]);
+
+  const handleVerify = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!setupData) return;
+
+    const trimmedCode = code.trim();
+    if (!trimmedCode) {
+      setError('Enter the 6-digit code from your authenticator app');
+      return;
+    }
+
+    setIsVerifying(true);
+    setError(null);
+    try {
+      const response = await AuthService.activateMfa({
+        activation_token: setupData.activation_token,
+        code: trimmedCode,
+      });
+      setRecoveryCodes(response.recovery_codes);
+      setStep('recovery');
+    } catch (err) {
+      if (err instanceof ApiError) {
+        const errorValues = Object.values(err.errors as Record<string, string[]>)?.[0];
+        setError(Array.isArray(errorValues) ? errorValues[0] : err.message || 'Invalid code');
+      } else {
+        setError('Verification failed');
+      }
+    } finally {
+      setIsVerifying(false);
+    }
+  };
+
+  const handleDone = () => {
+    onSuccess();
+    onClose();
+  };
+
+  const copyRecoveryCodes = async () => {
+    try {
+      await navigator.clipboard.writeText(recoveryCodes.join('\n'));
+      toast.success('Recovery codes copied to clipboard');
+    } catch {
+      toast.error('Failed to copy');
+    }
+  };
+
+  return (
+    <BaseModal
+      isOpen={isOpen}
+      onClose={onClose}
+      title={step === 'setup' ? 'Enable two-factor authentication' : 'Save your recovery codes'}
+      size="md"
+      footer={
+        step === 'setup' ? (
+          <Button
+            type="submit"
+            form="enable-mfa-form"
+            disabled={isVerifying || isInitLoading || !setupData}
+            className="w-full"
+          >
+            {isVerifying ? 'Verifying…' : 'Verify and enable'}
+          </Button>
+        ) : (
+          <Button onClick={handleDone} className="w-full">
+            Done
+          </Button>
+        )
+      }
+    >
+      {step === 'setup' ? (
+        <form id="enable-mfa-form" onSubmit={handleVerify} className="space-y-4">
+          <p className="text-sm text-gray-600">
+            Use an authenticator app to scan the QR code, then enter the 6-digit code below.
+          </p>
+
+          <div className="flex justify-center py-2">
+            {isInitLoading ? (
+              <div className="h-[192px] w-[192px] bg-gray-100 rounded animate-pulse" />
+            ) : setupData ? (
+              <div className="p-3 bg-white border border-gray-200 rounded">
+                <QRCodeSVG value={setupData.totp_url} size={192} />
+              </div>
+            ) : null}
+          </div>
+
+          {setupData && (
+            <div className="text-xs text-gray-500 text-center">
+              Can't scan? You can use this setup key to manually configure your authenticator app:{' '}
+              <span className="font-mono text-gray-700 break-all">{setupData.secret}</span>
+            </div>
+          )}
+
+          <div>
+            <label htmlFor="mfa-code" className="block text-sm font-medium text-gray-700 mb-1">
+              Verify code from the authenticator app
+            </label>
+            <input
+              id="mfa-code"
+              type="text"
+              value={code}
+              onChange={(e) => setCode(e.target.value)}
+              placeholder="123456"
+              className="w-full p-3 border rounded"
+              autoComplete="one-time-code"
+              inputMode="numeric"
+              autoFocus
+            />
+          </div>
+
+          {error && <div className="p-3 bg-red-50 text-red-700 rounded-lg text-sm">{error}</div>}
+        </form>
+      ) : (
+        <div className="space-y-4">
+          <div className="p-3 bg-yellow-50 border border-yellow-200 text-yellow-900 rounded-lg text-sm">
+            Save these recovery codes in a safe place. Each code can be used once to sign in if you
+            lose access to your authenticator app. You won't be able to see them again.
+          </div>
+
+          <div className="relative bg-gray-50 border border-gray-200 rounded p-4 font-mono text-sm">
+            <button
+              type="button"
+              onClick={copyRecoveryCodes}
+              className="absolute top-2 right-2 p-1.5 text-gray-400 hover:text-gray-600 hover:bg-gray-200 rounded transition-colors"
+              aria-label="Copy recovery codes"
+            >
+              <Copy className="h-4 w-4" />
+            </button>
+            <div className="grid grid-cols-2 gap-2 pr-8">
+              {recoveryCodes.map((rc) => (
+                <div key={rc} className="text-gray-800">
+                  {rc}
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      )}
+    </BaseModal>
+  );
+}

--- a/app/settings/components/EnableMfaModal.tsx
+++ b/app/settings/components/EnableMfaModal.tsx
@@ -155,6 +155,7 @@ export function EnableMfaModal({ isOpen, onClose, onSuccess }: EnableMfaModalPro
               value={code}
               onChange={(e) => setCode(e.target.value)}
               placeholder="123456"
+              maxLength={6}
               className="w-full p-3 border rounded"
               autoComplete="one-time-code"
               inputMode="numeric"

--- a/app/settings/components/SecuritySection.tsx
+++ b/app/settings/components/SecuritySection.tsx
@@ -1,46 +1,47 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { AuthService } from '@/services/auth.service';
 import type { MfaStatusApiResponse } from '@/services/types';
 import { formatDate } from '@/utils/date';
 import { Badge } from '@/components/ui/Badge';
+import { Button } from '@/components/ui/Button';
+import { EnableMfaModal } from './EnableMfaModal';
 
 export function SecuritySection() {
   const [status, setStatus] = useState<MfaStatusApiResponse | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [isEnableOpen, setIsEnableOpen] = useState(false);
+
+  const fetchStatus = useCallback(async () => {
+    try {
+      const data = await AuthService.getMfaStatus();
+      setStatus(data);
+      setError(null);
+    } catch {
+      setError('Failed to load security settings');
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
 
   useEffect(() => {
-    let cancelled = false;
-    (async () => {
-      try {
-        const data = await AuthService.getMfaStatus();
-        if (!cancelled) {
-          setStatus(data);
-        }
-      } catch {
-        if (!cancelled) {
-          setError('Failed to load security settings');
-        }
-      } finally {
-        if (!cancelled) {
-          setIsLoading(false);
-        }
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, []);
+    fetchStatus();
+  }, [fetchStatus]);
 
   return (
     <section className="rounded-lg border border-gray-200 bg-white p-6">
-      <header className="mb-4">
-        <h2 className="text-lg font-semibold text-gray-900">Two-factor authentication</h2>
-        <p className="text-sm text-gray-500">
-          Add an extra layer of security by requiring a one-time code at sign-in.
-        </p>
+      <header className="mb-4 flex items-start justify-between gap-4">
+        <div>
+          <h2 className="text-lg font-semibold text-gray-900">Two-factor authentication</h2>
+          <p className="text-sm text-gray-500">
+            Add an extra layer of security by requiring a one-time code at sign-in.
+          </p>
+        </div>
+        {!isLoading && !error && !status?.mfa_enabled && (
+          <Button onClick={() => setIsEnableOpen(true)}>Enable</Button>
+        )}
       </header>
 
       {isLoading ? (
@@ -60,6 +61,12 @@ export function SecuritySection() {
       ) : (
         <Badge className="border-red-700 bg-white text-red-700">Not enabled</Badge>
       )}
+
+      <EnableMfaModal
+        isOpen={isEnableOpen}
+        onClose={() => setIsEnableOpen(false)}
+        onSuccess={fetchStatus}
+      />
     </section>
   );
 }


### PR DESCRIPTION
This adds a modal for showing the QR code for MFA setup with a text box for code verification. It also adds a screen that shows the recovery codes after successful activation.

Add "Enable" button if MFA is not set up yet:
<img width="1159" height="267" alt="image" src="https://github.com/user-attachments/assets/8dadb190-f051-461d-b761-afef2fde1407" />

Show QR code and add for verification code to enable MFA:
<img width="470" height="642" alt="image" src="https://github.com/user-attachments/assets/b034b19c-bc7e-40e4-9c2c-9687d254310e" />

Show recovery codes after successful activation:
<img width="475" height="483" alt="image" src="https://github.com/user-attachments/assets/72444373-a306-4e0f-a9da-acd60d85ba51" />
