### PR TITLE
[activity sidebar]: label bounties, link contributions, and route comments to correct tab

### DIFF
--- a/components/Funding/ActivityCard.tsx
+++ b/components/Funding/ActivityCard.tsx
@@ -42,11 +42,13 @@ const CONTENT_TYPE_MAP: Record<string, ContentType> = {
 
 function getActionLabel(entry: FeedEntry): string {
   if (entry.contentType === 'COMMENT') {
-    const comment = (entry.content as FeedCommentContent).comment;
-    return COMMENT_ACTION_LABELS[comment?.commentType] || 'commented on';
+    const commentContent = entry.content as FeedCommentContent;
+    if (commentContent.hasBounties) return 'opened a bounty';
+    return COMMENT_ACTION_LABELS[commentContent.comment?.commentType] || 'commented on';
   }
   if (entry.contentType === 'BOUNTY') return 'contributed to';
-  if (entry.contentType === 'USDFUNDRAISECONTRIBUTION') return 'Funded Proposal';
+  if (entry.contentType === 'USDFUNDRAISECONTRIBUTION' || entry.contentType === 'PURCHASE')
+    return 'Funded Proposal';
   return DOC_ACTION_LABELS[entry.contentType] || 'contributed';
 }
 
@@ -56,9 +58,16 @@ function getEntryMeta(entry: FeedEntry) {
 
   if (entry.contentType === 'COMMENT' || entry.contentType === 'BOUNTY') {
     const work = entry.relatedWork;
-    const isReview =
-      entry.contentType === 'COMMENT' &&
-      (content as FeedCommentContent).comment?.commentType === 'REVIEW';
+    const commentContent = entry.contentType === 'COMMENT' ? (content as FeedCommentContent) : null;
+    const isReview = commentContent?.comment?.commentType === 'REVIEW';
+    const hasBounties = entry.contentType === 'BOUNTY' || commentContent?.hasBounties === true;
+    const tab = isReview
+      ? 'reviews'
+      : hasBounties
+        ? 'bounties'
+        : entry.contentType === 'COMMENT'
+          ? 'conversation'
+          : undefined;
     return {
       title: work?.title,
       author,
@@ -67,21 +76,22 @@ function getEntryMeta(entry: FeedEntry) {
             id: work.id,
             slug: work.slug,
             contentType: work.contentType,
-            tab: isReview ? 'reviews' : undefined,
+            tab,
           })
         : undefined,
     };
   }
 
-  if (entry.contentType === 'USDFUNDRAISECONTRIBUTION') {
+  if (entry.contentType === 'USDFUNDRAISECONTRIBUTION' || entry.contentType === 'PURCHASE') {
     const post = content as FeedPostContent;
+    const proposalId = post.id;
     return {
       title: post.title,
       author,
-      href: post.unifiedDocumentId
+      href: proposalId
         ? buildWorkUrl({
-            id: post.unifiedDocumentId,
-            slug: post.slug,
+            id: proposalId,
+            slug: post.slug || undefined,
             contentType: 'preregistration',
           })
         : undefined,
@@ -109,10 +119,15 @@ function getFundingAmount(entry: FeedEntry): number | undefined {
 }
 
 function getActionIcon(entry: FeedEntry): React.ReactNode {
-  if (entry.contentType === 'USDFUNDRAISECONTRIBUTION')
+  if (entry.contentType === 'USDFUNDRAISECONTRIBUTION' || entry.contentType === 'PURCHASE')
+    return <Coins size={14} className="inline -mt-0.5 ml-1 text-gray-600" />;
+  if (entry.contentType === 'BOUNTY')
     return <Coins size={14} className="inline -mt-0.5 ml-1 text-gray-600" />;
   if (entry.contentType !== 'COMMENT') return null;
-  const commentType = (entry.content as FeedCommentContent).comment?.commentType;
+  const commentContent = entry.content as FeedCommentContent;
+  if (commentContent.hasBounties)
+    return <Coins size={14} className="inline -mt-0.5 ml-1 text-gray-600" />;
+  const commentType = commentContent.comment?.commentType;
   if (commentType === 'AUTHOR_UPDATE')
     return <Bell size={14} className="inline -mt-0.5 ml-1 text-gray-600" />;
   if (commentType === 'GENERIC_COMMENT' || commentType === 'ANSWER')
@@ -128,7 +143,8 @@ function getReviewScore(entry: FeedEntry): number | undefined {
 }
 
 function getContributionAmount(entry: FeedEntry): number | undefined {
-  if (entry.contentType !== 'USDFUNDRAISECONTRIBUTION') return undefined;
+  if (entry.contentType !== 'USDFUNDRAISECONTRIBUTION' && entry.contentType !== 'PURCHASE')
+    return undefined;
   const post = entry.content as FeedPostContent;
   return post.fundraiseContribution?.amount || undefined;
 }

--- a/types/feed.ts
+++ b/types/feed.ts
@@ -141,6 +141,7 @@ export interface FeedCommentContent extends BaseFeedContent {
       objectId: number;
     };
   };
+  hasBounties?: boolean;
   isRemoved?: boolean;
   relatedDocumentId?: number | string;
   relatedDocumentContentType?: ContentType;
@@ -729,6 +730,9 @@ export const transformFeedEntry = (feedEntry: RawApiFeedEntry): FeedEntry => {
         // Transform the comment to get score and other properties
         const transformedComment = transformComment(commentData);
 
+        const hasBounties =
+          Array.isArray(content_object.bounties) && content_object.bounties.length > 0;
+
         // Create a FeedCommentContent object
         const commentContent: FeedCommentContent = {
           id: content_object.id,
@@ -738,6 +742,7 @@ export const transformFeedEntry = (feedEntry: RawApiFeedEntry): FeedEntry => {
           updatedDate: content_object.updated_date || action_date || created_date,
           createdBy: transformAuthorProfile(author || content_object.author),
           isRemoved: content_object.is_removed,
+          hasBounties,
           comment: {
             id: content_object.id,
             content: content_object.comment_content_json,
@@ -945,7 +950,7 @@ export const transformFeedEntry = (feedEntry: RawApiFeedEntry): FeedEntry => {
       contentType = content_type as 'PURCHASE' | 'USDFUNDRAISECONTRIBUTION';
       try {
         const contributionEntry: FeedPostContent = {
-          id: content_object.id || id,
+          id: content_object.post_id ?? content_object.id ?? id,
           unifiedDocumentId: content_object.unified_document_id,
           contentType: 'PREREGISTRATION',
           createdDate: action_date || created_date,


### PR DESCRIPTION
### What
- Activity sidebar showed "commented" for entries that actually opened a bounty.
### How
- Added `hasBounties` to `FeedCommentContent`  and used it in `ActivityCard.getActionLabel` / `getActionIcon` so comments with bounties render "opened a bounty" with the Coin icon.
<img width="339" height="156" alt="image" src="https://github.com/user-attachments/assets/19834160-5e45-4ee2-b487-306be1c89b61" />


### What
- Activity sidebar contribution entries (PURCHASE / fund actions) had no clickable link to the funded proposal.
### How
- Used `content_object.post_id` as the `id` in the `PURCHASE` transform so `buildWorkUrl({ contentType: 'preregistration', id })` produces a working `/proposal/<post_id>` link.
<img width="294" height="177" alt="image" src="https://github.com/user-attachments/assets/e3eee445-702b-4b3b-8333-f14dc47a33c9" />


### What
- Comment entries linked to the work root, instead of a real tab.
### How
- In `ActivityCard.getEntryMeta`, routed comment links by priority: 
  - review → `/reviews`, bounty (or `hasBounties`) → `/bounties`, otherwise → `/conversation`
- so generic comments and answers land on the conversation tab instead of an unrouted work page.