### PR TITLE
Fix notification deep links using unified document type

### DIFF
--- a/components/Notification/lib/formatNotification.ts
+++ b/components/Notification/lib/formatNotification.ts
@@ -1,6 +1,7 @@
 import { type IconName } from '@/components/ui/icons/Icon';
 import { Notification } from '@/types/notification';
 import { formatUsdValue, formatRSC } from '@/utils/number';
+import { buildWorkUrl } from '@/utils/url';
 
 export interface NotificationTypeInfo {
   icon: IconName;
@@ -204,8 +205,8 @@ export function getRSCAmountFromNotification(notification: Notification): number
  * - https://xyz-researchhub.vercel.app/paper/9348486/title → /paper/9348486/title
  *
  * For notifications with null/empty URLs:
- * - Creates relative paper URLs for any notification with a paper ID
- * - Adds /bounties suffix specifically for BOUNTY_FOR_YOU notifications
+ * - Builds a path with {@link buildWorkUrl} using work.contentType (from API document_type) or paper as default
+ * - Adds /bounties tab for selected bounty notification types
  */
 export function formatNavigationUrl(notification: Notification): string | undefined {
   if (
@@ -238,21 +239,23 @@ export function formatNavigationUrl(notification: Notification): string | undefi
 
   // Handle null/empty URL when we have document data
   if ((!url || url.trim() === '') && notification.work?.id) {
-    const paperId = notification.work.id;
-    let basePath = notification.work.slug
-      ? `/paper/${paperId}/${notification.work.slug}`
-      : `/paper/${paperId}`;
+    const contentType = notification.work.contentType ?? 'paper';
+    const bountyTabTypes = [
+      'BOUNTY_FOR_YOU',
+      'BOUNTY_EXPIRING_SOON',
+      'BOUNTY_HUB_EXPIRING_SOON',
+      'BOUNTY_PAYOUT',
+    ] as const;
+    const tab = bountyTabTypes.includes(notification.type as (typeof bountyTabTypes)[number])
+      ? 'bounties'
+      : undefined;
 
-    if (
-      notification.type === 'BOUNTY_FOR_YOU' ||
-      notification.type === 'BOUNTY_EXPIRING_SOON' ||
-      notification.type === 'BOUNTY_HUB_EXPIRING_SOON' ||
-      notification.type === 'BOUNTY_PAYOUT'
-    ) {
-      basePath += '/bounties';
-    }
-
-    return basePath;
+    return buildWorkUrl({
+      id: notification.work.id,
+      slug: notification.work.slug,
+      contentType,
+      tab,
+    });
   }
 
   if (!url) return undefined;

--- a/types/notification.ts
+++ b/types/notification.ts
@@ -52,7 +52,7 @@ export type TransformedNotification = Notification & BaseTransformed;
 export type TransformedNotificationExtra = NotificationExtra & BaseTransformed;
 export type TransformedNotificationBodyElement = NotificationBodyElement & BaseTransformed;
 
-export type NotificationWork = NonNullable<Notification['work']>;
+export type NotificationForWork = NonNullable<Notification['work']>;
 
 // Helper function to transform notification extra without using createTransformer
 const transformNotificationExtraRaw = (raw: any): NotificationExtra | undefined => {
@@ -112,7 +112,7 @@ export const transformNotificationBody = (body: any): NotificationBodyElement[] 
 };
 
 // Helper function to transform work without using createTransformer
-const transformWorkRaw = (raw: any): NotificationWork | undefined => {
+const transformWorkRaw = (raw: any): NotificationForWork | undefined => {
   if (!raw) return undefined;
 
   const contentType = mapApiDocumentTypeToClientType(raw.document_type);
@@ -162,7 +162,7 @@ const transformWorkRaw = (raw: any): NotificationWork | undefined => {
 export const transformWork = (raw: any) => {
   const transformed = transformWorkRaw(raw);
   if (!transformed) return undefined;
-  return createTransformer<any, NotificationWork>(() => transformed)(raw);
+  return createTransformer<any, NotificationForWork>(() => transformed)(raw);
 };
 
 export const transformNotification = createTransformer<any, Notification>((raw) => ({

--- a/types/notification.ts
+++ b/types/notification.ts
@@ -1,10 +1,7 @@
 import { createTransformer, BaseTransformed } from './transformer';
 import { User, transformUser } from './user';
-import { ContentType } from './work';
-import { ContentMetrics } from './metrics';
-import { Journal } from './journal';
-import { Topic } from './topic';
-import { AuthorProfile } from './authorProfile';
+import type { ContentType } from './work';
+import { mapApiDocumentTypeToClientType } from '@/utils/contentTypeMapping';
 
 export interface NotificationHub {
   name: string;
@@ -40,6 +37,7 @@ export interface Notification {
     id: number;
     title: string;
     slug?: string;
+    contentType?: ContentType;
   };
   type: string;
   body: NotificationBodyElement[];
@@ -53,6 +51,8 @@ export interface Notification {
 export type TransformedNotification = Notification & BaseTransformed;
 export type TransformedNotificationExtra = NotificationExtra & BaseTransformed;
 export type TransformedNotificationBodyElement = NotificationBodyElement & BaseTransformed;
+
+export type NotificationWork = NonNullable<Notification['work']>;
 
 // Helper function to transform notification extra without using createTransformer
 const transformNotificationExtraRaw = (raw: any): NotificationExtra | undefined => {
@@ -112,8 +112,10 @@ export const transformNotificationBody = (body: any): NotificationBodyElement[] 
 };
 
 // Helper function to transform work without using createTransformer
-const transformWorkRaw = (raw: any): { id: number; title: string; slug?: string } | undefined => {
+const transformWorkRaw = (raw: any): NotificationWork | undefined => {
   if (!raw) return undefined;
+
+  const contentType = mapApiDocumentTypeToClientType(raw.document_type);
 
   // Direct extraction when raw is already a unified_document
   if (raw.documents) {
@@ -125,6 +127,7 @@ const transformWorkRaw = (raw: any): { id: number; title: string; slug?: string 
         id: firstDoc.id,
         title: firstDoc.title || firstDoc.paper_title || '',
         slug: firstDoc.slug,
+        contentType: contentType,
       };
     }
     // Handle single document object
@@ -133,6 +136,7 @@ const transformWorkRaw = (raw: any): { id: number; title: string; slug?: string 
         id: raw.documents.id,
         title: raw.documents.title || raw.documents.paper_title || '',
         slug: raw.documents.slug,
+        contentType: contentType,
       };
     }
   }
@@ -148,6 +152,7 @@ const transformWorkRaw = (raw: any): { id: number; title: string; slug?: string 
       id: raw.id,
       title: raw.title || raw.paper_title || '',
       slug: raw.slug,
+      contentType: contentType,
     };
   }
 
@@ -157,9 +162,7 @@ const transformWorkRaw = (raw: any): { id: number; title: string; slug?: string 
 export const transformWork = (raw: any) => {
   const transformed = transformWorkRaw(raw);
   if (!transformed) return undefined;
-  return createTransformer<any, { id: number; title: string; slug?: string }>(() => transformed)(
-    raw
-  );
+  return createTransformer<any, NotificationWork>(() => transformed)(raw);
 };
 
 export const transformNotification = createTransformer<any, Notification>((raw) => ({


### PR DESCRIPTION
What?
=====
- Notification rows that fell back to an empty `navigation_url` always linked to `/paper/...`, so bounty and other doc notifications could open the wrong route (e.g. proposal title but paper URL).

> _Issue: the URL should take you to a `/proposal` but instead this is taking to a `/paper`_

How?
=====
- Read `unified_document.document_type` in the notification transformer and map it to `work.contentType.
- When `navigation_url` is missing, build the path with buildWorkUrl using work.contentType (default paper) and keep the existing /bounties tab for the same bounty notification types as before.