### PR TITLE
Removing DOI Assignment text from journal process

### DIFF
--- a/app/paper/create/pdf/page.tsx
+++ b/app/paper/create/pdf/page.tsx
@@ -547,10 +547,6 @@ export default function UploadPDFPage() {
                   </li>
                   <li className="flex items-center">
                     <Check className="h-5 w-5 text-green-500 mr-2 flex-shrink-0" />{' '}
-                    <span className="text-sm text-gray-700">DOI Assignment</span>
-                  </li>
-                  <li className="flex items-center">
-                    <Check className="h-5 w-5 text-green-500 mr-2 flex-shrink-0" />{' '}
                     <span className="text-sm text-gray-700">Indexed on ResearchHub</span>
                   </li>
                   <li className="flex items-center">
@@ -592,10 +588,6 @@ export default function UploadPDFPage() {
                   <li className="flex items-center">
                     <Check className="h-5 w-5 text-green-500 mr-2 flex-shrink-0" />{' '}
                     <span className="text-sm text-gray-700">Open Access Publication</span>
-                  </li>
-                  <li className="flex items-center">
-                    <Check className="h-5 w-5 text-green-500 mr-2 flex-shrink-0" />{' '}
-                    <span className="text-sm text-gray-700">DOI Assignment</span>
                   </li>
                   <li className="flex items-center">
                     <Check className="h-5 w-5 text-green-500 mr-2 flex-shrink-0" />{' '}


### PR DESCRIPTION
## Overview ##

This PR removes the DOI assignment text from the journal entry creation process in alignment with our removing DOI creation from all works except proposals.

## Screenshots ##

Before: 
<img width="979" height="939" alt="image" src="https://github.com/user-attachments/assets/11d4befe-40c2-41b9-920b-12121ce3e8be" />

After: 
<img width="870" height="707" alt="image" src="https://github.com/user-attachments/assets/35ff5f55-8b0f-4781-b890-5548480449a3" />
