### PR TITLE
Refactor Changelog link and add to MobileBottomNav

### DIFF
--- a/app/layouts/MobileBottomNav.tsx
+++ b/app/layouts/MobileBottomNav.tsx
@@ -13,6 +13,7 @@ import {
   faBars,
 } from '@fortawesome/pro-light-svg-icons';
 import { faXTwitter, faDiscord, faGithub, faLinkedin } from '@fortawesome/free-brands-svg-icons';
+import { ChangelogLink } from '@/components/changelog/ChangelogLink';
 import { Icon } from '@/components/ui/icons';
 import { IconName } from '@/components/ui/icons/Icon';
 import { ResearchCoinIcon } from '@/components/ui/icons/ResearchCoinIcon';
@@ -356,6 +357,7 @@ export const MobileBottomNav: React.FC = () => {
               <a href="https://www.researchhub.com/about" className="hover:text-gray-700">
                 About
               </a>
+              <ChangelogLink />
             </div>
           </div>
         </div>

--- a/components/FooterLinks.tsx
+++ b/components/FooterLinks.tsx
@@ -1,25 +1,12 @@
 'use client';
 
-import { useState, useEffect } from 'react';
 import { faXTwitter, faDiscord, faGithub, faLinkedin } from '@fortawesome/free-brands-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { ChangelogLink } from '@/components/changelog/ChangelogLink';
 import { useCurrencyPreference } from '@/contexts/CurrencyPreferenceContext';
-import { RadiatingDot } from '@/components/ui/RadiatingDot';
-import { CHANGELOG_STORAGE_KEY } from '@/constants/changelog';
 
 export const FooterLinks: React.FC = () => {
   const { showUSD, toggleCurrency } = useCurrencyPreference();
-  const [hasSeenChangelog, setHasSeenChangelog] = useState(true);
-
-  useEffect(() => {
-    const hasSeen = localStorage.getItem(CHANGELOG_STORAGE_KEY);
-    setHasSeenChangelog(!!hasSeen);
-  }, []);
-
-  const handleChangelogClick = () => {
-    localStorage.setItem(CHANGELOG_STORAGE_KEY, 'true');
-    setHasSeenChangelog(true);
-  };
 
   return (
     <div className="px-4 py-6 border-t text-sm">
@@ -75,14 +62,7 @@ export const FooterLinks: React.FC = () => {
         <a href="https://docs.researchhub.com/" className="hover:text-gray-700">
           Docs
         </a>
-        <a
-          href="/changelog"
-          className={`flex items-center gap-1 ${hasSeenChangelog ? 'hover:text-gray-700' : 'text-orange-500 hover:text-orange-600'}`}
-          onClick={handleChangelogClick}
-        >
-          {!hasSeenChangelog && <RadiatingDot color="bg-orange-500" size="sm" />}
-          Changelog
-        </a>
+        <ChangelogLink />
         <a href="https://www.researchhub.com/tos" className="hover:text-gray-700">
           Terms
         </a>

--- a/components/changelog/ChangelogLink.tsx
+++ b/components/changelog/ChangelogLink.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { RadiatingDot } from '@/components/ui/RadiatingDot';
+import { CHANGELOG_STORAGE_KEY } from '@/constants/changelog';
+import { cn } from '@/utils/styles';
+
+interface ChangelogLinkProps {
+  className?: string;
+}
+
+/**
+ * Renders the Changelog link with a "new entry" radiating-dot indicator that
+ * persists per-user in localStorage. Centralizes the seen-state logic so
+ * desktop and mobile surfaces stay in sync without duplicating it.
+ */
+export const ChangelogLink: React.FC<ChangelogLinkProps> = ({ className }) => {
+  const [hasSeenChangelog, setHasSeenChangelog] = useState(true);
+
+  useEffect(() => {
+    const hasSeen = localStorage.getItem(CHANGELOG_STORAGE_KEY);
+    setHasSeenChangelog(!!hasSeen);
+  }, []);
+
+  const handleClick = () => {
+    localStorage.setItem(CHANGELOG_STORAGE_KEY, 'true');
+    setHasSeenChangelog(true);
+  };
+
+  return (
+    <a
+      href="/changelog"
+      onClick={handleClick}
+      className={cn(
+        'flex items-center gap-1',
+        hasSeenChangelog ? 'hover:text-gray-700' : 'text-orange-500 hover:text-orange-600',
+        className
+      )}
+    >
+      {!hasSeenChangelog && <RadiatingDot color="bg-orange-500" size="sm" />}
+      Changelog
+    </a>
+  );
+};

--- a/components/changelog/ChangelogLink.tsx
+++ b/components/changelog/ChangelogLink.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useEffect } from 'react';
+import Link from 'next/link';
 import { RadiatingDot } from '@/components/ui/RadiatingDot';
 import { CHANGELOG_STORAGE_KEY } from '@/constants/changelog';
 import { cn } from '@/utils/styles';
@@ -28,7 +29,7 @@ export const ChangelogLink: React.FC<ChangelogLinkProps> = ({ className }) => {
   };
 
   return (
-    <a
+    <Link
       href="/changelog"
       onClick={handleClick}
       className={cn(
@@ -39,6 +40,6 @@ export const ChangelogLink: React.FC<ChangelogLinkProps> = ({ className }) => {
     >
       {!hasSeenChangelog && <RadiatingDot color="bg-orange-500" size="sm" />}
       Changelog
-    </a>
+    </Link>
   );
 };


### PR DESCRIPTION
## Issue:
The Changelog link and Radiating Indicator were not visible on Mobile via the MobileBottomNav. So you could only get to the changelog reasonably from Web.

## Solution:
1. Refactor the Changelog link logic into a new component to share the localstorage and not duplicate logic.
3. Add the ChangelogLink to the MobileBottomNav and replace the Changelog Link on the Left Sidebar (FooterLinks)
## Before
<img width="330" height="583" alt="Screenshot 2026-05-12 at 2 14 33 PM" src="https://github.com/user-attachments/assets/99a6a3bb-e955-44f2-9fe0-db376397f105" />


## After
<img width="331" height="581" alt="Screenshot 2026-05-12 at 2 37 12 PM" src="https://github.com/user-attachments/assets/c39b73b4-4bee-42f7-8cbd-ae2aa390b40e" />

