### PR TITLE
Gate bounty create/award to Foundation and moderators

### DIFF
--- a/app/paper/create/success/page.tsx
+++ b/app/paper/create/success/page.tsx
@@ -7,10 +7,14 @@ import { Button } from '@/components/ui/Button';
 import { CheckCircle, Eye, Share2, MessageCircle, Award, Link, Clock } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import toast from 'react-hot-toast';
+import { useUser } from '@/contexts/UserContext';
+import { canManageBounties } from '@/components/Bounty/lib/bountyUtil';
 
 export default function SubmissionSuccessPage() {
   const router = useRouter();
   const searchParams = useSearchParams();
+  const { user } = useUser();
+  const canCreateBounty = canManageBounties(user);
   const [paperTitle, setPaperTitle] = useState<string>('');
   const [paperId, setPaperId] = useState<string | null>(null);
   const [isJournal, setIsJournal] = useState<boolean>(false);
@@ -179,7 +183,9 @@ export default function SubmissionSuccessPage() {
             <div className="mt-12 pt-8 border-t border-gray-200">
               <h3 className="text-center text-xl font-medium text-gray-900 mb-6">What's Next?</h3>
 
-              <div className="grid grid-cols-1 sm:grid-cols-3 gap-6">
+              <div
+                className={`grid grid-cols-1 gap-6 ${canCreateBounty ? 'sm:grid-cols-3' : 'sm:grid-cols-2'}`}
+              >
                 <div className="bg-gray-50 p-6 rounded-lg flex flex-col h-full">
                   <div className="flex-grow">
                     <div className="flex justify-center mb-4">
@@ -206,33 +212,35 @@ export default function SubmissionSuccessPage() {
                   </div>
                 </div>
 
-                <div className="bg-gray-50 p-6 rounded-lg flex flex-col h-full">
-                  <div className="flex-grow">
-                    <div className="flex justify-center mb-4">
-                      <div className="bg-purple-100 p-3 rounded-full">
-                        <Award className="h-6 w-6 text-purple-600" />
+                {canCreateBounty && (
+                  <div className="bg-gray-50 p-6 rounded-lg flex flex-col h-full">
+                    <div className="flex-grow">
+                      <div className="flex justify-center mb-4">
+                        <div className="bg-purple-100 p-3 rounded-full">
+                          <Award className="h-6 w-6 text-purple-600" />
+                        </div>
                       </div>
+                      <h4 className="font-medium text-gray-900 mb-2 text-center">
+                        Open a Peer Review Bounty
+                      </h4>
+                      <p className="text-sm text-gray-600 mb-6 text-center">
+                        Create a ResearchCoin bounty to entice users to review your paper.
+                      </p>
                     </div>
-                    <h4 className="font-medium text-gray-900 mb-2 text-center">
-                      Open a Peer Review Bounty
-                    </h4>
-                    <p className="text-sm text-gray-600 mb-6 text-center">
-                      Create a ResearchCoin bounty to entice users to review your paper.
-                    </p>
+                    <div className="mt-auto">
+                      {paperId && (
+                        <Button
+                          onClick={() => router.push(`/paper/${paperId}/bounties`)}
+                          variant="outlined"
+                          className="w-full"
+                          size="sm"
+                        >
+                          Create bounty
+                        </Button>
+                      )}
+                    </div>
                   </div>
-                  <div className="mt-auto">
-                    {paperId && (
-                      <Button
-                        onClick={() => router.push(`/paper/${paperId}/bounties`)}
-                        variant="outlined"
-                        className="w-full"
-                        size="sm"
-                      >
-                        Create bounty
-                      </Button>
-                    )}
-                  </div>
-                </div>
+                )}
 
                 <div className="bg-gray-50 p-6 rounded-lg flex flex-col h-full">
                   <div className="flex-grow">

--- a/components/Bounty/lib/bountyUtil.ts
+++ b/components/Bounty/lib/bountyUtil.ts
@@ -1,4 +1,5 @@
 import { Bounty } from '@/types/bounty';
+import type { User } from '@/types/user';
 import { FOUNDATION_USER_ID, FOUNDATION_BOUNTY_FLAT_USD } from '@/config/constants';
 
 /**
@@ -506,6 +507,28 @@ export const isFoundationBounty = (bounty: Bounty): boolean => {
   const creatorUserId = getCreatorUserId(bounty);
   return creatorUserId === FOUNDATION_USER_ID;
 };
+
+/**
+ * True when the given user ID is the ResearchHub Foundation account.
+ * Use with the logged-in user's `user.id` to gate create/award UI.
+ */
+export const isFoundationUser = (userId?: number | null): boolean =>
+  FOUNDATION_USER_ID != null && userId === FOUNDATION_USER_ID;
+
+/**
+ * True when the user is a platform moderator.
+ */
+export const isModeratorUser = (user?: User | null): boolean =>
+  !!user?.isModerator || !!user?.moderator;
+
+/**
+ * True when the user can create or award bounties (Foundation account or moderator).
+ */
+export const canManageBounties = (user?: User | null): boolean =>
+  isFoundationUser(user?.id) || isModeratorUser(user);
+
+/** Set to true to re-enable bounty backing (Support button, Backers list). */
+export const ENABLE_BOUNTY_BACKING = false;
 
 /**
  * Calculates the display amount for a bounty in USD.

--- a/components/Comment/CommentEmptyState.tsx
+++ b/components/Comment/CommentEmptyState.tsx
@@ -7,12 +7,14 @@ import { useAuthenticatedAction } from '@/contexts/AuthModalContext';
 interface CommentEmptyStateProps {
   commentType: CommentType;
   onCreateBounty: () => void;
+  canCreateBounty?: boolean;
   work?: Work;
 }
 
 export const CommentEmptyState = ({
   commentType,
   onCreateBounty,
+  canCreateBounty = false,
   work,
 }: CommentEmptyStateProps) => {
   const { executeAuthenticatedAction } = useAuthenticatedAction();
@@ -56,7 +58,7 @@ export const CommentEmptyState = ({
       <h3 className="mb-2 text-lg font-medium text-gray-900">{message}</h3>
       <p className="text-sm text-gray-500">{description}</p>
 
-      {commentType === 'BOUNTY' && (
+      {commentType === 'BOUNTY' && canCreateBounty && (
         <div className="mt-6">
           <Button
             onClick={() => executeAuthenticatedAction(onCreateBounty)}

--- a/components/Comment/CommentFeed.tsx
+++ b/components/Comment/CommentFeed.tsx
@@ -19,7 +19,7 @@ import { useAuthenticatedAction } from '@/contexts/AuthModalContext';
 import { useUser } from '@/contexts/UserContext';
 import { CommentEmptyState } from './CommentEmptyState';
 import { CreateBountyModal } from '@/components/modals/CreateBountyModal';
-import { comment } from 'postcss';
+import { canManageBounties } from '@/components/Bounty/lib/bountyUtil';
 import { useShareModalContext } from '@/contexts/ShareContext';
 import { useStorageKey } from '@/utils/storageKeys';
 
@@ -62,6 +62,8 @@ function CommentFeed({
     }
   }, [commentType, documentId, debug]);
 
+  const { user } = useUser();
+  const canCreateBounty = canManageBounties(user);
   const [isBountyModalOpen, setIsBountyModalOpen] = useState(false);
 
   const handleCreateBounty = useCallback(() => {
@@ -90,17 +92,20 @@ function CommentFeed({
           contentType={contentType}
           debug={debug}
           onCreateBounty={handleCreateBounty}
+          canCreateBounty={canCreateBounty}
           unifiedDocumentId={unifiedDocumentId}
           work={work}
           workAuthors={workAuthors}
           belowEditor={belowEditor}
         />
       </div>
-      <CreateBountyModal
-        isOpen={isBountyModalOpen}
-        onClose={handleCloseBountyModal}
-        workId={documentId.toString()}
-      />
+      {canCreateBounty && (
+        <CreateBountyModal
+          isOpen={isBountyModalOpen}
+          onClose={handleCloseBountyModal}
+          workId={documentId.toString()}
+        />
+      )}
     </CommentProvider>
   );
 }
@@ -116,10 +121,14 @@ function CommentFeedContent({
   debug = false,
   unifiedDocumentId,
   onCreateBounty,
+  canCreateBounty = false,
   work,
   workAuthors,
   belowEditor,
-}: Omit<CommentFeedProps, 'documentId'> & { onCreateBounty: () => void }) {
+}: Omit<CommentFeedProps, 'documentId'> & {
+  onCreateBounty: () => void;
+  canCreateBounty?: boolean;
+}) {
   // Add debugging for content component if debug is enabled
   useEffect(() => {
     if (debug) {
@@ -285,6 +294,7 @@ function CommentFeedContent({
           <CommentEmptyState
             commentType={commentType || 'GENERIC_COMMENT'}
             onCreateBounty={handleCreateBounty}
+            canCreateBounty={canCreateBounty}
             work={work}
           />
         ) : (
@@ -292,15 +302,17 @@ function CommentFeedContent({
             {commentType === 'BOUNTY' && (
               <div className="flex justify-between items-center mb-4">
                 <CommentSortAndFilters commentType={commentType} commentCount={count} />
-                <Button
-                  onClick={() => executeAuthenticatedAction(handleCreateBounty)}
-                  variant="outlined"
-                  size="sm"
-                  className="flex items-center gap-2"
-                >
-                  <Plus className="h-4 w-4" />
-                  Create Bounty
-                </Button>
+                {canCreateBounty && (
+                  <Button
+                    onClick={() => executeAuthenticatedAction(handleCreateBounty)}
+                    variant="outlined"
+                    size="sm"
+                    className="flex items-center gap-2"
+                  >
+                    <Plus className="h-4 w-4" />
+                    Create Bounty
+                  </Button>
+                )}
               </div>
             )}
 

--- a/components/Comment/CommentItem.tsx
+++ b/components/Comment/CommentItem.tsx
@@ -12,7 +12,7 @@ import LoadMoreReplies from './LoadMoreReplies';
 import { ConfirmModal } from '@/components/modals/ConfirmModal';
 import { CommentContent } from './lib/types';
 import { AwardBountyModal } from '@/components/Comment/AwardBountyModal';
-import { getDisplayBounty, isOpenBounty } from '@/components/Bounty/lib/bountyUtil';
+import { canManageBounties } from '@/components/Bounty/lib/bountyUtil';
 import { FeedItemComment } from '@/components/Feed/items/FeedItemComment';
 import { transformCommentToFeedItem, transformBountyCommentToFeedItem } from '@/types/feed';
 import { FeedItemBountyComment } from '@/components/Feed/items/FeedItemBountyComment';
@@ -72,6 +72,7 @@ export const CommentItem = ({
   const { user } = useUser();
   // Check if the current user is the author of the comment
   const isAuthor = user?.authorProfile?.id === comment?.createdBy?.authorProfile?.id;
+  const canAwardBounty = canManageBounties(user);
 
   // Determine if this comment is being edited or replied to
   const isEditing = editingCommentId === comment.id;
@@ -225,6 +226,8 @@ export const CommentItem = ({
               showTooltips={showTooltips}
               isAuthor={isAuthor}
               showCreatorActions={isAuthor}
+              canAwardBounty={canAwardBounty}
+              showContributeButton={false}
               onAward={(bountyId) => {
                 setSelectedBountyId(bountyId);
                 setShowAwardModal(true);
@@ -381,8 +384,9 @@ export const CommentItem = ({
         }
 
         .prose pre code {
-          font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono',
-            'Courier New', monospace;
+          font-family:
+            ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New',
+            monospace;
           font-size: 0.875rem;
           line-height: 1.5;
           background: none;

--- a/components/Feed/items/FeedItemBountyComment.tsx
+++ b/components/Feed/items/FeedItemBountyComment.tsx
@@ -11,6 +11,7 @@ import {
   isOpenBounty,
   getBountyDisplayAmount,
   isActiveBounty,
+  ENABLE_BOUNTY_BACKING,
 } from '@/components/Bounty/lib/bountyUtil';
 import { ContentFormat } from '@/types/comment';
 import { ID } from '@/types/root';
@@ -84,6 +85,7 @@ interface FeedItemBountyCommentProps {
   onReply?: () => void; // Prop for Reply action
   onContributeSuccess?: () => void; // Prop for handling successful contribution
   isAuthor?: boolean; // Prop to determine if current user is the author
+  canAwardBounty?: boolean; // Foundation account or moderator can award bounties
   showCreatorActions?: boolean; // Prop to determine whether to show creator actions
   actionLabels?: {
     upvote?: string;
@@ -108,13 +110,14 @@ export const FeedItemBountyComment: FC<FeedItemBountyCommentProps> = ({
   showRelatedWork = true,
   href,
   showTooltips = true, // Default to showing tooltips
-  showContributeButton = true, // Default to showing contribute button
+  showContributeButton = false,
   onViewSolution,
   onAward,
   onEdit,
   onReply,
   onContributeSuccess,
   isAuthor = false,
+  canAwardBounty = false,
   showCreatorActions = true, // Default to showing creator actions
   actionLabels,
   showFooter = true, // Default to showing the footer
@@ -301,8 +304,10 @@ export const FeedItemBountyComment: FC<FeedItemBountyCommentProps> = ({
     }
   };
 
+  const showBackingUI = ENABLE_BOUNTY_BACKING && showContributeButton;
+
   const awardButton =
-    showCreatorActions && isAuthor && isActiveBounty(bounty) && onAward ? (
+    showCreatorActions && canAwardBounty && isActiveBounty(bounty) && onAward ? (
       <Button
         onClick={handleAwardBounty}
         size="sm"
@@ -414,7 +419,7 @@ export const FeedItemBountyComment: FC<FeedItemBountyCommentProps> = ({
                   </span>
                 </div>
 
-                {contributors.length > 0 && (
+                {showBackingUI && contributors.length > 0 && (
                   <div className="hidden sm:flex flex-col leading-tight">
                     <span className="text-xs text-gray-500 uppercase tracking-wide mb-1">
                       Backers
@@ -467,7 +472,7 @@ export const FeedItemBountyComment: FC<FeedItemBountyCommentProps> = ({
 
               <div className="flex items-center gap-2 flex-shrink-0">
                 {awardButton}
-                {isActive && showContributeButton && !isAuthor && (
+                {showBackingUI && isActive && !isAuthor && (
                   <Button
                     variant="outlined"
                     size="sm"
@@ -495,21 +500,23 @@ export const FeedItemBountyComment: FC<FeedItemBountyCommentProps> = ({
         )}
       </BaseFeedItem>
 
-      <ContributeBountyModal
-        isOpen={isContributeModalOpen}
-        onClose={() => setIsContributeModalOpen(false)}
-        onContributeSuccess={() => {
-          if (onContributeSuccess) {
-            onContributeSuccess();
-          }
-        }}
-        commentId={bountyEntry.comment.id}
-        documentId={bountyEntry.relatedDocumentId || 0}
-        contentType={bountyEntry.relatedDocumentContentType || 'paper'}
-        bountyTitle={'Bounty'}
-        bountyType={bounty.bountyType}
-        expirationDate={bounty.expirationDate}
-      />
+      {ENABLE_BOUNTY_BACKING && (
+        <ContributeBountyModal
+          isOpen={isContributeModalOpen}
+          onClose={() => setIsContributeModalOpen(false)}
+          onContributeSuccess={() => {
+            if (onContributeSuccess) {
+              onContributeSuccess();
+            }
+          }}
+          commentId={bountyEntry.comment.id}
+          documentId={bountyEntry.relatedDocumentId || 0}
+          contentType={bountyEntry.relatedDocumentContentType || 'paper'}
+          bountyTitle={'Bounty'}
+          bountyType={bounty.bountyType}
+          expirationDate={bounty.expirationDate}
+        />
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## What?

- Restrict **who can create and award bounties** on the frontend to the ResearchHub Foundation account (`NEXT_PUBLIC_FOUNDATION_USER_ID`) and **platform moderators**.
- **Hide bounty backing** (Support button, Backers list).
- Keep bounty services and modals in the codebase (`ContributeBountyModal`, `BountyService.contributeToBounty`, `createBounty`, etc.) so backing or broader permissions can be re-enabled without restoring deleted code.
