### PR TITLE
Spruce Up Achievements Optimization

### DIFF
--- a/components/profile/ProfileAchievements.tsx
+++ b/components/profile/ProfileAchievements.tsx
@@ -1,24 +1,159 @@
 'use client';
 
-import React, { ReactElement } from 'react';
 import { Achievement } from '@/types/authorProfile';
 import { Tooltip } from '@/components/ui/Tooltip';
-import { getAchievementDetails, TIER_COLORS, TIER_INDICES } from './ProfileAchievements.utils';
+import { resolveAchievement, TierStyle } from './ProfileAchievements.utils';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { cn } from '@/utils/styles';
 import { faTrophyStar } from '@fortawesome/pro-light-svg-icons';
+import { faSparkles } from '@fortawesome/pro-solid-svg-icons';
+import type { IconDefinition } from '@fortawesome/fontawesome-svg-core';
+
+type BadgeSize = 'sm' | 'md' | 'lg';
+
+const BADGE_SIZE: Record<BadgeSize, { box: string; icon: string }> = {
+  sm: { box: 'h-8 w-8', icon: 'text-[11px]' },
+  md: { box: 'h-10 w-10', icon: 'text-[14px]' },
+  lg: { box: 'h-14 w-14', icon: 'text-[20px]' },
+};
+
+const CRYSTAL_SHIELD_CLIP = 'polygon(50% 0%, 91% 16%, 84% 70%, 50% 100%, 16% 70%, 9% 16%)';
+
+interface AchievementIconBadgeProps {
+  icon: IconDefinition;
+  tier: TierStyle;
+  size?: BadgeSize;
+  className?: string;
+}
+
+function AchievementIconBadge({ icon, tier, size = 'sm', className }: AchievementIconBadgeProps) {
+  const { box, icon: iconClass } = BADGE_SIZE[size];
+  return (
+    <span
+      className={cn(
+        'relative inline-flex items-center justify-center flex-shrink-0',
+        box,
+        className
+      )}
+    >
+      <span
+        className="absolute inset-0 shadow-sm"
+        style={{ background: tier.outline, clipPath: CRYSTAL_SHIELD_CLIP }}
+      />
+      <span
+        className="absolute inset-[2px]"
+        style={{ background: tier.fill, clipPath: CRYSTAL_SHIELD_CLIP }}
+      />
+      <span
+        className="absolute inset-[5px]"
+        style={{ background: tier.facet, clipPath: CRYSTAL_SHIELD_CLIP }}
+      />
+      <FontAwesomeIcon
+        icon={icon}
+        className={cn('relative drop-shadow-sm', iconClass)}
+        style={{ color: tier.iconColor }}
+      />
+    </span>
+  );
+}
+
+interface TierPillProps {
+  tier: TierStyle;
+  className?: string;
+}
+
+function TierPill({ tier, className }: TierPillProps) {
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center rounded-full border px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide leading-none',
+        tier.pillBg,
+        tier.pillText,
+        tier.pillBorder,
+        className
+      )}
+    >
+      {tier.label}
+    </span>
+  );
+}
 
 export function AchievementsSkeleton() {
   return (
-    <div className="flex flex-col gap-3 p-2">
+    <div className="flex flex-col gap-1.5">
       {[...Array(4)].map((_, i) => (
-        <div key={i} className="flex items-center gap-2 text-sm font-medium rounded w-full">
-          <div className="flex justify-center">
-            <div className="w-7 h-7 rounded-full bg-gray-200 animate-pulse" />
-          </div>
-          <div className="flex-1 h-5 bg-gray-200 rounded animate-pulse" />
+        <div key={i} className="flex items-center gap-2.5 py-1.5 px-1.5 rounded-lg w-full">
+          <div className="h-8 w-8 rounded-lg bg-gray-200 animate-pulse flex-shrink-0" />
+          <div className="flex-1 h-4 bg-gray-200 rounded animate-pulse" />
+          <div className="h-4 w-12 bg-gray-200 rounded-full animate-pulse" />
         </div>
       ))}
+    </div>
+  );
+}
+
+interface AchievementTooltipProps {
+  achievement: Achievement;
+}
+
+function AchievementTooltipContent({ achievement }: AchievementTooltipProps) {
+  const {
+    meta,
+    tier,
+    currentTierName,
+    nextTierName,
+    displayValue,
+    nextTierDisplayValue,
+    isTopTier,
+  } = resolveAchievement(achievement);
+
+  const progressPct = Math.min(100, Math.max(0, achievement.pctProgress * 100));
+
+  return (
+    <div className="flex w-72 flex-col gap-3 p-1 text-left">
+      <div className="flex items-center gap-2.5">
+        <AchievementIconBadge icon={meta.icon} tier={tier} size="md" />
+        <div className="min-w-0 flex-1">
+          <div className="text-sm font-semibold text-gray-900 truncate">{meta.title}</div>
+          <div className="mt-0.5">
+            <TierPill tier={tier} />
+          </div>
+        </div>
+      </div>
+
+      <p className="text-xs leading-relaxed text-gray-600">{meta.describe(displayValue)}</p>
+
+      {!isTopTier ? (
+        <div className="flex flex-col gap-1.5">
+          <div className="flex items-center justify-between text-[11px] text-gray-500">
+            <span>
+              Next: <span className={cn('font-semibold', tier.pillText)}>{nextTierName}</span>
+            </span>
+            <span className="font-medium text-gray-700">
+              {displayValue} / {nextTierDisplayValue}
+              {meta.unit}
+            </span>
+          </div>
+          <div className="h-1.5 w-full overflow-hidden rounded-full bg-gray-100">
+            <div
+              className={cn('h-full rounded-full transition-all duration-300', tier.barFill)}
+              style={{ width: `${progressPct}%` }}
+            />
+          </div>
+        </div>
+      ) : (
+        <div
+          className={cn(
+            'inline-flex items-center gap-1.5 self-start rounded-full border px-2 py-1 text-[11px] font-semibold',
+            tier.pillBg,
+            tier.pillText,
+            tier.pillBorder
+          )}
+        >
+          <FontAwesomeIcon icon={faSparkles} className="text-[10px]" />
+          {currentTierName} tier achieved
+        </div>
+      )}
     </div>
   );
 }
@@ -28,143 +163,48 @@ interface AchievementsProps {
   isLoading: boolean;
 }
 
-const Achievements: React.FC<AchievementsProps> = ({ achievements, isLoading }) => {
-  const getTooltipContent = (
-    achievement: Achievement,
-    achievementDetails: { icon: ReactElement; title: string }
-  ) => {
-    const filledColor =
-      TIER_COLORS[achievement.currentMilestoneIndex + 1] || TIER_COLORS[TIER_COLORS.length - 1];
-    const currentTierName = TIER_INDICES[achievement.currentMilestoneIndex] || 'Unknown Tier';
-    const nextTierName = TIER_INDICES[achievement.currentMilestoneIndex + 1] || 'Max Tier';
-    const isTopTier =
-      achievement.currentMilestoneIndex === achievement.milestones.length - 1 ||
-      achievement.currentMilestoneIndex >= TIER_INDICES.length - 1;
-
-    let value = achievement.value;
-    let displayValue = value.toLocaleString();
-    let nextTierValue = achievement.milestones[achievement.currentMilestoneIndex + 1] || 0;
-    let nextTierDisplayValue = nextTierValue.toLocaleString();
-
-    let unit = '';
-    let descriptionText = '';
-
-    switch (achievement.type) {
-      case 'OPEN_SCIENCE_SUPPORTER':
-        descriptionText = `Funded open science using ${displayValue} RSC.`;
-        unit = ' RSC';
-        break;
-      case 'EXPERT_PEER_REVIEWER':
-        descriptionText = `Peer reviewed ${displayValue} publications.`;
-        unit = ' reviews';
-        break;
-      case 'HIGHLY_UPVOTED':
-        descriptionText = `Received ${displayValue} upvotes.`;
-        unit = ' upvotes';
-        break;
-      case 'CITED_AUTHOR':
-        descriptionText = `Author's publications Cited ${displayValue} times.`;
-        unit = ' citations';
-        break;
-      case 'OPEN_ACCESS':
-        value = Math.round(achievement.value * 100);
-        nextTierValue = nextTierValue * 100;
-        displayValue = value + '%';
-        nextTierDisplayValue = nextTierValue + '%';
-        descriptionText = `Published ${displayValue} of works as open access.`;
-        break;
-      default:
-        descriptionText = `Achieved ${displayValue} points.`;
-        break;
-    }
-
-    return (
-      <div className="p-2 text-sm flex flex-col gap-1 w-64 text-left">
-        <div className="flex items-center gap-2 font-semibold">
-          {React.cloneElement(achievementDetails.icon as React.ReactElement<any>, {
-            style: {
-              ...(achievementDetails.icon as React.ReactElement<any>).props.style,
-              fontSize: '18px',
-            },
-          })}
-          <span>
-            {achievementDetails.title} ({currentTierName})
-          </span>
-        </div>
-        <div className="text-xs font-normal mb-2">{descriptionText}</div>
-        {!isTopTier && (
-          <>
-            <div className="flex justify-between text-xs">
-              <span>Next tier:</span>
-              <span>
-                {displayValue} / {nextTierDisplayValue}
-                {unit}
-              </span>
-            </div>
-            <div className="w-full h-5 bg-gray-300 rounded relative text-white text-xs">
-              <div
-                className="absolute top-0 left-0 h-full flex items-center pl-1 rounded-l"
-                style={{ backgroundColor: filledColor, width: `${achievement.pctProgress * 100}%` }}
-              >
-                {nextTierName}
-              </div>
-            </div>
-          </>
-        )}
-        {isTopTier && (
-          <div className="text-xs font-semibold text-green-600">Max tier achieved!</div>
-        )}
-      </div>
-    );
-  };
-
+const Achievements = ({ achievements, isLoading }: AchievementsProps) => {
   if (isLoading) {
     return <AchievementsSkeleton />;
   }
 
   if (achievements.length === 0) {
     return (
-      <div className="flex flex-col items-start sidebar-profile:items-center justify-center gap-4 sidebar-profile:p-6 text-gray-500">
-        <FontAwesomeIcon
-          icon={faTrophyStar}
-          style={{ fontSize: '60px' }}
-          className="hidden sidebar-profile:block text-gray-400"
-        />
-        <div className="text-left sidebar-profile:text-center">
-          This user has not unlocked any achievements yet.
+      <div className="flex flex-col items-start sidebar-profile:items-center justify-center gap-3 sidebar-profile:py-6 text-gray-500">
+        <div className="hidden sidebar-profile:flex h-14 w-14 items-center justify-center rounded-2xl bg-gradient-to-br from-primary-50 to-primary-100">
+          <FontAwesomeIcon icon={faTrophyStar} className="text-2xl text-primary-500" />
+        </div>
+        <div className="text-sm text-left sidebar-profile:text-center">
+          No achievements unlocked yet.
         </div>
       </div>
     );
   }
 
   return (
-    <div className="flex flex-col gap-1.5">
+    <div className="flex flex-col gap-1">
       {achievements.map((achievement) => {
-        const achievementDetails = getAchievementDetails({ achievement });
+        const { meta, tier } = resolveAchievement(achievement);
         return (
           <Tooltip
-            key={achievement.type}
-            content={getTooltipContent(achievement, achievementDetails)}
+            key={`${achievement.type}-${achievement.currentMilestoneIndex}`}
+            content={<AchievementTooltipContent achievement={achievement} />}
             position="bottom"
             delay={100}
             width="w-auto"
-            className="bg-gray-800 text-white shadow-xl border-gray-700"
             wrapperClassName="w-full"
           >
             <div
               className={cn(
-                'flex items-center gap-1.5 text-xs font-medium rounded hover:bg-gray-100 dark:hover:bg-gray-700 cursor-default w-full'
+                'group flex items-center gap-2.5 rounded-lg px-1.5 py-1.5 w-full cursor-default',
+                'transition-colors hover:bg-gray-50 dark:hover:bg-gray-800'
               )}
             >
-              <div className="flex justify-center">
-                {React.cloneElement(achievementDetails.icon as React.ReactElement<any>, {
-                  style: {
-                    ...(achievementDetails.icon as React.ReactElement<any>).props.style,
-                    fontSize: '14px',
-                  },
-                })}
-              </div>
-              <span className="flex-1">{achievementDetails.title}</span>
+              <AchievementIconBadge icon={meta.icon} tier={tier} size="sm" />
+              <span className="flex-1 min-w-0 truncate text-sm font-medium text-gray-900">
+                {meta.title}
+              </span>
+              <TierPill tier={tier} />
             </div>
           </Tooltip>
         );

--- a/components/profile/ProfileAchievements.tsx
+++ b/components/profile/ProfileAchievements.tsx
@@ -106,7 +106,7 @@ interface AchievementTooltipProps {
 }
 
 function AchievementTooltipContent({ achievement }: Readonly<AchievementTooltipProps>) {
-  const { meta, tier, nextTier, displayValue, nextTierDisplayValue, isTopTier } =
+  const { meta, tier, nextTier, displayValue, targetDisplayValue, isTopTier } =
     resolveAchievement(achievement);
 
   const progressPct = Math.min(100, Math.max(0, achievement.pctProgress * 100));
@@ -125,38 +125,34 @@ function AchievementTooltipContent({ achievement }: Readonly<AchievementTooltipP
 
       <p className="text-xs leading-relaxed text-gray-600">{meta.describe(displayValue)}</p>
 
-      {isTopTier ? (
-        <div
-          className={cn(
-            'inline-flex items-center gap-1.5 self-start rounded-full border px-2 py-1 text-[11px] font-semibold',
-            tier.pillBg,
-            tier.pillText,
-            tier.pillBorder
-          )}
-        >
-          <FontAwesomeIcon icon={faSparkles} className="text-[10px]" />
-          Max tier achieved.
-        </div>
-      ) : (
-        <div className="flex flex-col gap-1.5">
-          <div className="flex items-center justify-between text-[11px] text-gray-500">
+      <div className="flex flex-col gap-1.5">
+        <div className="flex items-center justify-between text-[11px] text-gray-500">
+          {isTopTier ? (
+            <span className="inline-flex items-center gap-1 font-semibold text-emerald-600">
+              <FontAwesomeIcon icon={faSparkles} className="text-[10px]" />
+              Max tier achieved
+            </span>
+          ) : (
             <span className="inline-flex items-center gap-1">
               Next:
               <AchievementIconBadge icon={meta.icon} tier={nextTier ?? tier} size="xs" />
             </span>
-            <span className="font-medium text-gray-700">
-              {displayValue} / {nextTierDisplayValue}
-              {meta.unit}
-            </span>
-          </div>
-          <div className="h-1.5 w-full overflow-hidden rounded-full bg-gray-100">
-            <div
-              className={cn('h-full rounded-full transition-all duration-300', tier.barFill)}
-              style={{ width: `${progressPct}%` }}
-            />
-          </div>
+          )}
+          <span className="font-medium text-gray-700">
+            {displayValue} / {targetDisplayValue}
+            {meta.unit}
+          </span>
         </div>
-      )}
+        <div className="h-1.5 w-full overflow-hidden rounded-full bg-gray-100">
+          <div
+            className={cn(
+              'h-full rounded-full transition-all duration-300',
+              isTopTier ? 'bg-gradient-to-r from-emerald-600 to-emerald-300' : tier.barFill
+            )}
+            style={{ width: `${progressPct}%` }}
+          />
+        </div>
+      </div>
     </div>
   );
 }

--- a/components/profile/ProfileAchievements.tsx
+++ b/components/profile/ProfileAchievements.tsx
@@ -43,14 +43,10 @@ function AchievementIconBadge({
     >
       <span
         className="absolute inset-0 shadow-sm"
-        style={{ background: tier.outline, clipPath: CRYSTAL_SHIELD_CLIP }}
-      />
-      <span
-        className="absolute inset-[2px]"
         style={{ background: tier.fill, clipPath: CRYSTAL_SHIELD_CLIP }}
       />
       <span
-        className="absolute inset-[5px]"
+        className="absolute inset-[3px]"
         style={{ background: tier.facet, clipPath: CRYSTAL_SHIELD_CLIP }}
       />
       <FontAwesomeIcon
@@ -112,6 +108,7 @@ function AchievementTooltipContent({ achievement }: Readonly<AchievementTooltipP
   const {
     meta,
     tier,
+    nextTier,
     currentTierName,
     nextTierName,
     displayValue,
@@ -151,7 +148,10 @@ function AchievementTooltipContent({ achievement }: Readonly<AchievementTooltipP
         <div className="flex flex-col gap-1.5">
           <div className="flex items-center justify-between text-[11px] text-gray-500">
             <span>
-              Next: <span className={cn('font-semibold', tier.pillText)}>{nextTierName}</span>
+              Next:{' '}
+              <span className={cn('font-semibold', (nextTier ?? tier).pillText)}>
+                {nextTierName}
+              </span>
             </span>
             <span className="font-medium text-gray-700">
               {displayValue} / {nextTierDisplayValue}

--- a/components/profile/ProfileAchievements.tsx
+++ b/components/profile/ProfileAchievements.tsx
@@ -130,9 +130,7 @@ const AchievementTooltipContent = ({ resolved }: AchievementTooltipContentProps)
             </span>
           )}
           <span className="font-medium text-gray-700">
-            {isTopTier
-              ? [displayValue, meta.unit].filter(Boolean).join(' ')
-              : [displayValue, '/', targetDisplayValue, meta.unit].filter(Boolean).join(' ')}
+            {[displayValue, '/', targetDisplayValue, meta.unit].filter(Boolean).join(' ')}
           </span>
         </div>
         <div className="h-1.5 w-full overflow-hidden rounded-full bg-gray-100">

--- a/components/profile/ProfileAchievements.tsx
+++ b/components/profile/ProfileAchievements.tsx
@@ -2,23 +2,24 @@
 
 import { Achievement } from '@/types/authorProfile';
 import { Tooltip } from '@/components/ui/Tooltip';
-import { resolveAchievement, TierStyle } from './ProfileAchievements.utils';
+import { resolveAchievement, ResolvedAchievement, TierStyle } from './ProfileAchievements.utils';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { cn } from '@/utils/styles';
 import { faTrophyStar } from '@fortawesome/pro-light-svg-icons';
 import { faSparkles } from '@fortawesome/pro-solid-svg-icons';
 import type { IconDefinition } from '@fortawesome/fontawesome-svg-core';
 
-type BadgeSize = 'xs' | 'sm' | 'md' | 'lg';
+type BadgeSize = 'xs' | 'sm' | 'md';
 
-const BADGE_SIZE: Record<BadgeSize, { box: string; icon: string; facetInset: string }> = {
-  xs: { box: 'h-5 w-5', icon: 'text-[8px]', facetInset: 'inset-[2px]' },
-  sm: { box: 'h-8 w-8', icon: 'text-[11px]', facetInset: 'inset-[3px]' },
-  md: { box: 'h-10 w-10', icon: 'text-[14px]', facetInset: 'inset-[3px]' },
-  lg: { box: 'h-14 w-14', icon: 'text-[20px]', facetInset: 'inset-[5px]' },
+const BADGE_ICON_COLOR = '#FFFFFF';
+
+const BADGE_SIZE: Record<BadgeSize, { box: string; iconText: string; facetInset: string }> = {
+  xs: { box: 'h-5 w-5', iconText: 'text-[8px]', facetInset: 'inset-[2px]' },
+  sm: { box: 'h-8 w-8', iconText: 'text-[11px]', facetInset: 'inset-[3px]' },
+  md: { box: 'h-10 w-10', iconText: 'text-[14px]', facetInset: 'inset-[3px]' },
 };
 
-const CRYSTAL_SHIELD_CLIP = 'polygon(50% 0%, 91% 16%, 84% 70%, 50% 100%, 16% 70%, 9% 16%)';
+const BADGE_CLIP_PATH = 'polygon(50% 0%, 91% 16%, 84% 70%, 50% 100%, 16% 70%, 9% 16%)';
 
 interface AchievementIconBadgeProps {
   icon: IconDefinition;
@@ -27,13 +28,13 @@ interface AchievementIconBadgeProps {
   className?: string;
 }
 
-function AchievementIconBadge({
+const AchievementIconBadge = ({
   icon,
   tier,
   size = 'sm',
   className,
-}: Readonly<AchievementIconBadgeProps>) {
-  const { box, icon: iconClass, facetInset } = BADGE_SIZE[size];
+}: AchievementIconBadgeProps) => {
+  const { box, iconText, facetInset } = BADGE_SIZE[size];
   return (
     <span
       className={cn(
@@ -44,72 +45,62 @@ function AchievementIconBadge({
     >
       <span
         className="absolute inset-0 shadow-sm"
-        style={{ background: tier.fill, clipPath: CRYSTAL_SHIELD_CLIP }}
+        style={{ background: tier.fill, clipPath: BADGE_CLIP_PATH }}
       />
       <span
         className={cn('absolute', facetInset)}
-        style={{ background: tier.facet, clipPath: CRYSTAL_SHIELD_CLIP }}
+        style={{ background: tier.facet, clipPath: BADGE_CLIP_PATH }}
       />
       <FontAwesomeIcon
         icon={icon}
-        className={cn('relative drop-shadow-sm', iconClass)}
-        style={{ color: tier.iconColor }}
+        className={cn('relative drop-shadow-sm', iconText)}
+        style={{ color: BADGE_ICON_COLOR }}
       />
     </span>
   );
-}
+};
 
 interface TierPillProps {
   tier: TierStyle;
   className?: string;
 }
 
-function TierPill({ tier, className }: Readonly<TierPillProps>) {
-  return (
-    <span
-      className={cn(
-        'inline-flex items-center rounded-full border px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide leading-none',
-        tier.pillBg,
-        tier.pillText,
-        tier.pillBorder,
-        className
-      )}
-    >
-      {tier.label}
-    </span>
-  );
+const TierPill = ({ tier, className }: TierPillProps) => (
+  <span
+    className={cn(
+      'inline-flex items-center rounded-full border px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide leading-none',
+      tier.pillBg,
+      tier.pillText,
+      tier.pillBorder,
+      className
+    )}
+  >
+    {tier.label}
+  </span>
+);
+
+export const AchievementsSkeleton = () => (
+  <div className="flex flex-col gap-1.5">
+    {Array.from({ length: 4 }).map((_, skeletonIndex) => (
+      <div
+        key={'achievement-skeleton-' + skeletonIndex}
+        className="flex items-center gap-2.5 py-1.5 px-1.5 rounded-lg w-full"
+      >
+        <div className="h-8 w-8 rounded-lg bg-gray-200 animate-pulse flex-shrink-0" />
+        <div className="flex-1 h-4 bg-gray-200 rounded animate-pulse" />
+        <div className="h-4 w-12 bg-gray-200 rounded-full animate-pulse" />
+      </div>
+    ))}
+  </div>
+);
+
+interface AchievementTooltipContentProps {
+  resolved: ResolvedAchievement;
 }
 
-const SKELETON_ROWS = [
-  'achievement-skeleton-1',
-  'achievement-skeleton-2',
-  'achievement-skeleton-3',
-  'achievement-skeleton-4',
-] as const;
-
-export function AchievementsSkeleton() {
-  return (
-    <div className="flex flex-col gap-1.5">
-      {SKELETON_ROWS.map((rowId) => (
-        <div key={rowId} className="flex items-center gap-2.5 py-1.5 px-1.5 rounded-lg w-full">
-          <div className="h-8 w-8 rounded-lg bg-gray-200 animate-pulse flex-shrink-0" />
-          <div className="flex-1 h-4 bg-gray-200 rounded animate-pulse" />
-          <div className="h-4 w-12 bg-gray-200 rounded-full animate-pulse" />
-        </div>
-      ))}
-    </div>
-  );
-}
-
-interface AchievementTooltipProps {
-  achievement: Achievement;
-}
-
-function AchievementTooltipContent({ achievement }: Readonly<AchievementTooltipProps>) {
-  const { meta, tier, nextTier, displayValue, targetDisplayValue, isTopTier } =
-    resolveAchievement(achievement);
-
-  const progressPct = Math.min(100, Math.max(0, achievement.pctProgress * 100));
+const AchievementTooltipContent = ({ resolved }: AchievementTooltipContentProps) => {
+  const { meta, tier, nextTier, displayValue, targetDisplayValue, progressPct, isTopTier } =
+    resolved;
 
   return (
     <div className="flex w-72 flex-col gap-3 p-1 text-left">
@@ -135,12 +126,12 @@ function AchievementTooltipContent({ achievement }: Readonly<AchievementTooltipP
           ) : (
             <span className="inline-flex items-center gap-1">
               Next:
-              <AchievementIconBadge icon={meta.icon} tier={nextTier ?? tier} size="xs" />
+              <AchievementIconBadge icon={meta.icon} tier={nextTier!} size="xs" />
             </span>
           )}
           <span className="font-medium text-gray-700">
             {displayValue} / {targetDisplayValue}
-            {meta.unit}
+            {meta.unit && ` ${meta.unit}`}
           </span>
         </div>
         <div className="h-1.5 w-full overflow-hidden rounded-full bg-gray-100">
@@ -155,14 +146,14 @@ function AchievementTooltipContent({ achievement }: Readonly<AchievementTooltipP
       </div>
     </div>
   );
-}
+};
 
-interface AchievementsProps {
+interface ProfileAchievementsProps {
   achievements: Achievement[];
   isLoading: boolean;
 }
 
-const Achievements = ({ achievements, isLoading }: AchievementsProps) => {
+const ProfileAchievements = ({ achievements, isLoading }: ProfileAchievementsProps) => {
   if (isLoading) {
     return <AchievementsSkeleton />;
   }
@@ -183,27 +174,22 @@ const Achievements = ({ achievements, isLoading }: AchievementsProps) => {
   return (
     <div className="flex flex-col gap-1">
       {achievements.map((achievement) => {
-        const { meta, tier } = resolveAchievement(achievement);
+        const resolved = resolveAchievement(achievement);
         return (
           <Tooltip
             key={`${achievement.type}-${achievement.currentMilestoneIndex}`}
-            content={<AchievementTooltipContent achievement={achievement} />}
+            content={<AchievementTooltipContent resolved={resolved} />}
             position="bottom"
             delay={100}
             width="w-auto"
             wrapperClassName="w-full"
           >
-            <div
-              className={cn(
-                'group flex items-center gap-2.5 rounded-lg px-1.5 py-1.5 w-full cursor-default',
-                'transition-colors hover:bg-gray-50 dark:hover:bg-gray-800'
-              )}
-            >
-              <AchievementIconBadge icon={meta.icon} tier={tier} size="sm" />
+            <div className="group flex items-center gap-2.5 rounded-lg px-1.5 py-1.5 w-full cursor-default transition-colors hover:bg-gray-50 dark:hover:bg-gray-800">
+              <AchievementIconBadge icon={resolved.meta.icon} tier={resolved.tier} size="sm" />
               <span className="flex-1 min-w-0 truncate text-sm font-medium text-gray-900">
-                {meta.title}
+                {resolved.meta.title}
               </span>
-              <TierPill tier={tier} />
+              <TierPill tier={resolved.tier} />
             </div>
           </Tooltip>
         );
@@ -212,4 +198,4 @@ const Achievements = ({ achievements, isLoading }: AchievementsProps) => {
   );
 };
 
-export default Achievements;
+export default ProfileAchievements;

--- a/components/profile/ProfileAchievements.tsx
+++ b/components/profile/ProfileAchievements.tsx
@@ -9,12 +9,13 @@ import { faTrophyStar } from '@fortawesome/pro-light-svg-icons';
 import { faSparkles } from '@fortawesome/pro-solid-svg-icons';
 import type { IconDefinition } from '@fortawesome/fontawesome-svg-core';
 
-type BadgeSize = 'sm' | 'md' | 'lg';
+type BadgeSize = 'xs' | 'sm' | 'md' | 'lg';
 
-const BADGE_SIZE: Record<BadgeSize, { box: string; icon: string }> = {
-  sm: { box: 'h-8 w-8', icon: 'text-[11px]' },
-  md: { box: 'h-10 w-10', icon: 'text-[14px]' },
-  lg: { box: 'h-14 w-14', icon: 'text-[20px]' },
+const BADGE_SIZE: Record<BadgeSize, { box: string; icon: string; facetInset: string }> = {
+  xs: { box: 'h-5 w-5', icon: 'text-[8px]', facetInset: 'inset-[2px]' },
+  sm: { box: 'h-8 w-8', icon: 'text-[11px]', facetInset: 'inset-[3px]' },
+  md: { box: 'h-10 w-10', icon: 'text-[14px]', facetInset: 'inset-[3px]' },
+  lg: { box: 'h-14 w-14', icon: 'text-[20px]', facetInset: 'inset-[5px]' },
 };
 
 const CRYSTAL_SHIELD_CLIP = 'polygon(50% 0%, 91% 16%, 84% 70%, 50% 100%, 16% 70%, 9% 16%)';
@@ -32,7 +33,7 @@ function AchievementIconBadge({
   size = 'sm',
   className,
 }: Readonly<AchievementIconBadgeProps>) {
-  const { box, icon: iconClass } = BADGE_SIZE[size];
+  const { box, icon: iconClass, facetInset } = BADGE_SIZE[size];
   return (
     <span
       className={cn(
@@ -46,7 +47,7 @@ function AchievementIconBadge({
         style={{ background: tier.fill, clipPath: CRYSTAL_SHIELD_CLIP }}
       />
       <span
-        className="absolute inset-[3px]"
+        className={cn('absolute', facetInset)}
         style={{ background: tier.facet, clipPath: CRYSTAL_SHIELD_CLIP }}
       />
       <FontAwesomeIcon
@@ -105,16 +106,8 @@ interface AchievementTooltipProps {
 }
 
 function AchievementTooltipContent({ achievement }: Readonly<AchievementTooltipProps>) {
-  const {
-    meta,
-    tier,
-    nextTier,
-    currentTierName,
-    nextTierName,
-    displayValue,
-    nextTierDisplayValue,
-    isTopTier,
-  } = resolveAchievement(achievement);
+  const { meta, tier, nextTier, displayValue, nextTierDisplayValue, isTopTier } =
+    resolveAchievement(achievement);
 
   const progressPct = Math.min(100, Math.max(0, achievement.pctProgress * 100));
 
@@ -142,16 +135,14 @@ function AchievementTooltipContent({ achievement }: Readonly<AchievementTooltipP
           )}
         >
           <FontAwesomeIcon icon={faSparkles} className="text-[10px]" />
-          {currentTierName} tier achieved
+          Max tier achieved.
         </div>
       ) : (
         <div className="flex flex-col gap-1.5">
           <div className="flex items-center justify-between text-[11px] text-gray-500">
-            <span>
-              Next:{' '}
-              <span className={cn('font-semibold', (nextTier ?? tier).pillText)}>
-                {nextTierName}
-              </span>
+            <span className="inline-flex items-center gap-1">
+              Next:
+              <AchievementIconBadge icon={meta.icon} tier={nextTier ?? tier} size="xs" />
             </span>
             <span className="font-medium text-gray-700">
               {displayValue} / {nextTierDisplayValue}

--- a/components/profile/ProfileAchievements.tsx
+++ b/components/profile/ProfileAchievements.tsx
@@ -131,8 +131,8 @@ const AchievementTooltipContent = ({ resolved }: AchievementTooltipContentProps)
           )}
           <span className="font-medium text-gray-700">
             {isTopTier
-              ? `${displayValue}${meta.unit ? ` ${meta.unit}` : ''}`
-              : `${displayValue} / ${targetDisplayValue}${meta.unit ? ` ${meta.unit}` : ''}`}
+              ? [displayValue, meta.unit].filter(Boolean).join(' ')
+              : [displayValue, '/', targetDisplayValue, meta.unit].filter(Boolean).join(' ')}
           </span>
         </div>
         <div className="h-1.5 w-full overflow-hidden rounded-full bg-gray-100">

--- a/components/profile/ProfileAchievements.tsx
+++ b/components/profile/ProfileAchievements.tsx
@@ -26,7 +26,12 @@ interface AchievementIconBadgeProps {
   className?: string;
 }
 
-function AchievementIconBadge({ icon, tier, size = 'sm', className }: AchievementIconBadgeProps) {
+function AchievementIconBadge({
+  icon,
+  tier,
+  size = 'sm',
+  className,
+}: Readonly<AchievementIconBadgeProps>) {
   const { box, icon: iconClass } = BADGE_SIZE[size];
   return (
     <span
@@ -62,7 +67,7 @@ interface TierPillProps {
   className?: string;
 }
 
-function TierPill({ tier, className }: TierPillProps) {
+function TierPill({ tier, className }: Readonly<TierPillProps>) {
   return (
     <span
       className={cn(
@@ -78,11 +83,18 @@ function TierPill({ tier, className }: TierPillProps) {
   );
 }
 
+const SKELETON_ROWS = [
+  'achievement-skeleton-1',
+  'achievement-skeleton-2',
+  'achievement-skeleton-3',
+  'achievement-skeleton-4',
+] as const;
+
 export function AchievementsSkeleton() {
   return (
     <div className="flex flex-col gap-1.5">
-      {[...Array(4)].map((_, i) => (
-        <div key={i} className="flex items-center gap-2.5 py-1.5 px-1.5 rounded-lg w-full">
+      {SKELETON_ROWS.map((rowId) => (
+        <div key={rowId} className="flex items-center gap-2.5 py-1.5 px-1.5 rounded-lg w-full">
           <div className="h-8 w-8 rounded-lg bg-gray-200 animate-pulse flex-shrink-0" />
           <div className="flex-1 h-4 bg-gray-200 rounded animate-pulse" />
           <div className="h-4 w-12 bg-gray-200 rounded-full animate-pulse" />
@@ -96,7 +108,7 @@ interface AchievementTooltipProps {
   achievement: Achievement;
 }
 
-function AchievementTooltipContent({ achievement }: AchievementTooltipProps) {
+function AchievementTooltipContent({ achievement }: Readonly<AchievementTooltipProps>) {
   const {
     meta,
     tier,
@@ -123,7 +135,19 @@ function AchievementTooltipContent({ achievement }: AchievementTooltipProps) {
 
       <p className="text-xs leading-relaxed text-gray-600">{meta.describe(displayValue)}</p>
 
-      {!isTopTier ? (
+      {isTopTier ? (
+        <div
+          className={cn(
+            'inline-flex items-center gap-1.5 self-start rounded-full border px-2 py-1 text-[11px] font-semibold',
+            tier.pillBg,
+            tier.pillText,
+            tier.pillBorder
+          )}
+        >
+          <FontAwesomeIcon icon={faSparkles} className="text-[10px]" />
+          {currentTierName} tier achieved
+        </div>
+      ) : (
         <div className="flex flex-col gap-1.5">
           <div className="flex items-center justify-between text-[11px] text-gray-500">
             <span>
@@ -140,18 +164,6 @@ function AchievementTooltipContent({ achievement }: AchievementTooltipProps) {
               style={{ width: `${progressPct}%` }}
             />
           </div>
-        </div>
-      ) : (
-        <div
-          className={cn(
-            'inline-flex items-center gap-1.5 self-start rounded-full border px-2 py-1 text-[11px] font-semibold',
-            tier.pillBg,
-            tier.pillText,
-            tier.pillBorder
-          )}
-        >
-          <FontAwesomeIcon icon={faSparkles} className="text-[10px]" />
-          {currentTierName} tier achieved
         </div>
       )}
     </div>

--- a/components/profile/ProfileAchievements.tsx
+++ b/components/profile/ProfileAchievements.tsx
@@ -130,8 +130,9 @@ const AchievementTooltipContent = ({ resolved }: AchievementTooltipContentProps)
             </span>
           )}
           <span className="font-medium text-gray-700">
-            {displayValue} / {targetDisplayValue}
-            {meta.unit && ` ${meta.unit}`}
+            {isTopTier
+              ? `${displayValue}${meta.unit ? ` ${meta.unit}` : ''}`
+              : `${displayValue} / ${targetDisplayValue}${meta.unit ? ` ${meta.unit}` : ''}`}
           </span>
         </div>
         <div className="h-1.5 w-full overflow-hidden rounded-full bg-gray-100">

--- a/components/profile/ProfileAchievements.tsx
+++ b/components/profile/ProfileAchievements.tsx
@@ -11,8 +11,6 @@ import type { IconDefinition } from '@fortawesome/fontawesome-svg-core';
 
 type BadgeSize = 'xs' | 'sm' | 'md';
 
-const BADGE_ICON_COLOR = '#FFFFFF';
-
 const BADGE_SIZE: Record<BadgeSize, { box: string; iconText: string; facetInset: string }> = {
   xs: { box: 'h-5 w-5', iconText: 'text-[8px]', facetInset: 'inset-[2px]' },
   sm: { box: 'h-8 w-8', iconText: 'text-[11px]', facetInset: 'inset-[3px]' },
@@ -54,7 +52,7 @@ const AchievementIconBadge = ({
       <FontAwesomeIcon
         icon={icon}
         className={cn('relative drop-shadow-sm', iconText)}
-        style={{ color: BADGE_ICON_COLOR }}
+        style={{ color: '#FFFFFF' }}
       />
     </span>
   );

--- a/components/profile/ProfileAchievements.utils.ts
+++ b/components/profile/ProfileAchievements.utils.ts
@@ -124,7 +124,7 @@ const FALLBACK_META: AchievementMeta = {
 
 const toTitleCase = (text: string) =>
   text
-    .replace(/_/g, ' ')
+    .replaceAll('_', ' ')
     .replace(/\w\S*/g, (word) => word.charAt(0).toUpperCase() + word.substring(1).toLowerCase());
 
 const getAchievementMeta = (type: AchievementType): AchievementMeta => {

--- a/components/profile/ProfileAchievements.utils.ts
+++ b/components/profile/ProfileAchievements.utils.ts
@@ -9,53 +9,42 @@ import {
 } from '@fortawesome/pro-solid-svg-icons';
 import type { IconDefinition } from '@fortawesome/fontawesome-svg-core';
 
-export const TIER_INDICES = ['Tier1', 'Tier2', 'Tier3'] as const;
-export type TierName = (typeof TIER_INDICES)[number];
+const TIER_NAMES = ['Bronze', 'Silver', 'Gold'] as const;
+type TierName = (typeof TIER_NAMES)[number];
 
 export interface TierStyle {
-  name: TierName;
-  label: string;
+  label: TierName;
   fill: string;
   facet: string;
-  iconColor: string;
   pillBg: string;
   pillText: string;
   pillBorder: string;
   barFill: string;
 }
 
-export const TIER_STYLES: Record<TierName, TierStyle> = {
-  Tier1: {
-    name: 'Tier1',
-    label: 'Bronze',
+const TIER_STYLES: Record<TierName, Omit<TierStyle, 'label'>> = {
+  Bronze: {
     fill: 'linear-gradient(145deg,#E0A26B 0%,#B57440 48%,#7C3A1A 100%)',
     facet:
       'linear-gradient(145deg,rgba(255,238,212,0.55) 0%,rgba(255,200,140,0.18) 48%,rgba(120,60,20,0) 100%)',
-    iconColor: '#FFFFFF',
     pillBg: 'bg-amber-50',
     pillText: 'text-amber-800',
     pillBorder: 'border-amber-200',
     barFill: 'bg-gradient-to-r from-amber-700 to-amber-400',
   },
-  Tier2: {
-    name: 'Tier2',
-    label: 'Silver',
+  Silver: {
     fill: 'linear-gradient(145deg,#E2E8F0 0%,#94A3B8 48%,#475569 100%)',
     facet:
       'linear-gradient(145deg,rgba(255,255,255,0.55) 0%,rgba(255,255,255,0.18) 48%,rgba(255,255,255,0) 100%)',
-    iconColor: '#FFFFFF',
     pillBg: 'bg-slate-100',
     pillText: 'text-slate-700',
     pillBorder: 'border-slate-300',
     barFill: 'bg-gradient-to-r from-slate-600 to-slate-300',
   },
-  Tier3: {
-    name: 'Tier3',
-    label: 'Gold',
+  Gold: {
     fill: 'linear-gradient(145deg,#FFE08A 0%,#D79A18 48%,#8A5A00 100%)',
     facet:
       'linear-gradient(145deg,rgba(255,255,255,0.55) 0%,rgba(255,235,170,0.18) 48%,rgba(255,255,255,0) 100%)',
-    iconColor: '#FFFFFF',
     pillBg: 'bg-amber-100',
     pillText: 'text-amber-900',
     pillBorder: 'border-amber-300',
@@ -63,19 +52,13 @@ export const TIER_STYLES: Record<TierName, TierStyle> = {
   },
 };
 
-const getTierNameForIndex = (index: number): TierName => {
-  const boundedIndex = Math.min(Math.max(index, 0), TIER_INDICES.length - 1);
-  return TIER_INDICES[boundedIndex];
+const getTierStyleForIndex = (index: number): TierStyle => {
+  const bounded = Math.min(Math.max(index, 0), TIER_NAMES.length - 1);
+  const name = TIER_NAMES[bounded];
+  return { label: name, ...TIER_STYLES[name] };
 };
 
-export const getTierStyleForIndex = (index: number): TierStyle => {
-  const name = getTierNameForIndex(index);
-  return TIER_STYLES[name];
-};
-
-export const getTierLabelForIndex = (index: number): string => getTierStyleForIndex(index).label;
-
-export interface AchievementMeta {
+interface AchievementMeta {
   icon: IconDefinition;
   title: string;
   unit: string;
@@ -86,38 +69,39 @@ export interface AchievementMeta {
 }
 
 const integerFormatter = (value: number) => Math.round(value).toLocaleString();
+
 const percentFormatter = (value: number) => {
-  const percentage = value * 100;
-  const displayValue = Number.isInteger(percentage) ? percentage.toString() : percentage.toFixed(1);
-  return `${displayValue}%`;
+  const pct = value * 100;
+  const formatted = Number.isInteger(pct) ? pct.toString() : pct.toFixed(1);
+  return `${formatted}%`;
 };
 
 const ACHIEVEMENT_META: Record<AchievementType, AchievementMeta> = {
   OPEN_SCIENCE_SUPPORTER: {
     icon: faHandHoldingHeart,
     title: 'Open Science Supporter',
-    unit: ' RSC',
+    unit: 'RSC',
     formatValue: integerFormatter,
     describe: (value) => `Funded open science using ${value} RSC.`,
   },
   CITED_AUTHOR: {
     icon: faQuoteLeft,
     title: 'Cited Author',
-    unit: ' citations',
+    unit: 'citations',
     formatValue: integerFormatter,
     describe: (value) => `Publications have been cited ${value} times.`,
   },
   EXPERT_PEER_REVIEWER: {
     icon: faGlasses,
     title: 'Peer Reviewer',
-    unit: ' reviews',
+    unit: 'reviews',
     formatValue: integerFormatter,
     describe: (value) => `Peer reviewed ${value} publications.`,
   },
   HIGHLY_UPVOTED: {
     icon: faFire,
     title: 'Active User',
-    unit: ' upvotes',
+    unit: 'upvotes',
     formatValue: integerFormatter,
     describe: (value) => `Received ${value} upvotes from the community.`,
   },
@@ -125,7 +109,6 @@ const ACHIEVEMENT_META: Record<AchievementType, AchievementMeta> = {
     icon: faChartNetwork,
     title: 'Open Access Advocate',
     unit: '',
-    // Stored as a 0-1 ratio in the API payload; surface as a percentage.
     formatValue: percentFormatter,
     describe: (value) => `${value} of works published as open access.`,
   },
@@ -139,16 +122,13 @@ const FALLBACK_META: AchievementMeta = {
   describe: (value) => `Achieved ${value} points.`,
 };
 
-export const getAchievementMeta = (type: AchievementType): AchievementMeta => {
-  const meta = ACHIEVEMENT_META[type];
-  if (meta) return meta;
+const toTitleCase = (text: string) =>
+  text
+    .replace(/_/g, ' ')
+    .replace(/\w\S*/g, (word) => word.charAt(0).toUpperCase() + word.substring(1).toLowerCase());
 
-  return {
-    ...FALLBACK_META,
-    title: (type as string)
-      .replace(/_/g, ' ')
-      .replace(/\w\S*/g, (txt) => txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase()),
-  };
+const getAchievementMeta = (type: AchievementType): AchievementMeta => {
+  return ACHIEVEMENT_META[type] ?? { ...FALLBACK_META, title: toTitleCase(type) };
 };
 
 export interface ResolvedAchievement {
@@ -156,8 +136,6 @@ export interface ResolvedAchievement {
   tier: TierStyle;
   /** Styling for the next tier above the current one, when one exists. */
   nextTier: TierStyle | undefined;
-  currentTierName: string;
-  nextTierName: string;
   displayValue: string;
   /**
    * The value the progress row compares against on the right of the bar.
@@ -166,22 +144,20 @@ export interface ResolvedAchievement {
    * `value / threshold` (often value > threshold for max tier).
    */
   targetDisplayValue: string;
+  progressPct: number;
   isTopTier: boolean;
 }
 
 export const resolveAchievement = (achievement: Achievement): ResolvedAchievement => {
   const meta = getAchievementMeta(achievement.type);
   const tier = getTierStyleForIndex(achievement.currentMilestoneIndex);
-  const currentTierName = tier.label;
-  const hasNextTier = Boolean(achievement.milestones[achievement.currentMilestoneIndex + 1]);
+
+  const hasNextTier = achievement.currentMilestoneIndex + 1 < achievement.milestones.length;
   const nextTier = hasNextTier
     ? getTierStyleForIndex(achievement.currentMilestoneIndex + 1)
     : undefined;
-  const nextTierName = nextTier?.label ?? 'Max Tier';
 
-  const isTopTier =
-    achievement.currentMilestoneIndex === achievement.milestones.length - 1 ||
-    achievement.currentMilestoneIndex >= TIER_INDICES.length - 1;
+  const isTopTier = !hasNextTier || achievement.currentMilestoneIndex >= TIER_NAMES.length - 1;
 
   const targetRawValue = isTopTier
     ? (achievement.milestones[achievement.currentMilestoneIndex] ?? 0)
@@ -191,10 +167,9 @@ export const resolveAchievement = (achievement: Achievement): ResolvedAchievemen
     meta,
     tier,
     nextTier,
-    currentTierName,
-    nextTierName,
     displayValue: meta.formatValue(achievement.value),
     targetDisplayValue: meta.formatValue(targetRawValue),
+    progressPct: Math.min(100, Math.max(0, achievement.pctProgress * 100)),
     isTopTier,
   };
 };

--- a/components/profile/ProfileAchievements.utils.tsx
+++ b/components/profile/ProfileAchievements.utils.tsx
@@ -15,7 +15,6 @@ export type TierName = (typeof TIER_INDICES)[number];
 export interface TierStyle {
   name: TierName;
   label: string;
-  outline: string;
   fill: string;
   facet: string;
   iconColor: string;
@@ -28,39 +27,39 @@ export interface TierStyle {
 export const TIER_STYLES: Record<TierName, TierStyle> = {
   Tier1: {
     name: 'Tier1',
-    label: 'Tier 1',
-    outline: '#93C5FD',
-    fill: 'linear-gradient(145deg,#F8FBFF 0%,#DBEAFE 46%,#9CC9FF 100%)',
-    facet: 'linear-gradient(145deg,#FFFFFF 0%,#EFF6FF 48%,#CFE3FF 100%)',
-    iconColor: '#1D4ED8',
-    pillBg: 'bg-primary-50',
-    pillText: 'text-primary-700',
-    pillBorder: 'border-primary-200',
-    barFill: 'bg-gradient-to-r from-primary-200 to-primary-400',
+    label: 'Bronze',
+    fill: 'linear-gradient(145deg,#E0A26B 0%,#B57440 48%,#7C3A1A 100%)',
+    facet:
+      'linear-gradient(145deg,rgba(255,238,212,0.55) 0%,rgba(255,200,140,0.18) 48%,rgba(120,60,20,0) 100%)',
+    iconColor: '#FFFFFF',
+    pillBg: 'bg-amber-50',
+    pillText: 'text-amber-800',
+    pillBorder: 'border-amber-200',
+    barFill: 'bg-gradient-to-r from-amber-700 to-amber-400',
   },
   Tier2: {
     name: 'Tier2',
-    label: 'Tier 2',
-    outline: '#3971FF',
-    fill: 'linear-gradient(145deg,#DBEAFE 0%,#3971FF 58%,#1D4ED8 100%)',
-    facet: 'rgba(255, 255, 255, 0.24)',
+    label: 'Silver',
+    fill: 'linear-gradient(145deg,#E2E8F0 0%,#94A3B8 48%,#475569 100%)',
+    facet:
+      'linear-gradient(145deg,rgba(255,255,255,0.55) 0%,rgba(255,255,255,0.18) 48%,rgba(255,255,255,0) 100%)',
     iconColor: '#FFFFFF',
-    pillBg: 'bg-primary-100',
-    pillText: 'text-primary-800',
-    pillBorder: 'border-primary-300',
-    barFill: 'bg-gradient-to-r from-primary-400 to-primary-700',
+    pillBg: 'bg-slate-100',
+    pillText: 'text-slate-700',
+    pillBorder: 'border-slate-300',
+    barFill: 'bg-gradient-to-r from-slate-600 to-slate-300',
   },
   Tier3: {
     name: 'Tier3',
-    label: 'Tier 3',
-    outline: '#172554',
-    fill: 'linear-gradient(145deg,#3971FF 0%,#1E40AF 54%,#0B1B5E 100%)',
-    facet: 'rgba(255, 255, 255, 0.2)',
+    label: 'Gold',
+    fill: 'linear-gradient(145deg,#FFE08A 0%,#D79A18 48%,#8A5A00 100%)',
+    facet:
+      'linear-gradient(145deg,rgba(255,255,255,0.55) 0%,rgba(255,235,170,0.18) 48%,rgba(255,255,255,0) 100%)',
     iconColor: '#FFFFFF',
-    pillBg: 'bg-blue-50',
-    pillText: 'text-blue-900',
-    pillBorder: 'border-blue-200',
-    barFill: 'bg-gradient-to-r from-primary-600 to-blue-950',
+    pillBg: 'bg-amber-100',
+    pillText: 'text-amber-900',
+    pillBorder: 'border-amber-300',
+    barFill: 'bg-gradient-to-r from-yellow-600 to-yellow-300',
   },
 };
 
@@ -155,6 +154,8 @@ export const getAchievementMeta = (type: AchievementType): AchievementMeta => {
 export interface ResolvedAchievement {
   meta: AchievementMeta;
   tier: TierStyle;
+  /** Styling for the next tier above the current one, when one exists. */
+  nextTier: TierStyle | undefined;
   currentTierName: string;
   nextTierName: string;
   displayValue: string;
@@ -166,9 +167,11 @@ export const resolveAchievement = (achievement: Achievement): ResolvedAchievemen
   const meta = getAchievementMeta(achievement.type);
   const tier = getTierStyleForIndex(achievement.currentMilestoneIndex);
   const currentTierName = tier.label;
-  const nextTierName = achievement.milestones[achievement.currentMilestoneIndex + 1]
-    ? getTierLabelForIndex(achievement.currentMilestoneIndex + 1)
-    : 'Max Tier';
+  const hasNextTier = Boolean(achievement.milestones[achievement.currentMilestoneIndex + 1]);
+  const nextTier = hasNextTier
+    ? getTierStyleForIndex(achievement.currentMilestoneIndex + 1)
+    : undefined;
+  const nextTierName = nextTier?.label ?? 'Max Tier';
 
   const isTopTier =
     achievement.currentMilestoneIndex === achievement.milestones.length - 1 ||
@@ -179,6 +182,7 @@ export const resolveAchievement = (achievement: Achievement): ResolvedAchievemen
   return {
     meta,
     tier,
+    nextTier,
     currentTierName,
     nextTierName,
     displayValue: meta.formatValue(achievement.value),

--- a/components/profile/ProfileAchievements.utils.tsx
+++ b/components/profile/ProfileAchievements.utils.tsx
@@ -1,104 +1,188 @@
-import { Achievement } from '@/types/authorProfile';
-import { ReactElement } from 'react';
-import { faAward } from '@fortawesome/pro-light-svg-icons';
-import { faQuoteRight, faCircleUp, faStar, faLockOpen } from '@fortawesome/pro-solid-svg-icons';
-import React from 'react';
-import { Icon } from '@/components/ui/icons/Icon';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { Achievement, AchievementType } from '@/types/authorProfile';
+import {
+  faAward,
+  faChartNetwork,
+  faFire,
+  faGlasses,
+  faHandHoldingHeart,
+  faQuoteLeft,
+} from '@fortawesome/pro-solid-svg-icons';
+import type { IconDefinition } from '@fortawesome/fontawesome-svg-core';
 
-// Define Tier colors and names - adjust these to your application's theme
-export const TIER_COLORS = [
-  '#A97142', // Bronze
-  '#A8A8A8', // Silver
-  '#FFBF00', // Gold
-  '#B9B9D7', // Platinum
-  '#65C6E2', // Diamond
-];
+export const TIER_INDICES = ['Tier1', 'Tier2', 'Tier3'] as const;
+export type TierName = (typeof TIER_INDICES)[number];
 
-export const TIER_INDICES = ['Bronze', 'Silver', 'Gold', 'Platinum', 'Diamond'];
+export interface TierStyle {
+  name: TierName;
+  label: string;
+  outline: string;
+  fill: string;
+  facet: string;
+  iconColor: string;
+  pillBg: string;
+  pillText: string;
+  pillBorder: string;
+  barFill: string;
+}
 
-interface AchievementDetails {
-  icon: ReactElement;
+export const TIER_STYLES: Record<TierName, TierStyle> = {
+  Tier1: {
+    name: 'Tier1',
+    label: 'Tier 1',
+    outline: '#93C5FD',
+    fill: 'linear-gradient(145deg,#F8FBFF 0%,#DBEAFE 46%,#9CC9FF 100%)',
+    facet: 'linear-gradient(145deg,#FFFFFF 0%,#EFF6FF 48%,#CFE3FF 100%)',
+    iconColor: '#1D4ED8',
+    pillBg: 'bg-primary-50',
+    pillText: 'text-primary-700',
+    pillBorder: 'border-primary-200',
+    barFill: 'bg-gradient-to-r from-primary-200 to-primary-400',
+  },
+  Tier2: {
+    name: 'Tier2',
+    label: 'Tier 2',
+    outline: '#3971FF',
+    fill: 'linear-gradient(145deg,#DBEAFE 0%,#3971FF 58%,#1D4ED8 100%)',
+    facet: 'rgba(255, 255, 255, 0.24)',
+    iconColor: '#FFFFFF',
+    pillBg: 'bg-primary-100',
+    pillText: 'text-primary-800',
+    pillBorder: 'border-primary-300',
+    barFill: 'bg-gradient-to-r from-primary-400 to-primary-700',
+  },
+  Tier3: {
+    name: 'Tier3',
+    label: 'Tier 3',
+    outline: '#172554',
+    fill: 'linear-gradient(145deg,#3971FF 0%,#1E40AF 54%,#0B1B5E 100%)',
+    facet: 'rgba(255, 255, 255, 0.2)',
+    iconColor: '#FFFFFF',
+    pillBg: 'bg-blue-50',
+    pillText: 'text-blue-900',
+    pillBorder: 'border-blue-200',
+    barFill: 'bg-gradient-to-r from-primary-600 to-blue-950',
+  },
+};
+
+const getTierNameForIndex = (index: number): TierName => {
+  const boundedIndex = Math.min(Math.max(index, 0), TIER_INDICES.length - 1);
+  return TIER_INDICES[boundedIndex];
+};
+
+export const getTierStyleForIndex = (index: number): TierStyle => {
+  const name = getTierNameForIndex(index);
+  return TIER_STYLES[name];
+};
+
+export const getTierLabelForIndex = (index: number): string => getTierStyleForIndex(index).label;
+
+export interface AchievementMeta {
+  icon: IconDefinition;
   title: string;
+  unit: string;
+  /** Formats raw `Achievement.value` into the user-facing display value. */
+  formatValue: (value: number) => string;
+  /** Short narrative describing the achievement at the current value. */
+  describe: (displayValue: string) => string;
 }
 
-function getTierCircleStyle(tierColor: string, size: number = 14) {
+const integerFormatter = (value: number) => Math.round(value).toLocaleString();
+const percentFormatter = (value: number) => {
+  const percentage = value * 100;
+  const displayValue = Number.isInteger(percentage) ? percentage.toString() : percentage.toFixed(1);
+  return `${displayValue}%`;
+};
+
+const ACHIEVEMENT_META: Record<AchievementType, AchievementMeta> = {
+  OPEN_SCIENCE_SUPPORTER: {
+    icon: faHandHoldingHeart,
+    title: 'Open Science Supporter',
+    unit: ' RSC',
+    formatValue: integerFormatter,
+    describe: (value) => `Funded open science using ${value} RSC.`,
+  },
+  CITED_AUTHOR: {
+    icon: faQuoteLeft,
+    title: 'Cited Author',
+    unit: ' citations',
+    formatValue: integerFormatter,
+    describe: (value) => `Publications have been cited ${value} times.`,
+  },
+  EXPERT_PEER_REVIEWER: {
+    icon: faGlasses,
+    title: 'Peer Reviewer',
+    unit: ' reviews',
+    formatValue: integerFormatter,
+    describe: (value) => `Peer reviewed ${value} publications.`,
+  },
+  HIGHLY_UPVOTED: {
+    icon: faFire,
+    title: 'Active User',
+    unit: ' upvotes',
+    formatValue: integerFormatter,
+    describe: (value) => `Received ${value} upvotes from the community.`,
+  },
+  OPEN_ACCESS: {
+    icon: faChartNetwork,
+    title: 'Open Access Advocate',
+    unit: '',
+    // Stored as a 0-1 ratio in the API payload; surface as a percentage.
+    formatValue: percentFormatter,
+    describe: (value) => `${value} of works published as open access.`,
+  },
+};
+
+const FALLBACK_META: AchievementMeta = {
+  icon: faAward,
+  title: 'Achievement',
+  unit: '',
+  formatValue: integerFormatter,
+  describe: (value) => `Achieved ${value} points.`,
+};
+
+export const getAchievementMeta = (type: AchievementType): AchievementMeta => {
+  const meta = ACHIEVEMENT_META[type];
+  if (meta) return meta;
+
   return {
-    background: tierColor,
-    borderRadius: '50%',
-    padding: 3,
-    width: size + 14,
-    height: size + 14,
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-  } as React.CSSProperties;
+    ...FALLBACK_META,
+    title: (type as string)
+      .replace(/_/g, ' ')
+      .replace(/\w\S*/g, (txt) => txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase()),
+  };
+};
+
+export interface ResolvedAchievement {
+  meta: AchievementMeta;
+  tier: TierStyle;
+  currentTierName: string;
+  nextTierName: string;
+  displayValue: string;
+  nextTierDisplayValue: string;
+  isTopTier: boolean;
 }
 
-export const getAchievementDetails = ({
-  achievement,
-}: {
-  achievement: Achievement;
-}): AchievementDetails => {
-  const tierColor = TIER_COLORS[achievement.currentMilestoneIndex] || TIER_COLORS[0];
-  const iconSize = 14;
+export const resolveAchievement = (achievement: Achievement): ResolvedAchievement => {
+  const meta = getAchievementMeta(achievement.type);
+  const tier = getTierStyleForIndex(achievement.currentMilestoneIndex);
+  const currentTierName = tier.label;
+  const nextTierName = achievement.milestones[achievement.currentMilestoneIndex + 1]
+    ? getTierLabelForIndex(achievement.currentMilestoneIndex + 1)
+    : 'Max Tier';
 
-  switch (achievement.type) {
-    case 'OPEN_SCIENCE_SUPPORTER':
-      return {
-        icon: (
-          <div style={getTierCircleStyle(tierColor, iconSize)}>
-            <Icon name="flaskFrame" size={18} color="white" />
-          </div>
-        ),
-        title: 'Open Science Supporter',
-      };
-    case 'CITED_AUTHOR':
-      return {
-        icon: (
-          <div style={getTierCircleStyle(tierColor, iconSize)}>
-            <FontAwesomeIcon icon={faQuoteRight} style={{ color: 'white', fontSize: iconSize }} />
-          </div>
-        ),
-        title: 'Cited Author',
-      };
-    case 'EXPERT_PEER_REVIEWER':
-      return {
-        icon: (
-          <div style={getTierCircleStyle(tierColor, iconSize)}>
-            <FontAwesomeIcon icon={faStar} style={{ color: 'white', fontSize: iconSize }} />
-          </div>
-        ),
-        title: 'Peer Reviewer',
-      };
-    case 'HIGHLY_UPVOTED':
-      return {
-        icon: (
-          <div style={getTierCircleStyle(tierColor, iconSize)}>
-            <FontAwesomeIcon icon={faCircleUp} style={{ color: 'white', fontSize: iconSize }} />
-          </div>
-        ),
-        title: 'Active User',
-      };
-    case 'OPEN_ACCESS':
-      return {
-        icon: (
-          <div style={getTierCircleStyle(tierColor, iconSize)}>
-            <FontAwesomeIcon icon={faLockOpen} style={{ color: 'white', fontSize: iconSize }} />
-          </div>
-        ),
-        title: 'Open Access Advocate',
-      };
-    default:
-      return {
-        icon: (
-          <div style={getTierCircleStyle(tierColor, iconSize)}>
-            <FontAwesomeIcon icon={faAward} style={{ color: 'white', fontSize: iconSize }} />
-          </div>
-        ),
-        title: (achievement.type as string)
-          .replace(/_/g, ' ')
-          .replace(/\w\S*/g, (txt) => txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase()),
-      };
-  }
+  const isTopTier =
+    achievement.currentMilestoneIndex === achievement.milestones.length - 1 ||
+    achievement.currentMilestoneIndex >= TIER_INDICES.length - 1;
+
+  const nextRawValue = achievement.milestones[achievement.currentMilestoneIndex + 1] ?? 0;
+
+  return {
+    meta,
+    tier,
+    currentTierName,
+    nextTierName,
+    displayValue: meta.formatValue(achievement.value),
+    nextTierDisplayValue: meta.formatValue(nextRawValue),
+    isTopTier,
+  };
 };

--- a/components/profile/ProfileAchievements.utils.tsx
+++ b/components/profile/ProfileAchievements.utils.tsx
@@ -159,7 +159,13 @@ export interface ResolvedAchievement {
   currentTierName: string;
   nextTierName: string;
   displayValue: string;
-  nextTierDisplayValue: string;
+  /**
+   * The value the progress row compares against on the right of the bar.
+   * For in-progress tiers this is the next tier's milestone; for the top
+   * tier it's the top tier's own milestone, so the row reads as
+   * `value / threshold` (often value > threshold for max tier).
+   */
+  targetDisplayValue: string;
   isTopTier: boolean;
 }
 
@@ -177,7 +183,9 @@ export const resolveAchievement = (achievement: Achievement): ResolvedAchievemen
     achievement.currentMilestoneIndex === achievement.milestones.length - 1 ||
     achievement.currentMilestoneIndex >= TIER_INDICES.length - 1;
 
-  const nextRawValue = achievement.milestones[achievement.currentMilestoneIndex + 1] ?? 0;
+  const targetRawValue = isTopTier
+    ? (achievement.milestones[achievement.currentMilestoneIndex] ?? 0)
+    : (achievement.milestones[achievement.currentMilestoneIndex + 1] ?? 0);
 
   return {
     meta,
@@ -186,7 +194,7 @@ export const resolveAchievement = (achievement: Achievement): ResolvedAchievemen
     currentTierName,
     nextTierName,
     displayValue: meta.formatValue(achievement.value),
-    nextTierDisplayValue: meta.formatValue(nextRawValue),
+    targetDisplayValue: meta.formatValue(targetRawValue),
     isTopTier,
   };
 };


### PR DESCRIPTION
## Why:
Our current achievements have been around for a while and feel a little lower than the rest of the UI. Here's an attempt at getting them to feel fresh.

<img width="316" height="357" alt="Screenshot 2026-05-18 at 7 37 41 AM" src="https://github.com/user-attachments/assets/eb0b53cd-b8a1-4cc0-ab69-060bac836471" />


## Full preview
(All variations)
<img width="1459" height="457" alt="Screenshot 2026-05-17 at 8 26 06 PM" src="https://github.com/user-attachments/assets/014bdc32-74f6-4264-af74-9199cd041737" />

(When hovered - each tier)
<img width="467" height="644" alt="Screenshot 2026-05-17 at 8 41 34 PM" src="https://github.com/user-attachments/assets/83886d27-a29a-48d8-ae95-eb52e76a3f95" />

<img width="471" height="639" alt="Screenshot 2026-05-17 at 8 41 28 PM" src="https://github.com/user-attachments/assets/79a9e5e3-ab90-4b9b-a3af-f3f8a03e1c52" />


<img width="471" height="641" alt="Screenshot 2026-05-17 at 8 40 41 PM" src="https://github.com/user-attachments/assets/978459bf-aa56-4af3-9cf3-e5c77682e994" />



(Example mixed achievement set)
<img width="419" height="354" alt="Screenshot 2026-05-17 at 8 26 54 PM" src="https://github.com/user-attachments/assets/66cf37de-cd63-4f94-af80-ddb56cd7c92a" />


### On my staging user
<img width="329" height="143" alt="Screenshot 2026-05-17 at 8 27 19 PM" src="https://github.com/user-attachments/assets/9608a869-0852-4db1-bc3a-f6358a7d20f4" />

