### PR TITLE
make hub selector lowercase

### DIFF
--- a/app/earn/ReviewsPageContent.tsx
+++ b/app/earn/ReviewsPageContent.tsx
@@ -109,7 +109,7 @@ export function ReviewsPageContent() {
   const tabs: PillTab[] = useMemo(() => {
     const topicTabs: PillTab[] = allTopics.map((t) => ({
       id: String(t.id),
-      label: `#${t.name}`,
+      label: `#${t.name.toLowerCase()}`,
     }));
     return [{ id: ALL_TOPICS_ID, label: 'All' }, ...topicTabs];
   }, [allTopics]);

--- a/app/earn/ReviewsPageContent.tsx
+++ b/app/earn/ReviewsPageContent.tsx
@@ -109,7 +109,7 @@ export function ReviewsPageContent() {
   const tabs: PillTab[] = useMemo(() => {
     const topicTabs: PillTab[] = allTopics.map((t) => ({
       id: String(t.id),
-      label: `#${t.name.toLowerCase()}`,
+      label: `#${(t.slug || t.name).toLowerCase().replace(/\s+/g, '-')}`,
     }));
     return [{ id: ALL_TOPICS_ID, label: 'All' }, ...topicTabs];
   }, [allTopics]);


### PR DESCRIPTION
## Issue
Bounty hub selection is uppercase but the feed items have it in slug format. 
<img width="1512" height="857" alt="Screenshot 2026-05-16 at 8 54 42 PM" src="https://github.com/user-attachments/assets/0217f78d-7cb2-44ad-8345-93f04f4adffb" />

## Solution
Make them uniform by using the `topic.slug` not the `topic.name`.
<img width="1511" height="726" alt="Screenshot 2026-05-16 at 9 32 08 PM" src="https://github.com/user-attachments/assets/ff3a46c3-cd04-4bce-aa1a-164085044d2d" />
