### PR TITLE
Fix moderator audit crash when flagged content item is null

### DIFF
--- a/components/Moderators/AuditItemCard.tsx
+++ b/components/Moderators/AuditItemCard.tsx
@@ -6,6 +6,9 @@ import { AuditItemComment } from './AuditItemComment';
 import { AuditItemPost } from './AuditItemPost';
 import { AuditItemPaper } from './AuditItemPaper';
 import { SelectionCheckbox } from './SelectionCheckbox';
+import { ModerationMetadata } from './ModerationMetadata';
+import { ModerationActions } from './ModerationActions';
+import { getAuditUserInfo } from './utils/auditUtils';
 
 interface AuditItemCardProps {
   entry: FlaggedContent;
@@ -56,6 +59,35 @@ export const AuditItemCard: FC<AuditItemCardProps> = ({
   ) : null;
 
   const sharedProps = { entry, onAction, onRefresh, view, checkbox };
+
+  // API can return flags whose underlying content was deleted.
+  if (entry.item == null) {
+    const userInfo = getAuditUserInfo(entry);
+    const verdict = entry.verdict;
+
+    return (
+      <div className="bg-white border border-gray-200 rounded-lg p-4 hover:shadow-sm transition-shadow">
+        <div className="flex items-start gap-3 mb-3">
+          {checkbox}
+          <div className="flex-1 min-w-0">
+            <ModerationMetadata entry={entry} />
+          </div>
+        </div>
+        <p className="text-sm text-gray-600 mb-4">
+          The flagged content is no longer available (it may have been removed).
+        </p>
+        <ModerationActions
+          onDismiss={() => onAction('dismiss')}
+          onRemove={() => onAction('remove')}
+          view={view}
+          hasVerdict={!!verdict}
+          authorId={userInfo.authorId}
+          authorName={userInfo.name}
+          onRefresh={onRefresh}
+        />
+      </div>
+    );
+  }
 
   switch (contentType) {
     case 'comment':

--- a/components/Moderators/AuditItemCard.tsx
+++ b/components/Moderators/AuditItemCard.tsx
@@ -5,10 +5,8 @@ import { FlaggedContent } from '@/services/audit.service';
 import { AuditItemComment } from './AuditItemComment';
 import { AuditItemPost } from './AuditItemPost';
 import { AuditItemPaper } from './AuditItemPaper';
+import { AuditItemMissingContent } from './AuditItemMissingContent';
 import { SelectionCheckbox } from './SelectionCheckbox';
-import { ModerationMetadata } from './ModerationMetadata';
-import { ModerationActions } from './ModerationActions';
-import { getAuditUserInfo } from './utils/auditUtils';
 
 interface AuditItemCardProps {
   entry: FlaggedContent;
@@ -60,32 +58,15 @@ export const AuditItemCard: FC<AuditItemCardProps> = ({
 
   const sharedProps = { entry, onAction, onRefresh, view, checkbox };
 
-  // API can return flags whose underlying content was deleted.
   if (entry.item == null) {
-    const userInfo = getAuditUserInfo(entry);
-    const verdict = entry.verdict;
-
     return (
-      <div className="bg-white border border-gray-200 rounded-lg p-4 hover:shadow-sm transition-shadow">
-        <div className="flex items-start gap-3 mb-3">
-          {checkbox}
-          <div className="flex-1 min-w-0">
-            <ModerationMetadata entry={entry} />
-          </div>
-        </div>
-        <p className="text-sm text-gray-600 mb-4">
-          The flagged content is no longer available (it may have been removed).
-        </p>
-        <ModerationActions
-          onDismiss={() => onAction('dismiss')}
-          onRemove={() => onAction('remove')}
-          view={view}
-          hasVerdict={!!verdict}
-          authorId={userInfo.authorId}
-          authorName={userInfo.name}
-          onRefresh={onRefresh}
-        />
-      </div>
+      <AuditItemMissingContent
+        entry={entry}
+        onAction={onAction}
+        onRefresh={onRefresh}
+        view={view}
+        checkbox={checkbox}
+      />
     );
   }
 

--- a/components/Moderators/AuditItemMissingContent.tsx
+++ b/components/Moderators/AuditItemMissingContent.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import { FC, ReactNode } from 'react';
+import { FlaggedContent } from '@/services/audit.service';
+import { ModerationMetadata } from './ModerationMetadata';
+import { ModerationActions } from './ModerationActions';
+import { getAuditUserInfo } from './utils/auditUtils';
+
+interface AuditItemMissingContentProps {
+  entry: FlaggedContent;
+  onAction: (action: 'dismiss' | 'remove') => void;
+  onRefresh?: () => void;
+  view?: 'pending' | 'dismissed' | 'removed';
+  checkbox?: ReactNode;
+}
+
+/** Flag rows whose underlying content was deleted (`item: null` from API). */
+export const AuditItemMissingContent: FC<AuditItemMissingContentProps> = ({
+  entry,
+  onAction,
+  onRefresh,
+  view,
+  checkbox,
+}) => {
+  const userInfo = getAuditUserInfo(entry);
+  const verdict = entry.verdict;
+
+  return (
+    <div className="bg-white border border-gray-200 rounded-lg p-4 hover:shadow-sm transition-shadow">
+      <div className="flex items-start gap-3 mb-3">
+        {checkbox}
+        <div className="flex-1 min-w-0">
+          <ModerationMetadata entry={entry} />
+        </div>
+      </div>
+      <p className="text-sm text-gray-600 mb-4">
+        The flagged content is no longer available (it may have been removed).
+      </p>
+      <ModerationActions
+        onDismiss={() => onAction('dismiss')}
+        onRemove={() => onAction('remove')}
+        view={view}
+        hasVerdict={!!verdict}
+        authorId={userInfo.authorId}
+        authorName={userInfo.name}
+        onRefresh={onRefresh}
+      />
+    </div>
+  );
+};

--- a/services/audit.service.ts
+++ b/services/audit.service.ts
@@ -44,7 +44,7 @@ interface FlaggedContentApiResponse {
     id: ID;
     name: string;
   };
-  item: any;
+  item: any | null;
   created_date: string;
   hubs: any[];
 }
@@ -81,7 +81,7 @@ export interface FlaggedContent {
     id: ID;
     name: string;
   };
-  item: any;
+  item: any | null;
   createdDate: string;
   hubs: any[];
 }
@@ -127,10 +127,10 @@ const transformFlaggedContent = (apiItem: FlaggedContentApiResponse): FlaggedCon
   flaggedBy: {
     id: apiItem.flagged_by.id,
     authorProfile: {
-      id: apiItem.flagged_by.author_profile.id,
+      id: apiItem.flagged_by.author_profile?.id,
       firstName: apiItem.flagged_by.first_name,
       lastName: apiItem.flagged_by.last_name,
-      profileImage: apiItem.flagged_by.author_profile.profile_image,
+      profileImage: apiItem.flagged_by.author_profile?.profile_image,
     },
   },
   verdict: apiItem.verdict
@@ -138,10 +138,10 @@ const transformFlaggedContent = (apiItem: FlaggedContentApiResponse): FlaggedCon
         createdBy: {
           id: apiItem.verdict.created_by.id,
           authorProfile: {
-            id: apiItem.verdict.created_by.author_profile.id,
+            id: apiItem.verdict.created_by.author_profile?.id,
             firstName: apiItem.verdict.created_by.first_name,
             lastName: apiItem.verdict.created_by.last_name,
-            profileImage: apiItem.verdict.created_by.author_profile.profile_image,
+            profileImage: apiItem.verdict.created_by.author_profile?.profile_image,
           },
         },
         createdDate: apiItem.verdict.created_date,

--- a/types/audit.ts
+++ b/types/audit.ts
@@ -40,7 +40,8 @@ export interface FlaggedContent {
     name: string;
     slug: string;
   }>;
-  item?: {
+  /** Missing when the underlying content was deleted; API sends JSON `null`. */
+  item?: null | {
     id: ID;
     createdBy?: AuthorProfile;
     commentContentJson?: string | object;


### PR DESCRIPTION
What?
=====
- The Audit UI treated item as always present (`entry.item!`), which caused `Cannot read properties of null (reading 'thread') when rendering researchhubpost rows`.
<img width="761" height="786" alt="image" src="https://github.com/user-attachments/assets/66bcd3fa-0020-483c-a8d9-be89338cb4ce" />

How?
=====
- Render a safe fallback card when `entry.item` is missing/null (flag metadata + dismiss/remove still available).
- Harden audit transform for optional/missing `author_profile` so serialization edge cases don't throw during mapping.