### PR TITLE
Update security settings and MFA modals design

### DIFF
--- a/app/settings/components/DisableMfaModal.tsx
+++ b/app/settings/components/DisableMfaModal.tsx
@@ -100,7 +100,7 @@ export function DisableMfaModal({ isOpen, onClose, onSuccess }: Readonly<Disable
             onChange={(e) => setCode(e.target.value)}
             placeholder="123456"
             maxLength={6}
-            className="w-full p-3 border rounded"
+            className="w-full p-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500 outline-none transition-colors"
             autoComplete="one-time-code"
             inputMode="numeric"
             autoFocus

--- a/app/settings/components/DisableMfaModal.tsx
+++ b/app/settings/components/DisableMfaModal.tsx
@@ -77,10 +77,10 @@ export function DisableMfaModal({ isOpen, onClose, onSuccess }: Readonly<Disable
             className="flex-1"
           >
             {isSubmitting ? (
-              <>
+              <span className="flex items-center gap-2">
                 <Loader2 className="h-4 w-4 animate-spin" />
                 Disabling...
-              </>
+              </span>
             ) : (
               'Disable'
             )}

--- a/app/settings/components/DisableMfaModal.tsx
+++ b/app/settings/components/DisableMfaModal.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import { ShieldOff } from 'lucide-react';
+import { Loader2, ShieldOff } from 'lucide-react';
 import { BaseModal } from '@/components/ui/BaseModal';
 import { Button } from '@/components/ui/Button';
 import { AuthService } from '@/services/auth.service';
@@ -76,7 +76,14 @@ export function DisableMfaModal({ isOpen, onClose, onSuccess }: Readonly<Disable
             variant="destructive"
             className="flex-1"
           >
-            {isSubmitting ? 'Disabling…' : 'Disable'}
+            {isSubmitting ? (
+              <>
+                <Loader2 className="h-4 w-4 animate-spin" />
+                Disabling...
+              </>
+            ) : (
+              'Disable'
+            )}
           </Button>
         </div>
       }

--- a/app/settings/components/EnableMfaModal.tsx
+++ b/app/settings/components/EnableMfaModal.tsx
@@ -126,10 +126,10 @@ export function EnableMfaModal({ isOpen, onClose, onSuccess }: Readonly<EnableMf
             className="w-full"
           >
             {isVerifying ? (
-              <>
+              <span className="flex items-center gap-2">
                 <Loader2 className="h-4 w-4 animate-spin" />
                 Verifying...
-              </>
+              </span>
             ) : (
               'Verify and enable'
             )}
@@ -149,9 +149,9 @@ export function EnableMfaModal({ isOpen, onClose, onSuccess }: Readonly<EnableMf
 
           <div className="flex justify-center py-2">
             {isInitLoading ? (
-              <div className="h-[192px] w-[192px] bg-gray-100 rounded animate-pulse" />
+              <div className="h-[192px] w-[192px] bg-gray-100 rounded-lg animate-pulse" />
             ) : setupData ? (
-              <div className="p-3 bg-white border border-gray-200 rounded">
+              <div className="p-3 bg-white border border-gray-200 rounded-lg shadow-sm">
                 <QRCodeSVG value={setupData.totp_url} size={192} />
               </div>
             ) : null}
@@ -219,7 +219,7 @@ export function EnableMfaModal({ isOpen, onClose, onSuccess }: Readonly<EnableMf
             lose access to your authenticator app. You won't be able to see them again.
           </div>
 
-          <div className="relative bg-gray-50 border border-gray-200 rounded p-4 font-mono text-sm">
+          <div className="relative bg-gray-50 border border-gray-200 rounded-lg p-4 font-mono text-sm">
             <button
               type="button"
               onClick={copyRecoveryCodes}

--- a/app/settings/components/EnableMfaModal.tsx
+++ b/app/settings/components/EnableMfaModal.tsx
@@ -196,7 +196,7 @@ export function EnableMfaModal({ isOpen, onClose, onSuccess }: Readonly<EnableMf
               onChange={(e) => setCode(e.target.value)}
               placeholder="123456"
               maxLength={6}
-              className="w-full p-3 border rounded"
+              className="w-full p-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500 outline-none transition-colors"
               autoComplete="one-time-code"
               inputMode="numeric"
               autoFocus

--- a/app/settings/components/EnableMfaModal.tsx
+++ b/app/settings/components/EnableMfaModal.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import { ChevronDown, ChevronRight, Copy, Loader2 } from 'lucide-react';
+import { Copy, Loader2 } from 'lucide-react';
 import { QRCodeSVG } from 'qrcode.react';
 import { toast } from 'react-hot-toast';
 import { BaseModal } from '@/components/ui/BaseModal';
@@ -162,13 +162,8 @@ export function EnableMfaModal({ isOpen, onClose, onSuccess }: Readonly<EnableMf
               <button
                 type="button"
                 onClick={() => setShowSecret(!showSecret)}
-                className="inline-flex items-center gap-1 text-sm text-blue-600 hover:text-blue-800 hover:underline transition-colors"
+                className="text-sm text-blue-600 hover:text-blue-800 hover:underline transition-colors"
               >
-                {showSecret ? (
-                  <ChevronDown className="h-4 w-4" />
-                ) : (
-                  <ChevronRight className="h-4 w-4" />
-                )}
                 Can't scan the QR code?
               </button>
               {showSecret && (

--- a/app/settings/components/EnableMfaModal.tsx
+++ b/app/settings/components/EnableMfaModal.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import { Copy } from 'lucide-react';
+import { ChevronDown, ChevronRight, Copy } from 'lucide-react';
 import { QRCodeSVG } from 'qrcode.react';
 import { toast } from 'react-hot-toast';
 import { BaseModal } from '@/components/ui/BaseModal';
@@ -26,6 +26,7 @@ export function EnableMfaModal({ isOpen, onClose, onSuccess }: Readonly<EnableMf
   const [isInitLoading, setIsInitLoading] = useState(false);
   const [isVerifying, setIsVerifying] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [showSecret, setShowSecret] = useState(false);
 
   useEffect(() => {
     if (!isOpen) {
@@ -34,6 +35,7 @@ export function EnableMfaModal({ isOpen, onClose, onSuccess }: Readonly<EnableMf
       setCode('');
       setRecoveryCodes([]);
       setError(null);
+      setShowSecret(false);
       return;
     }
 
@@ -99,6 +101,16 @@ export function EnableMfaModal({ isOpen, onClose, onSuccess }: Readonly<EnableMf
     }
   };
 
+  const copySecret = async () => {
+    if (!setupData?.secret) return;
+    try {
+      await navigator.clipboard.writeText(setupData.secret);
+      toast.success('Setup key copied to clipboard');
+    } catch {
+      toast.error('Failed to copy');
+    }
+  };
+
   return (
     <BaseModal
       isOpen={isOpen}
@@ -139,9 +151,37 @@ export function EnableMfaModal({ isOpen, onClose, onSuccess }: Readonly<EnableMf
           </div>
 
           {setupData && (
-            <div className="text-xs text-gray-500 text-center">
-              Can't scan? You can use this setup key to manually configure your authenticator app:{' '}
-              <span className="font-mono text-gray-700 break-all">{setupData.secret}</span>
+            <div className="text-center">
+              <button
+                type="button"
+                onClick={() => setShowSecret(!showSecret)}
+                className="inline-flex items-center gap-1 text-sm text-blue-600 hover:text-blue-800 hover:underline transition-colors"
+              >
+                {showSecret ? (
+                  <ChevronDown className="h-4 w-4" />
+                ) : (
+                  <ChevronRight className="h-4 w-4" />
+                )}
+                Can't scan the QR code?
+              </button>
+              {showSecret && (
+                <div className="mt-2 space-y-2">
+                  <p className="text-xs text-gray-500">
+                    Use this setup key to manually configure your authenticator app:
+                  </p>
+                  <div className="inline-flex items-center gap-2 bg-gray-50 border border-gray-200 rounded-lg px-3 py-2">
+                    <span className="font-mono text-sm text-gray-800">{setupData.secret}</span>
+                    <button
+                      type="button"
+                      onClick={copySecret}
+                      className="p-1 text-gray-400 hover:text-gray-600 hover:bg-gray-200 rounded transition-colors"
+                      aria-label="Copy setup key"
+                    >
+                      <Copy className="h-3.5 w-3.5" />
+                    </button>
+                  </div>
+                </div>
+              )}
             </div>
           )}
 

--- a/app/settings/components/EnableMfaModal.tsx
+++ b/app/settings/components/EnableMfaModal.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import { ChevronDown, ChevronRight, Copy } from 'lucide-react';
+import { ChevronDown, ChevronRight, Copy, Loader2 } from 'lucide-react';
 import { QRCodeSVG } from 'qrcode.react';
 import { toast } from 'react-hot-toast';
 import { BaseModal } from '@/components/ui/BaseModal';
@@ -125,7 +125,14 @@ export function EnableMfaModal({ isOpen, onClose, onSuccess }: Readonly<EnableMf
             disabled={isVerifying || isInitLoading || !setupData}
             className="w-full"
           >
-            {isVerifying ? 'Verifying…' : 'Verify and enable'}
+            {isVerifying ? (
+              <>
+                <Loader2 className="h-4 w-4 animate-spin" />
+                Verifying...
+              </>
+            ) : (
+              'Verify and enable'
+            )}
           </Button>
         ) : (
           <Button onClick={handleDone} className="w-full">

--- a/app/settings/components/SecuritySection.tsx
+++ b/app/settings/components/SecuritySection.tsx
@@ -61,7 +61,10 @@ export function SecuritySection() {
         </div>
 
         {isLoading ? (
-          <div className="text-sm text-gray-500">Loading...</div>
+          <div className="flex items-center gap-2">
+            <div className="h-5 w-16 animate-pulse rounded-full bg-gray-200" />
+            <div className="h-4 w-32 animate-pulse rounded bg-gray-200" />
+          </div>
         ) : error ? (
           <div className="text-sm text-red-600">{error}</div>
         ) : status?.mfa_enabled ? (

--- a/app/settings/components/SecuritySection.tsx
+++ b/app/settings/components/SecuritySection.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useCallback, useEffect, useState } from 'react';
+import { Shield } from 'lucide-react';
 import { AuthService } from '@/services/auth.service';
 import type { MfaStatusApiResponse } from '@/services/types';
 import { formatDate } from '@/utils/date';
@@ -35,7 +36,10 @@ export function SecuritySection() {
   return (
     <section className="rounded-lg border border-gray-200 bg-white">
       <header className="rounded-t-lg border-b border-gray-200 bg-gray-50 px-6 py-4">
-        <h2 className="text-lg font-semibold text-gray-900">Security</h2>
+        <h2 className="flex items-center gap-2 text-lg font-semibold text-gray-900">
+          <Shield className="h-5 w-5" />
+          Security
+        </h2>
       </header>
 
       <div className="p-6">

--- a/app/settings/components/SecuritySection.tsx
+++ b/app/settings/components/SecuritySection.tsx
@@ -33,41 +33,49 @@ export function SecuritySection() {
   }, [fetchStatus]);
 
   return (
-    <section className="rounded-lg border border-gray-200 bg-white p-6">
-      <header className="mb-4 flex items-start justify-between gap-4">
-        <div>
-          <h2 className="text-lg font-semibold text-gray-900">Two-factor authentication</h2>
-          <p className="text-sm text-gray-500">
-            Add an extra layer of security by requiring a one-time code at sign-in.
-          </p>
-        </div>
-        {!isLoading && !error && !status?.mfa_enabled && (
-          <Button onClick={() => setIsEnableOpen(true)}>Enable</Button>
-        )}
-        {!isLoading && !error && status?.mfa_enabled && (
-          <Button variant="outlined" onClick={() => setIsDisableOpen(true)}>
-            Disable
-          </Button>
-        )}
+    <section className="rounded-lg border border-gray-200 bg-white">
+      <header className="rounded-t-lg border-b border-gray-200 bg-gray-50 px-6 py-4">
+        <h2 className="text-lg font-semibold text-gray-900">Security</h2>
       </header>
 
-      {isLoading ? (
-        <div className="text-sm text-gray-500">Loading...</div>
-      ) : error ? (
-        <div className="text-sm text-red-600">{error}</div>
-      ) : status?.mfa_enabled ? (
-        <div className="flex items-center gap-2 text-sm">
-          <Badge className="border-green-700 bg-white text-green-700">Enabled</Badge>
-          {status.created_at && (
-            <span className="text-gray-400">Registered on {formatDate(status.created_at)}</span>
+      <div className="p-6">
+        <div className="mb-4 flex items-start justify-between gap-4">
+          <div>
+            <h3 className="text-base font-semibold text-gray-900">Two-factor authentication</h3>
+            <p className="text-sm text-gray-500">
+              Add an extra layer of security by requiring a one-time code at sign-in.
+            </p>
+          </div>
+          {!isLoading && !error && !status?.mfa_enabled && (
+            <Button onClick={() => setIsEnableOpen(true)}>Enable</Button>
           )}
-          {status.last_used_at && (
-            <span className="text-gray-400">| Last used on {formatDate(status.last_used_at)}</span>
+          {!isLoading && !error && status?.mfa_enabled && (
+            <Button variant="outlined" onClick={() => setIsDisableOpen(true)}>
+              Disable
+            </Button>
           )}
         </div>
-      ) : (
-        <Badge className="border-red-700 bg-white text-red-700">Not enabled</Badge>
-      )}
+
+        {isLoading ? (
+          <div className="text-sm text-gray-500">Loading...</div>
+        ) : error ? (
+          <div className="text-sm text-red-600">{error}</div>
+        ) : status?.mfa_enabled ? (
+          <div className="flex items-center gap-2 text-sm">
+            <Badge className="border-green-700 bg-white text-green-700">Enabled</Badge>
+            {status.created_at && (
+              <span className="text-gray-400">Registered on {formatDate(status.created_at)}</span>
+            )}
+            {status.last_used_at && (
+              <span className="text-gray-400">
+                | Last used on {formatDate(status.last_used_at)}
+              </span>
+            )}
+          </div>
+        ) : (
+          <Badge className="border-red-700 bg-white text-red-700">Not enabled</Badge>
+        )}
+      </div>
 
       <EnableMfaModal
         isOpen={isEnableOpen}

--- a/app/settings/components/SecuritySection.tsx
+++ b/app/settings/components/SecuritySection.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useCallback, useEffect, useState } from 'react';
-import { Shield } from 'lucide-react';
+import { ShieldCheck } from 'lucide-react';
 import { AuthService } from '@/services/auth.service';
 import type { MfaStatusApiResponse } from '@/services/types';
 import { formatDate } from '@/utils/date';
@@ -37,7 +37,7 @@ export function SecuritySection() {
     <section className="rounded-lg border border-gray-200 bg-white">
       <header className="rounded-t-lg border-b border-gray-200 bg-gray-50 px-6 py-4">
         <h2 className="flex items-center gap-2 text-lg font-semibold text-gray-900">
-          <Shield className="h-5 w-5" />
+          <ShieldCheck className="h-5 w-5" />
           Security
         </h2>
       </header>

--- a/app/settings/components/SecuritySection.tsx
+++ b/app/settings/components/SecuritySection.tsx
@@ -39,7 +39,7 @@ export function SecuritySection() {
       </header>
 
       <div className="p-6">
-        <div className="mb-4 flex items-start justify-between gap-4">
+        <div className="mb-2 flex items-start justify-between gap-4">
           <div>
             <h3 className="text-base font-semibold text-gray-900">Two-factor authentication</h3>
             <p className="text-sm text-gray-500">


### PR DESCRIPTION
No functional changes in this PR, just small design and styling changes, such as:
- Adding loading spinner and loading skeletons to settings page and MFA modals.
- Add card design with heading and icons.
- Clean up "enable" modal by hiding setup key for manual setup behind pull-down link.
- Apply consistent styling across security components.

Settings page with MFA disabled:
<img width="1106" height="304" alt="image" src="https://github.com/user-attachments/assets/a8a3ac10-9b1a-4016-94ab-7431abae0d13" />

Settings page with MFA enabled:
<img width="1083" height="295" alt="image" src="https://github.com/user-attachments/assets/5059401c-f8fb-4e4e-aeab-e067b6752ae4" />

Enable MFA:
<img width="456" height="623" alt="image" src="https://github.com/user-attachments/assets/f72868f5-8f49-4918-a4a9-238c69c8d181" />

Recovery codes:
<img width="458" height="472" alt="image" src="https://github.com/user-attachments/assets/931412c7-c662-4d23-a8df-6e678f5bf538" />

Disable MFA:
<img width="461" height="364" alt="image" src="https://github.com/user-attachments/assets/1507c016-3567-41e5-98dd-af0ece38d1d0" />
