### PR TITLE
Move MFA code challenge into separate dialog

### DIFF
--- a/components/modals/ResearchCoin/WithdrawModal.tsx
+++ b/components/modals/ResearchCoin/WithdrawModal.tsx
@@ -326,18 +326,15 @@ export function WithdrawModal({
             <div className="bg-gray-50 rounded-lg p-4 space-y-3">
               <div className="space-y-2 text-sm">
                 <div className="flex justify-between">
-                  <span className="text-gray-600">Amount:</span>
-                  <div className="flex items-center gap-1">
-                    <ResearchCoinIcon size={14} />
-                    <span className="font-medium">{formatRSC({ amount: withdrawAmount })} RSC</span>
-                  </div>
+                  <span className="text-gray-700">Amount:</span>
+                  <span className="font-medium">{formatRSC({ amount: withdrawAmount })} RSC</span>
                 </div>
                 <div className="flex justify-between">
                   <span className="text-gray-700">Network fee:</span>
                   <span className="text-gray-700">-{formatRSC({ amount: fee || 0 })} RSC</span>
                 </div>
                 <div className="flex justify-between pt-2 border-t border-gray-200">
-                  <span className="text-gray-600">You will receive:</span>
+                  <span className="text-gray-700">You will receive:</span>
                   <div className="flex items-center gap-1">
                     <ResearchCoinIcon size={14} />
                     <span className="font-semibold text-gray-900">

--- a/components/modals/ResearchCoin/WithdrawModal.tsx
+++ b/components/modals/ResearchCoin/WithdrawModal.tsx
@@ -334,7 +334,7 @@ export function WithdrawModal({
                 </div>
                 <div className="flex justify-between">
                   <span className="text-gray-700">Network fee:</span>
-                  <span className="text-gray-700">-{fee} RSC</span>
+                  <span className="text-gray-700">-{formatRSC({ amount: fee || 0 })} RSC</span>
                 </div>
                 <div className="flex justify-between pt-2 border-t border-gray-200">
                   <span className="text-gray-600">You will receive:</span>

--- a/components/modals/ResearchCoin/WithdrawModal.tsx
+++ b/components/modals/ResearchCoin/WithdrawModal.tsx
@@ -42,6 +42,7 @@ export function WithdrawModal({
   const [destinationAddress, setDestinationAddress] = useState<string>('');
   const [mfaCode, setMfaCode] = useState<string>('');
   const [isMfaEnabled, setIsMfaEnabled] = useState<boolean>(false);
+  const [showMfaConfirmation, setShowMfaConfirmation] = useState<boolean>(false);
   const contentRef = useRef<HTMLDivElement>(null);
   const [{ txStatus, isLoading, fee, isFeeLoading, feeError }, withdrawRSC, resetTransaction] =
     useWithdrawRSC({
@@ -60,6 +61,7 @@ export function WithdrawModal({
         setDestinationAddress('');
         setMfaCode('');
         setIsMfaEnabled(false);
+        setShowMfaConfirmation(false);
         resetTransaction();
       }, 300);
 
@@ -134,20 +136,19 @@ export function WithdrawModal({
     [withdrawAmount, availableBalance]
   );
 
-  // Determine if withdraw button should be disabled
-  const isButtonDisabled = useMemo(
+  // Determine if the form is valid (to proceed to either MFA confirmation or direct withdrawal)
+  const isFormValid = useMemo(
     () =>
-      !amount ||
-      withdrawAmount <= 0 ||
-      txStatus.state === 'pending' ||
-      isFeeLoading ||
-      !fee ||
-      hasInsufficientBalance ||
-      isBelowMinimum ||
-      amountUserWillReceive <= 0 ||
-      !isAddressValid ||
-      !destinationAddress ||
-      (isMfaEnabled && !mfaCode.trim()),
+      amount &&
+      withdrawAmount > 0 &&
+      txStatus.state !== 'pending' &&
+      !isFeeLoading &&
+      fee &&
+      !hasInsufficientBalance &&
+      !isBelowMinimum &&
+      amountUserWillReceive > 0 &&
+      isAddressValid &&
+      destinationAddress,
     [
       amount,
       withdrawAmount,
@@ -159,9 +160,13 @@ export function WithdrawModal({
       amountUserWillReceive,
       isAddressValid,
       destinationAddress,
-      isMfaEnabled,
-      mfaCode,
     ]
+  );
+
+  // Determine if confirm button in MFA step should be disabled
+  const isConfirmDisabled = useMemo(
+    () => !isFormValid || (isMfaEnabled && !mfaCode.trim()) || txStatus.state === 'pending',
+    [isFormValid, isMfaEnabled, mfaCode, txStatus.state]
   );
 
   const isInputDisabled = useCallback(() => {
@@ -175,7 +180,7 @@ export function WithdrawModal({
   }, [availableBalance, isInputDisabled, fee]);
 
   const handleWithdraw = useCallback(async () => {
-    if (!destinationAddress || !amount || isButtonDisabled || !fee) {
+    if (!destinationAddress || !amount || !isFormValid || !fee) {
       return;
     }
 
@@ -193,7 +198,7 @@ export function WithdrawModal({
   }, [
     destinationAddress,
     amount,
-    isButtonDisabled,
+    isFormValid,
     withdrawRSC,
     txStatus.state,
     onSuccess,
@@ -220,9 +225,49 @@ export function WithdrawModal({
       return <TransactionFooter txHash={txHash} blockExplorerUrl={blockExplorerUrl} />;
     }
 
+    // MFA confirmation step footer
+    if (showMfaConfirmation) {
+      return (
+        <TransactionFooter blockExplorerUrl={blockExplorerUrl}>
+          <div className="flex gap-3 w-full">
+            <Button
+              variant="outlined"
+              onClick={() => setShowMfaConfirmation(false)}
+              disabled={txStatus.state === 'pending'}
+              className="flex-1"
+              size="lg"
+            >
+              Back
+            </Button>
+            <Button
+              onClick={handleWithdraw}
+              disabled={isConfirmDisabled}
+              className="flex-1"
+              size="lg"
+            >
+              {txStatus.state === 'pending' ? (
+                <>
+                  <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                  Processing...
+                </>
+              ) : (
+                'Confirm Withdrawal'
+              )}
+            </Button>
+          </div>
+        </TransactionFooter>
+      );
+    }
+
+    // Main form footer
     return (
       <TransactionFooter blockExplorerUrl={blockExplorerUrl}>
-        <Button onClick={handleWithdraw} disabled={isButtonDisabled} className="w-full" size="lg">
+        <Button
+          onClick={() => (isMfaEnabled ? setShowMfaConfirmation(true) : handleWithdraw())}
+          disabled={!isFormValid}
+          className="w-full"
+          size="lg"
+        >
           {isFeeLoading || txStatus.state === 'pending' ? (
             <>
               <Loader2 className="h-4 w-4 mr-2 animate-spin" />
@@ -234,7 +279,16 @@ export function WithdrawModal({
         </Button>
       </TransactionFooter>
     );
-  }, [txStatus, blockExplorerUrl, isButtonDisabled, handleWithdraw, isFeeLoading]);
+  }, [
+    txStatus,
+    blockExplorerUrl,
+    isFormValid,
+    isConfirmDisabled,
+    handleWithdraw,
+    isFeeLoading,
+    showMfaConfirmation,
+    isMfaEnabled,
+  ]);
 
   return (
     <BaseModal
@@ -254,6 +308,73 @@ export function WithdrawModal({
             networkConfig={networkConfig}
             address={destinationAddress || ''}
           />
+        ) : showMfaConfirmation ? (
+          /* MFA Confirmation View */
+          <>
+            {txStatus.state === 'error' && (
+              <Alert variant="error">
+                <div className="space-y-1">
+                  <div className="font-medium">Withdrawal failed</div>
+                  {'message' in txStatus && txStatus.message && (
+                    <div className="text-sm font-normal opacity-90">{txStatus.message}</div>
+                  )}
+                </div>
+              </Alert>
+            )}
+
+            {/* Withdrawal Summary */}
+            <div className="bg-gray-50 rounded-lg p-4 space-y-3">
+              <h3 className="font-medium text-gray-900">Confirm Withdrawal</h3>
+              <div className="space-y-2 text-sm">
+                <div className="flex justify-between">
+                  <span className="text-gray-600">Amount</span>
+                  <div className="flex items-center gap-1">
+                    <ResearchCoinIcon size={14} />
+                    <span className="font-medium">{formatRSC({ amount: withdrawAmount })} RSC</span>
+                  </div>
+                </div>
+                <div className="flex justify-between">
+                  <span className="text-gray-600">Network fee</span>
+                  <span className="text-gray-700">-{fee} RSC</span>
+                </div>
+                <div className="flex justify-between pt-2 border-t border-gray-200">
+                  <span className="text-gray-600">You will receive</span>
+                  <div className="flex items-center gap-1">
+                    <ResearchCoinIcon size={14} />
+                    <span className="font-semibold text-gray-900">
+                      {formatRSC({ amount: amountUserWillReceive })} RSC
+                    </span>
+                  </div>
+                </div>
+              </div>
+              <div className="pt-2 border-t border-gray-200">
+                <div className="text-sm text-gray-600 mb-1">Destination</div>
+                <div className="font-mono text-xs text-gray-800 bg-white px-2 py-1.5 rounded border border-gray-200 break-all">
+                  {destinationAddress}
+                </div>
+                <div className="text-xs text-gray-500 mt-1">{networkConfig.name}</div>
+              </div>
+            </div>
+
+            {/* MFA Code Input */}
+            <div className="space-y-2">
+              <span className="text-[15px] text-gray-700">Authenticator code</span>
+              <Input
+                value={mfaCode}
+                onChange={(e) => setMfaCode(e.target.value)}
+                placeholder="123456"
+                maxLength={6}
+                inputMode="numeric"
+                disabled={txStatus.state === 'pending'}
+                autoComplete="one-time-code"
+                autoCapitalize="none"
+                autoFocus
+              />
+              <p className="text-sm text-gray-500">
+                Enter the 6-digit code from your authenticator app to confirm this withdrawal.
+              </p>
+            </div>
+          </>
         ) : (
           /* Form View */
           <>
@@ -420,26 +541,6 @@ export function WithdrawModal({
                 </div>
               </Alert>
             </div>
-
-            {/* MFA Code (if the user has MFA enabled) */}
-            {isMfaEnabled && (
-              <div className="space-y-2">
-                <span className="text-[15px] text-gray-700">Authenticator code</span>
-                <Input
-                  value={mfaCode}
-                  onChange={(e) => setMfaCode(e.target.value)}
-                  placeholder="123456"
-                  maxLength={6}
-                  inputMode="numeric"
-                  disabled={isInputDisabled()}
-                  autoComplete="one-time-code"
-                  autoCapitalize="none"
-                />
-                <p className="text-sm text-gray-500">
-                  Enter the 6-digit code from your authenticator app.
-                </p>
-              </div>
-            )}
 
             {/* Balance Display */}
             <BalanceDisplay

--- a/components/modals/ResearchCoin/WithdrawModal.tsx
+++ b/components/modals/ResearchCoin/WithdrawModal.tsx
@@ -327,18 +327,18 @@ export function WithdrawModal({
               <h3 className="font-medium text-gray-900">Confirm Withdrawal</h3>
               <div className="space-y-2 text-sm">
                 <div className="flex justify-between">
-                  <span className="text-gray-600">Amount</span>
+                  <span className="text-gray-600">Amount:</span>
                   <div className="flex items-center gap-1">
                     <ResearchCoinIcon size={14} />
                     <span className="font-medium">{formatRSC({ amount: withdrawAmount })} RSC</span>
                   </div>
                 </div>
                 <div className="flex justify-between">
-                  <span className="text-gray-600">Network fee</span>
+                  <span className="text-gray-700">Network fee:</span>
                   <span className="text-gray-700">-{fee} RSC</span>
                 </div>
                 <div className="flex justify-between pt-2 border-t border-gray-200">
-                  <span className="text-gray-600">You will receive</span>
+                  <span className="text-gray-600">You will receive:</span>
                   <div className="flex items-center gap-1">
                     <ResearchCoinIcon size={14} />
                     <span className="font-semibold text-gray-900">
@@ -347,12 +347,13 @@ export function WithdrawModal({
                   </div>
                 </div>
               </div>
-              <div className="pt-2 border-t border-gray-200">
-                <div className="text-sm text-gray-600 mb-1">Destination</div>
-                <div className="font-mono text-xs text-gray-800 bg-white px-2 py-1.5 rounded border border-gray-200 break-all">
+              <div className="pt-2 border-t border-gray-200 space-y-1">
+                <div className="text-sm text-gray-700">
+                  Destination Address ({networkConfig.name}):
+                </div>
+                <div className="font-mono text-sm text-gray-800 break-all">
                   {destinationAddress}
                 </div>
-                <div className="text-xs text-gray-500 mt-1">{networkConfig.name}</div>
               </div>
             </div>
 

--- a/components/modals/ResearchCoin/WithdrawModal.tsx
+++ b/components/modals/ResearchCoin/WithdrawModal.tsx
@@ -326,26 +326,33 @@ export function WithdrawModal({
             <div className="bg-gray-50 rounded-lg p-4 space-y-3">
               <div className="space-y-2 text-sm">
                 <div className="flex justify-between">
-                  <span className="text-gray-700">Amount:</span>
-                  <span className="font-medium">{formatRSC({ amount: withdrawAmount })} RSC</span>
+                  <span className="text-gray-700">Amount</span>
+                  <span>
+                    <span className="font-medium">{formatRSC({ amount: withdrawAmount })}</span>
+                    <span className="text-gray-500"> RSC</span>
+                  </span>
                 </div>
                 <div className="flex justify-between">
-                  <span className="text-gray-700">Network fee:</span>
-                  <span className="text-gray-700">-{formatRSC({ amount: fee || 0 })} RSC</span>
+                  <span className="text-gray-700">Network fee</span>
+                  <span>
+                    <span className="text-gray-700">-{formatRSC({ amount: fee || 0 })}</span>
+                    <span className="text-gray-500"> RSC</span>
+                  </span>
                 </div>
                 <div className="flex justify-between pt-2 border-t border-gray-200">
-                  <span className="text-gray-700">You will receive:</span>
+                  <span className="text-gray-700">You will receive</span>
                   <div className="flex items-center gap-1">
                     <ResearchCoinIcon size={14} />
                     <span className="font-semibold text-gray-900">
-                      {formatRSC({ amount: amountUserWillReceive })} RSC
+                      {formatRSC({ amount: amountUserWillReceive })}
                     </span>
+                    <span className="text-gray-500">RSC</span>
                   </div>
                 </div>
               </div>
               <div className="pt-2 border-t border-gray-200 space-y-1">
                 <div className="text-sm text-gray-700">
-                  Destination Address ({networkConfig.name}):
+                  Destination Address ({networkConfig.name})
                 </div>
                 <div className="font-mono text-sm text-gray-800 break-all">
                   {destinationAddress}
@@ -468,7 +475,7 @@ export function WithdrawModal({
                   {withdrawAmount > 0 && (fee || isFeeLoading) && (
                     <div className="mt-3 pt-3 border-t border-gray-200">
                       <div className="flex justify-between items-center">
-                        <span className="text-sm font-medium text-gray-700">You will receive:</span>
+                        <span className="text-sm font-medium text-gray-700">You will receive</span>
                         <div className="flex items-center gap-1">
                           <ResearchCoinIcon size={16} />
                           {isFeeLoading ? (

--- a/components/modals/ResearchCoin/WithdrawModal.tsx
+++ b/components/modals/ResearchCoin/WithdrawModal.tsx
@@ -3,7 +3,7 @@
 import { useCallback, useMemo, useState, useEffect, useRef } from 'react';
 import { Check, AlertCircle, Loader2, Copy } from 'lucide-react';
 import { BaseModal } from '@/components/ui/BaseModal';
-import { formatRSC } from '@/utils/number';
+import { formatRSC, getMaxDecimalPlaces } from '@/utils/number';
 import { ResearchCoinIcon } from '@/components/ui/icons/ResearchCoinIcon';
 import { useWithdrawRSC } from '@/hooks/useWithdrawRSC';
 import { cn } from '@/utils/styles';
@@ -115,6 +115,10 @@ export function WithdrawModal({
     if (!fee) return 0;
     return Math.max(0, withdrawAmount - fee);
   }, [withdrawAmount, fee]);
+
+  const summaryDecimals = useMemo(() => {
+    return getMaxDecimalPlaces(withdrawAmount, fee || 0, amountUserWillReceive);
+  }, [withdrawAmount, fee, amountUserWillReceive]);
 
   const isBelowMinimum = useMemo(
     () => withdrawAmount > 0 && withdrawAmount < MIN_WITHDRAWAL_AMOUNT,
@@ -328,23 +332,27 @@ export function WithdrawModal({
                 <div className="flex justify-between">
                   <span className="text-gray-700">Amount</span>
                   <span>
-                    <span className="font-medium">{formatRSC({ amount: withdrawAmount })}</span>
+                    <span className="font-medium">
+                      {formatRSC({ amount: withdrawAmount, decimalPlaces: summaryDecimals })}
+                    </span>
                     <span className="text-gray-500"> RSC</span>
                   </span>
                 </div>
                 <div className="flex justify-between">
                   <span className="text-gray-700">Network fee</span>
                   <span>
-                    <span className="text-gray-700">-{formatRSC({ amount: fee || 0 })}</span>
+                    <span className="text-gray-700">
+                      -{formatRSC({ amount: fee || 0, decimalPlaces: summaryDecimals })}
+                    </span>
                     <span className="text-gray-500"> RSC</span>
                   </span>
                 </div>
                 <div className="flex justify-between pt-2 border-t border-gray-200">
-                  <span className="text-gray-700">You will receive</span>
+                  <span className="font-medium text-gray-700">You will receive</span>
                   <div className="flex items-center gap-1">
                     <ResearchCoinIcon size={14} />
                     <span className="font-semibold text-gray-900">
-                      {formatRSC({ amount: amountUserWillReceive })}
+                      {formatRSC({ amount: amountUserWillReceive, decimalPlaces: summaryDecimals })}
                     </span>
                     <span className="text-gray-500">RSC</span>
                   </div>

--- a/components/modals/ResearchCoin/WithdrawModal.tsx
+++ b/components/modals/ResearchCoin/WithdrawModal.tsx
@@ -324,7 +324,6 @@ export function WithdrawModal({
 
             {/* Withdrawal Summary */}
             <div className="bg-gray-50 rounded-lg p-4 space-y-3">
-              <h3 className="font-medium text-gray-900">Confirm Withdrawal</h3>
               <div className="space-y-2 text-sm">
                 <div className="flex justify-between">
                   <span className="text-gray-600">Amount:</span>

--- a/components/modals/ResearchCoin/shared/BalanceDisplay.tsx
+++ b/components/modals/ResearchCoin/shared/BalanceDisplay.tsx
@@ -20,7 +20,7 @@ export function BalanceDisplay({
   return (
     <div className="bg-gray-50 rounded-lg p-4 border border-gray-100">
       <div className="flex items-center justify-between">
-        <span className="text-sm text-gray-600">Current Balance:</span>
+        <span className="text-sm text-gray-600">Current Balance</span>
         <div className="text-right flex items-center gap-2">
           <div className="flex items-center gap-2">
             <ResearchCoinIcon size={16} />
@@ -36,7 +36,7 @@ export function BalanceDisplay({
         <>
           <div className="my-2 border-t border-gray-200" />
           <div className="flex items-center justify-between">
-            <span className="text-sm text-gray-600">{futureBalanceLabel}:</span>
+            <span className="text-sm text-gray-600">{futureBalanceLabel}</span>
             <div className="text-right flex items-center gap-2">
               <div className="flex items-center gap-2">
                 <ResearchCoinIcon size={16} />

--- a/utils/number.ts
+++ b/utils/number.ts
@@ -77,6 +77,29 @@ export function formatRSC({
 }
 
 /**
+ * Returns the number of decimal places in a number
+ * @example
+ * getDecimalPlaces(100) // 0
+ * getDecimalPlaces(10.5) // 1
+ * getDecimalPlaces(10.25) // 2
+ */
+export function getDecimalPlaces(num: number): number {
+  const str = String(num);
+  const idx = str.indexOf('.');
+  return idx === -1 ? 0 : str.length - idx - 1;
+}
+
+/**
+ * Returns the maximum number of decimal places across multiple numbers
+ * @example
+ * getMaxDecimalPlaces(100, 10.5, 89.5) // 1
+ * getMaxDecimalPlaces(100, 10.25, 89.75) // 2
+ */
+export function getMaxDecimalPlaces(...nums: number[]): number {
+  return Math.max(...nums.map(getDecimalPlaces));
+}
+
+/**
  * Formats a transaction amount with a + or - prefix and RSC suffix
  * @param amount The amount to format
  * @returns Formatted string with RSC suffix


### PR DESCRIPTION
- Remove the MFA code from the current withdrawal dialog to leave it as-is.
- If a user has MFA enabled, advance to a new confirmation dialog (see below).

<img width="520" height="564" alt="image" src="https://github.com/user-attachments/assets/4c89a88d-f0a6-4afd-bc6b-033fd62d142c" />

