### PR TITLE
small tweaks to Endaoment section

### DIFF
--- a/app/about/components/PartnershipSection.tsx
+++ b/app/about/components/PartnershipSection.tsx
@@ -5,7 +5,7 @@ import { Eyebrow } from './Eyebrow';
 import { MonoLabel } from './MonoLabel';
 
 const partnershipStats = [
-  { value: '$145.62M', label: 'Total impact' },
+  { value: '$150M+', label: 'Total impact', href: 'https://impact.endaoment.org/' },
   { value: '1.8M', label: 'Eligible orgs' },
 ];
 
@@ -63,9 +63,23 @@ export const PartnershipSection = () => (
                   <div className="font-medium tracking-[-0.02em] text-gray-900 leading-none text-[clamp(26px,5vw,40px)]">
                     {stat.value}
                   </div>
-                  <MonoLabel className="mt-2 block text-[10px] uppercase tracking-[0.16em] text-gray-500">
-                    {stat.label}
-                  </MonoLabel>
+                  {stat.href ? (
+                    <a
+                      href={stat.href}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="mt-2 inline-flex items-center gap-1.5 text-gray-500 hover:text-gray-900 hover:gap-2 transition-all"
+                    >
+                      <MonoLabel className="text-[10px] uppercase tracking-[0.16em] underline decoration-dotted underline-offset-4">
+                        {stat.label}
+                      </MonoLabel>
+                      <ExternalLink className="w-3 h-3" aria-hidden />
+                    </a>
+                  ) : (
+                    <MonoLabel className="mt-2 block text-[10px] uppercase tracking-[0.16em] text-gray-500">
+                      {stat.label}
+                    </MonoLabel>
+                  )}
                 </div>
               ))}
             </div>

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -5,7 +5,7 @@ import { Problem } from './components/Problem';
 import { Solution } from './components/Solution';
 import { FundingMarketplace } from './components/FundingMarketplace';
 import { ResearchCoin } from './components/ResearchCoin';
-import { PartnershipSection } from './components/PartnershipSection';
+// import { PartnershipSection } from './components/PartnershipSection';
 import { TeamSection } from './components/TeamSection';
 import { CTASection } from './components/CTASection';
 import { LandingPageFooter } from '@/components/landing/LandingPageFooter';
@@ -26,7 +26,7 @@ const AboutPage = () => (
       <FundingMarketplace />
       <FundedAt />
       <ResearchCoin />
-      <PartnershipSection />
+      {/* <PartnershipSection /> */}
     </section>
 
     <section id="team">


### PR DESCRIPTION
Touch up Endaoment section on About page but temporarily hide it while they review copy. 

### After:
<img width="1217" height="506" alt="Screenshot 2026-05-11 at 4 05 46 PM" src="https://github.com/user-attachments/assets/11f38ba4-1364-4e59-a798-7bd7f7f7b7c4" />


### Before
<img width="1187" height="471" alt="Screenshot 2026-05-11 at 4 05 29 PM" src="https://github.com/user-attachments/assets/b1aa4aa1-5c3d-4788-9e7b-3c433a00bcb7" />
