### PR TITLE
Show "email opened" engagement as status

### DIFF
--- a/app/expert-finder/lib/generatedEmailStatus.ts
+++ b/app/expert-finder/lib/generatedEmailStatus.ts
@@ -22,7 +22,6 @@ export type GeneratedEmailStatusBadgeVariant =
   | 'default'
   | 'primary'
   | 'success'
-  | 'successStrong'
   | 'warning'
   | 'error';
 
@@ -34,10 +33,7 @@ export function getGeneratedEmailStatusPresentation(
   variant: GeneratedEmailStatusBadgeVariant;
 } {
   if (status === 'sent' && openCount > 0) {
-    return {
-      label: openCount === 1 ? 'Opened' : `Opened ${openCount}x`,
-      variant: 'successStrong',
-    };
+    return { label: 'Opened', variant: 'success' };
   }
   switch (status) {
     case 'bounced':

--- a/app/expert-finder/lib/generatedEmailStatus.ts
+++ b/app/expert-finder/lib/generatedEmailStatus.ts
@@ -22,13 +22,23 @@ export type GeneratedEmailStatusBadgeVariant =
   | 'default'
   | 'primary'
   | 'success'
+  | 'successStrong'
   | 'warning'
   | 'error';
 
-export function getGeneratedEmailStatusPresentation(status: string): {
+export function getGeneratedEmailStatusPresentation(
+  status: string,
+  openCount: number = 0
+): {
   label: string;
   variant: GeneratedEmailStatusBadgeVariant;
 } {
+  if (status === 'sent' && openCount > 0) {
+    return {
+      label: openCount === 1 ? 'Opened' : `Opened ${openCount}x`,
+      variant: 'successStrong',
+    };
+  }
   switch (status) {
     case 'bounced':
       return { label: 'Bounced', variant: 'error' };

--- a/app/expert-finder/library/[searchId]/outreach/[emailId]/OutreachDetailPageContent.tsx
+++ b/app/expert-finder/library/[searchId]/outreach/[emailId]/OutreachDetailPageContent.tsx
@@ -268,7 +268,7 @@ export function OutreachDetailPageContent({
 
   const isClosed = isGeneratedEmailClosed(email.status);
   const isSent = email.status === 'sent';
-  const statusPresentation = getGeneratedEmailStatusPresentation(email.status);
+  const statusPresentation = getGeneratedEmailStatusPresentation(email.status, email.openCount);
   const pipelineBusy = isGeneratedEmailPipelineBusy(email.status);
   /** No overflow actions once the message is sent or retired (draft / failed / in-flight still get Preview, etc.). */
   const showOutreachMoreMenu = !isClosed && !isSent;

--- a/app/expert-finder/library/[searchId]/outreach/[emailId]/OutreachDetailPageContent.tsx
+++ b/app/expert-finder/library/[searchId]/outreach/[emailId]/OutreachDetailPageContent.tsx
@@ -377,6 +377,13 @@ export function OutreachDetailPageContent({
                 Bounced on {formatExactTime(email.bouncedAt)}
               </span>
             )}
+            {!isGeneratedEmailBounced(email.status) && email.openCount > 0 && email.openedAt && (
+              <span className="text-xs text-gray-500">
+                {email.openCount === 1
+                  ? `Opened on ${formatExactTime(email.openedAt)}`
+                  : `Opened ${email.openCount} times, first on ${formatExactTime(email.openedAt)}`}
+              </span>
+            )}
             {isDraftLike && (
               <Button
                 variant="default"

--- a/app/expert-finder/library/[searchId]/outreach/components/OutreachMobileCard.tsx
+++ b/app/expert-finder/library/[searchId]/outreach/components/OutreachMobileCard.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import type { MouseEvent } from 'react';
-import { Eye } from 'lucide-react';
 import { Badge } from '@/components/ui/Badge';
 import { Tooltip } from '@/components/ui/Tooltip';
 import { formatTimestamp } from '@/utils/date';
@@ -11,10 +10,7 @@ import {
   getTemplateDescription,
 } from '@/app/expert-finder/library/[searchId]/components/GenerateEmailModal';
 import type { GeneratedEmail } from '@/types/expertFinder';
-import {
-  getGeneratedEmailStatusPresentation,
-  isGeneratedEmailBounced,
-} from '@/app/expert-finder/lib/generatedEmailStatus';
+import { getGeneratedEmailStatusPresentation } from '@/app/expert-finder/lib/generatedEmailStatus';
 
 const SUBJECT_TRUNCATE_LENGTH = 50;
 
@@ -43,7 +39,7 @@ export function OutreachMobileCard({
   const subject = truncateSubject(email.emailSubject);
   const templateLabel = getTemplateDisplayLabel(email.template);
   const templateDescription = getTemplateDescription(email.template);
-  const statusPresentation = getGeneratedEmailStatusPresentation(email.status);
+  const statusPresentation = getGeneratedEmailStatusPresentation(email.status, email.openCount);
   const createdByName = email.createdBy?.author?.fullName;
 
   const selectTrailing =
@@ -72,12 +68,6 @@ export function OutreachMobileCard({
         <Badge variant={statusPresentation.variant} size="sm">
           {statusPresentation.label}
         </Badge>
-        {email.openCount > 0 && !isGeneratedEmailBounced(email.status) && (
-          <span className="inline-flex items-center gap-1 text-xs text-gray-500">
-            <Eye className="h-3 w-3" aria-hidden />
-            {email.openCount === 1 ? 'Opened' : `Opened ${email.openCount}x`}
-          </span>
-        )}
         {templateDescription ? (
           <Tooltip content={templateDescription} width="w-72" position="top">
             <span className="text-xs text-gray-500 truncate max-w-[140px] cursor-help underline decoration-dotted decoration-gray-400 underline-offset-1">

--- a/app/expert-finder/library/[searchId]/outreach/components/OutreachMobileCard.tsx
+++ b/app/expert-finder/library/[searchId]/outreach/components/OutreachMobileCard.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import type { MouseEvent } from 'react';
+import { Eye } from 'lucide-react';
 import { Badge } from '@/components/ui/Badge';
 import { Tooltip } from '@/components/ui/Tooltip';
 import { formatTimestamp } from '@/utils/date';
@@ -10,7 +11,10 @@ import {
   getTemplateDescription,
 } from '@/app/expert-finder/library/[searchId]/components/GenerateEmailModal';
 import type { GeneratedEmail } from '@/types/expertFinder';
-import { getGeneratedEmailStatusPresentation } from '@/app/expert-finder/lib/generatedEmailStatus';
+import {
+  getGeneratedEmailStatusPresentation,
+  isGeneratedEmailBounced,
+} from '@/app/expert-finder/lib/generatedEmailStatus';
 
 const SUBJECT_TRUNCATE_LENGTH = 50;
 
@@ -68,6 +72,12 @@ export function OutreachMobileCard({
         <Badge variant={statusPresentation.variant} size="sm">
           {statusPresentation.label}
         </Badge>
+        {email.openCount > 0 && !isGeneratedEmailBounced(email.status) && (
+          <span className="inline-flex items-center gap-1 text-xs text-gray-500">
+            <Eye className="h-3 w-3" aria-hidden />
+            {email.openCount === 1 ? 'Opened' : `Opened ${email.openCount}x`}
+          </span>
+        )}
         {templateDescription ? (
           <Tooltip content={templateDescription} width="w-72" position="top">
             <span className="text-xs text-gray-500 truncate max-w-[140px] cursor-help underline decoration-dotted decoration-gray-400 underline-offset-1">

--- a/app/expert-finder/library/[searchId]/outreach/components/OutreachTable.tsx
+++ b/app/expert-finder/library/[searchId]/outreach/components/OutreachTable.tsx
@@ -1,15 +1,30 @@
 'use client';
 
 import Link from 'next/link';
+import { Eye } from 'lucide-react';
 import { TableContainer, SortableColumn } from '@/components/ui/Table/TableContainer';
 import { Badge } from '@/components/ui/Badge';
 import { formatTimestamp } from '@/utils/date';
 import type { GeneratedEmail } from '@/types/expertFinder';
-import { getGeneratedEmailStatusPresentation } from '@/app/expert-finder/lib/generatedEmailStatus';
+import {
+  getGeneratedEmailStatusPresentation,
+  isGeneratedEmailBounced,
+} from '@/app/expert-finder/lib/generatedEmailStatus';
 
-function statusBadge(email: GeneratedEmail) {
+function statusCell(email: GeneratedEmail) {
   const { label, variant } = getGeneratedEmailStatusPresentation(email.status);
-  return <Badge variant={variant}>{label}</Badge>;
+  const showOpened = email.openCount > 0 && !isGeneratedEmailBounced(email.status);
+  return (
+    <div className="flex flex-col items-start gap-1">
+      <Badge variant={variant}>{label}</Badge>
+      {showOpened && (
+        <span className="inline-flex items-center gap-1 text-xs text-gray-500">
+          <Eye className="h-3 w-3" aria-hidden />
+          {email.openCount === 1 ? 'Opened' : `Opened ${email.openCount}x`}
+        </span>
+      )}
+    </div>
+  );
 }
 
 const SUBJECT_TRUNCATE_LENGTH = 50;
@@ -103,7 +118,7 @@ export function OutreachTable({
         </Link>
       ),
       expertName: email.expertName || '—',
-      status: statusBadge(email),
+      status: statusCell(email),
       createdBy: email.createdBy?.author?.fullName ?? '—',
       createdAt: formatTimestamp(email.createdAt, false),
     };

--- a/app/expert-finder/library/[searchId]/outreach/components/OutreachTable.tsx
+++ b/app/expert-finder/library/[searchId]/outreach/components/OutreachTable.tsx
@@ -1,30 +1,15 @@
 'use client';
 
 import Link from 'next/link';
-import { Eye } from 'lucide-react';
 import { TableContainer, SortableColumn } from '@/components/ui/Table/TableContainer';
 import { Badge } from '@/components/ui/Badge';
 import { formatTimestamp } from '@/utils/date';
 import type { GeneratedEmail } from '@/types/expertFinder';
-import {
-  getGeneratedEmailStatusPresentation,
-  isGeneratedEmailBounced,
-} from '@/app/expert-finder/lib/generatedEmailStatus';
+import { getGeneratedEmailStatusPresentation } from '@/app/expert-finder/lib/generatedEmailStatus';
 
 function statusCell(email: GeneratedEmail) {
-  const { label, variant } = getGeneratedEmailStatusPresentation(email.status);
-  const showOpened = email.openCount > 0 && !isGeneratedEmailBounced(email.status);
-  return (
-    <div className="flex flex-col items-start gap-1">
-      <Badge variant={variant}>{label}</Badge>
-      {showOpened && (
-        <span className="inline-flex items-center gap-1 text-xs text-gray-500">
-          <Eye className="h-3 w-3" aria-hidden />
-          {email.openCount === 1 ? 'Opened' : `Opened ${email.openCount}x`}
-        </span>
-      )}
-    </div>
-  );
+  const { label, variant } = getGeneratedEmailStatusPresentation(email.status, email.openCount);
+  return <Badge variant={variant}>{label}</Badge>;
 }
 
 const SUBJECT_TRUNCATE_LENGTH = 50;

--- a/types/expertFinder.ts
+++ b/types/expertFinder.ts
@@ -251,6 +251,8 @@ export interface GeneratedEmail {
   status: string;
   notes: string;
   bouncedAt: string | null;
+  openedAt: string | null;
+  openCount: number;
   createdAt: string;
   updatedAt: string;
   createdBy: CreatedByInfo | null;
@@ -278,6 +280,8 @@ export const transformGeneratedEmail = createTransformer<any, GeneratedEmail>((r
   status: raw.status ?? 'draft',
   notes: raw.notes ?? '',
   bouncedAt: raw.bounced_at ?? null,
+  openedAt: raw.opened_at ?? null,
+  openCount: raw.open_count ?? 0,
   createdAt: raw.created_at ?? '',
   updatedAt: raw.updated_at ?? '',
   createdBy: transformCreatedBy(raw.created_by),


### PR DESCRIPTION
Display the email opened engagement as a status in the outreach screens.

In the email list:
<img width="828" height="285" alt="image" src="https://github.com/user-attachments/assets/9d71916c-7c4b-434a-9a87-3dc388633106" />

In the email detail view:
<img width="825" height="427" alt="image" src="https://github.com/user-attachments/assets/e5c90408-f2fc-4e4b-a8e5-e87741c13b1d" />
