### PR TITLE
Display error status when email bounced

### DIFF
--- a/app/expert-finder/lib/generatedEmailStatus.ts
+++ b/app/expert-finder/lib/generatedEmailStatus.ts
@@ -10,6 +10,10 @@ export function isGeneratedEmailPipelineBusy(status: string): boolean {
   return status === 'processing' || status === 'sending';
 }
 
+export function isGeneratedEmailBounced(status: string): boolean {
+  return status === 'bounced';
+}
+
 export function isGeneratedEmailFailed(status: string): boolean {
   return status === 'failed' || status === 'send_failed';
 }
@@ -26,6 +30,8 @@ export function getGeneratedEmailStatusPresentation(status: string): {
   variant: GeneratedEmailStatusBadgeVariant;
 } {
   switch (status) {
+    case 'bounced':
+      return { label: 'Bounced', variant: 'error' };
     case 'draft':
       return { label: 'Draft', variant: 'primary' };
     case 'sent':

--- a/app/expert-finder/library/[searchId]/outreach/[emailId]/OutreachDetailPageContent.tsx
+++ b/app/expert-finder/library/[searchId]/outreach/[emailId]/OutreachDetailPageContent.tsx
@@ -29,11 +29,13 @@ import { SendConfirmationModal } from '@/app/expert-finder/components/SendConfir
 import { Textarea } from '@/components/ui/form/Textarea';
 import {
   getGeneratedEmailStatusPresentation,
+  isGeneratedEmailBounced,
   isGeneratedEmailClosed,
   isGeneratedEmailDraftLike,
   isGeneratedEmailFailed,
   isGeneratedEmailPipelineBusy,
 } from '@/app/expert-finder/lib/generatedEmailStatus';
+import { formatExactTime } from '@/utils/date';
 import { cn } from '@/utils/styles';
 import {
   useGeneratedEmailDetail,
@@ -370,6 +372,11 @@ export function OutreachDetailPageContent({
           <div className="hidden sm:!block">{neighborNavBar}</div>
           <div className="flex flex-wrap items-center gap-2 justify-start md:!justify-end">
             <Badge variant={statusPresentation.variant}>{statusPresentation.label}</Badge>
+            {isGeneratedEmailBounced(email.status) && email.bouncedAt && (
+              <span className="text-xs text-gray-500">
+                Bounced on {formatExactTime(email.bouncedAt)}
+              </span>
+            )}
             {isDraftLike && (
               <Button
                 variant="default"

--- a/types/expertFinder.ts
+++ b/types/expertFinder.ts
@@ -250,6 +250,7 @@ export interface GeneratedEmail {
   template: string;
   status: string;
   notes: string;
+  bouncedAt: string | null;
   createdAt: string;
   updatedAt: string;
   createdBy: CreatedByInfo | null;
@@ -276,6 +277,7 @@ export const transformGeneratedEmail = createTransformer<any, GeneratedEmail>((r
   template: raw.template ?? '',
   status: raw.status ?? 'draft',
   notes: raw.notes ?? '',
+  bouncedAt: raw.bounced_at ?? null,
   createdAt: raw.created_at ?? '',
   updatedAt: raw.updated_at ?? '',
   createdBy: transformCreatedBy(raw.created_by),


### PR DESCRIPTION
Display error status if an outreach email bounced.

In the email list:

<img width="826" height="325" alt="image" src="https://github.com/user-attachments/assets/38ca03bd-687a-4c58-9ab5-91f1d94ec971" />

In the email detail view:

<img width="818" height="427" alt="image" src="https://github.com/user-attachments/assets/cb9d2c4b-7ffa-452e-b927-6a415d70402e" />
