### PR TITLE
Showing basic risk score data on user profile moderation

### DIFF
--- a/components/profile/ModerationTab.tsx
+++ b/components/profile/ModerationTab.tsx
@@ -40,6 +40,12 @@ function StatusBadges({
   );
 }
 
+function getRiskScoreColor(score: number) {
+  if (score >= 150) return 'text-red-600';
+  if (score <= 50) return 'text-green-600';
+  return '';
+}
+
 function ModerationSkeleton() {
   return (
     <div className="flex flex-col gap-4">
@@ -148,8 +154,7 @@ export function ModerationTab({ userId, authorId, refetchAuthorInfo }: Moderatio
     : 'N/A';
 
   const riskScore = userDetails.riskScore;
-  const riskScoreColor =
-    riskScore >= 150 ? 'text-red-600' : riskScore <= 50 ? 'text-green-600' : '';
+  const riskScoreColor = getRiskScoreColor(riskScore);
 
   const items: { label: string; value: React.ReactNode }[] = [
     { label: 'Email', value: userDetails.email || 'N/A' },

--- a/components/profile/ModerationTab.tsx
+++ b/components/profile/ModerationTab.tsx
@@ -147,6 +147,10 @@ export function ModerationTab({ userId, authorId, refetchAuthorInfo }: Moderatio
       )}`
     : 'N/A';
 
+  const riskScore = userDetails.riskScore;
+  const riskScoreColor =
+    riskScore >= 150 ? 'text-red-600' : riskScore <= 50 ? 'text-green-600' : '';
+
   const items: { label: string; value: React.ReactNode }[] = [
     { label: 'Email', value: userDetails.email || 'N/A' },
     { label: 'User ID', value: userDetails.id ?? 'N/A' },
@@ -163,16 +167,8 @@ export function ModerationTab({ userId, authorId, refetchAuthorInfo }: Moderatio
           {
             label: 'Risk Score',
             value: (
-              <span
-                className={
-                  userDetails.riskScore >= 150
-                    ? 'text-red-600 font-medium'
-                    : userDetails.riskScore <= 50
-                      ? 'text-green-600 font-medium'
-                      : 'font-medium'
-                }
-              >
-                {userDetails.riskScore === -1 ? 'N/A' : userDetails.riskScore}
+              <span className={`font-medium ${riskScoreColor}`}>
+                {riskScore === -1 ? 'N/A' : riskScore}
               </span>
             ),
           },

--- a/components/profile/ModerationTab.tsx
+++ b/components/profile/ModerationTab.tsx
@@ -159,7 +159,24 @@ export function ModerationTab({ userId, authorId, refetchAuthorInfo }: Moderatio
     { label: 'Verified status', value: userDetails.verification?.status || 'N/A' },
     { label: 'ORCID Email', value: userDetails.orcidVerifiedEduEmail || 'N/A' },
     ...(showRiskScore
-      ? [{ label: 'Risk Score', value: `(${userDetails.riskScoreGrade}) ${userDetails.riskScore}` }]
+      ? [
+          {
+            label: 'Risk Score',
+            value: (
+              <span
+                className={
+                  userDetails.riskScore >= 150
+                    ? 'text-red-600 font-medium'
+                    : userDetails.riskScore <= 50
+                      ? 'text-green-600 font-medium'
+                      : 'font-medium'
+                }
+              >
+                {userDetails.riskScore === -1 ? 'N/A' : userDetails.riskScore}
+              </span>
+            ),
+          },
+        ]
       : []),
   ];
 

--- a/components/profile/ModerationTab.tsx
+++ b/components/profile/ModerationTab.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useMemo, useState } from 'react';
+import { useSearchParams } from 'next/navigation';
 import { MoreHorizontal } from 'lucide-react';
 import { toast } from 'react-hot-toast';
 import { useUserDetailsForModerator } from '@/hooks/useAuthor';
@@ -59,6 +60,8 @@ function ModerationSkeleton() {
 
 export function ModerationTab({ userId, authorId, refetchAuthorInfo }: ModerationTabProps) {
   const { user: currentUser } = useUser();
+  const searchParams = useSearchParams();
+  const showRiskScore = searchParams.get('riskscore') === 'true';
   const [{ userDetails, isLoading }, refetchModerationDetails] = useUserDetailsForModerator(userId);
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const isHubEditor = !!currentUser?.authorProfile?.isHubEditor;
@@ -155,6 +158,9 @@ export function ModerationTab({ userId, authorId, refetchAuthorInfo }: Moderatio
     { label: 'Verification ID', value: userDetails.verification?.externalId || 'N/A' },
     { label: 'Verified status', value: userDetails.verification?.status || 'N/A' },
     { label: 'ORCID Email', value: userDetails.orcidVerifiedEduEmail || 'N/A' },
+    ...(showRiskScore
+      ? [{ label: 'Risk Score', value: `(${userDetails.riskScoreGrade}) ${userDetails.riskScore}` }]
+      : []),
   ];
 
   return (

--- a/types/user.ts
+++ b/types/user.ts
@@ -141,6 +141,8 @@ export type UserDetailsForModerator = {
   createdData: string;
   isOrcidConnected: boolean;
   orcidVerifiedEduEmail: string | null;
+  riskScore: number;
+  riskScoreGrade: string;
   verification: {
     createdDate: string;
     externalId: string;
@@ -163,6 +165,8 @@ export const transformUserDetailsForModerator = (raw: any): UserDetailsForModera
       createdData: '',
       isOrcidConnected: false,
       orcidVerifiedEduEmail: null,
+      riskScore: 100,
+      riskScoreGrade: 'C-',
       verification: null,
     };
   }
@@ -175,6 +179,8 @@ export const transformUserDetailsForModerator = (raw: any): UserDetailsForModera
     createdData: raw.created_date || '',
     isOrcidConnected: raw.is_orcid_connected || false,
     orcidVerifiedEduEmail: raw.orcid_verified_edu_email || null,
+    riskScore: raw.risk_score ?? 100,
+    riskScoreGrade: raw.risk_score_grade || 'C-',
     verification: raw.verification
       ? {
           createdDate: raw.verification.created_date || '',

--- a/types/user.ts
+++ b/types/user.ts
@@ -142,7 +142,6 @@ export type UserDetailsForModerator = {
   isOrcidConnected: boolean;
   orcidVerifiedEduEmail: string | null;
   riskScore: number;
-  riskScoreGrade: string;
   verification: {
     createdDate: string;
     externalId: string;
@@ -165,8 +164,7 @@ export const transformUserDetailsForModerator = (raw: any): UserDetailsForModera
       createdData: '',
       isOrcidConnected: false,
       orcidVerifiedEduEmail: null,
-      riskScore: 100,
-      riskScoreGrade: 'C-',
+      riskScore: -1,
       verification: null,
     };
   }
@@ -179,8 +177,7 @@ export const transformUserDetailsForModerator = (raw: any): UserDetailsForModera
     createdData: raw.created_date || '',
     isOrcidConnected: raw.is_orcid_connected || false,
     orcidVerifiedEduEmail: raw.orcid_verified_edu_email || null,
-    riskScore: raw.risk_score ?? 100,
-    riskScoreGrade: raw.risk_score_grade || 'C-',
+    riskScore: raw.risk_score ?? -1,
     verification: raw.verification
       ? {
           createdDate: raw.verification.created_date || '',


### PR DESCRIPTION
## Overview ## 

This PR displays the basic risk score and letter grade for a user on the moderation tab of a profile page, gated behind a feature flag.

## Screenshot ##

<img width="658" height="213" alt="image" src="https://github.com/user-attachments/assets/f4e8f1f0-a48e-4a34-9eb2-a0fa574f044a" />
