### PR TITLE
update quick amounts + logic

### DIFF
--- a/components/Funding/QuickAmountSelector.tsx
+++ b/components/Funding/QuickAmountSelector.tsx
@@ -5,6 +5,14 @@ import { cn } from '@/utils/styles';
 
 const QUICK_AMOUNTS_USD = [100, 1000, 5000, 10000];
 
+const formatQuickAmountLabel = (amount: number) => {
+  if (amount >= 1000) {
+    return `$${amount / 1000}K`;
+  }
+
+  return `$${amount}`;
+};
+
 interface QuickAmountSelectorProps {
   /** Currently selected quick amount (in USD) */
   selectedAmount: number | null;
@@ -66,7 +74,7 @@ export const QuickAmountSelector: FC<QuickAmountSelectorProps> = ({
               : 'bg-white text-gray-700 border-gray-300 hover:border-primary-400 hover:bg-primary-50'
           )}
         >
-          ${amount.toLocaleString()}
+          {formatQuickAmountLabel(amount)}
         </button>
       ))}
 

--- a/components/Funding/QuickAmountSelector.tsx
+++ b/components/Funding/QuickAmountSelector.tsx
@@ -59,7 +59,7 @@ export const QuickAmountSelector: FC<QuickAmountSelectorProps> = ({
   }
 
   return (
-    <div className={cn('flex flex-wrap items-center gap-2', className)}>
+    <div className={cn('flex flex-nowrap items-center gap-2', className)}>
       {/* Quick amount buttons */}
       {visibleAmounts.map((amount) => (
         <button

--- a/components/Funding/QuickAmountSelector.tsx
+++ b/components/Funding/QuickAmountSelector.tsx
@@ -51,7 +51,7 @@ export const QuickAmountSelector: FC<QuickAmountSelectorProps> = ({
   }
 
   return (
-    <div className={cn('flex flex-nowrap items-center gap-2', className)}>
+    <div className={cn('flex flex-wrap items-center gap-2', className)}>
       {/* Quick amount buttons */}
       {visibleAmounts.map((amount) => (
         <button

--- a/components/Funding/QuickAmountSelector.tsx
+++ b/components/Funding/QuickAmountSelector.tsx
@@ -3,6 +3,8 @@
 import { FC, useCallback, useMemo } from 'react';
 import { cn } from '@/utils/styles';
 
+const QUICK_AMOUNTS_USD = [100, 1000, 5000, 10000];
+
 interface QuickAmountSelectorProps {
   /** Currently selected quick amount (in USD) */
   selectedAmount: number | null;
@@ -16,12 +18,7 @@ interface QuickAmountSelectorProps {
 
 /**
  * Quick amount selector with preset USD amounts and a "Remaining" button.
- * Dynamically shows amounts based on remaining goal:
- * - Remaining >= $1000: Show $50, $100, $250, $1000
- * - Remaining $500-$999: Show $50, $100, $250
- * - Remaining $250-$499: Show $50, $100, $250
- * - Remaining $100-$249: Show $50, $100
- * - Remaining < $100: Hide quick buttons (only Remaining shown)
+ * Presets above the remaining goal are hidden so quick selections stay valid.
  */
 export const QuickAmountSelector: FC<QuickAmountSelectorProps> = ({
   selectedAmount,
@@ -44,17 +41,8 @@ export const QuickAmountSelector: FC<QuickAmountSelectorProps> = ({
     onAmountSelect(Math.round(remainingGoalUsd));
   }, [remainingGoalUsd, onAmountSelect]);
 
-  // Determine which quick amounts to show based on remaining goal
   const visibleAmounts = useMemo(() => {
-    if (remainingGoalUsd < 100) {
-      return []; // Hide all quick buttons
-    } else if (remainingGoalUsd < 250) {
-      return [50, 100]; // Show $50, $100
-    } else if (remainingGoalUsd < 1000) {
-      return [50, 100, 250]; // Show $50, $100, $250
-    } else {
-      return [50, 100, 250, 1000]; // Show all
-    }
+    return QUICK_AMOUNTS_USD.filter((amount) => amount <= remainingGoalUsd);
   }, [remainingGoalUsd]);
 
   // If no quick amounts and no remaining, don't render anything
@@ -75,12 +63,10 @@ export const QuickAmountSelector: FC<QuickAmountSelectorProps> = ({
             'focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-1',
             isQuickAmountSelected(amount)
               ? 'bg-primary-600 text-white border-primary-600'
-              : 'bg-white text-gray-700 border-gray-300 hover:border-primary-400 hover:bg-primary-50',
-            // Hide $50 button on mobile to fit all buttons on one line
-            amount === 50 && 'hidden tablet:!block'
+              : 'bg-white text-gray-700 border-gray-300 hover:border-primary-400 hover:bg-primary-50'
           )}
         >
-          ${amount}
+          ${amount.toLocaleString()}
         </button>
       ))}
 


### PR DESCRIPTION
## Issue
Quick fund amounts are still a bit low, and the preset visibility logic is manually encoded with threshold-specific if/else branches.
<img width="410" height="473" alt="Screenshot 2026-05-17 at 11 27 32 AM" src="https://github.com/user-attachments/assets/932546ac-e845-4d6c-b407-a11507dd2025" />
<img width="332" height="587" alt="Screenshot 2026-05-17 at 11 27 37 AM" src="https://github.com/user-attachments/assets/4659f57a-9275-4399-8c78-71f78b1e12be" />



## Solution
Increase the preset quick amounts to $100, $1,000, $5,000, and $10,000, then derive the visible buttons by filtering the preset list against the remaining fundraise amount. So we don't need to update separate threshold branches.

### All options visible ($100k fundraise)
<img width="407" height="528" alt="Screenshot 2026-05-17 at 11 24 47 AM" src="https://github.com/user-attachments/assets/0d83a13d-fa76-46b2-b892-3fb13a8cc9b7" />

(Mobile)
<img width="330" height="589" alt="Screenshot 2026-05-17 at 11 28 29 AM" src="https://github.com/user-attachments/assets/8d51dcb3-5acb-4593-b104-be2b8f935a24" />


### Partial options visible ($10K fundraise, $9.8k remaining)
<img width="454" height="527" alt="Screenshot 2026-05-17 at 11 25 12 AM" src="https://github.com/user-attachments/assets/357d4e83-3111-42be-8585-c7310d1e6ca7" />

(Mobile)
<img width="331" height="589" alt="Screenshot 2026-05-17 at 11 25 31 AM" src="https://github.com/user-attachments/assets/0aaf217c-51ed-4d51-a717-ad4454490e3b" />
