### PR TITLE
fix: keep RHF bounty USD display at $150

### DIFF
--- a/components/Bounty/lib/bountyUtil.ts
+++ b/components/Bounty/lib/bountyUtil.ts
@@ -494,6 +494,43 @@ const getCreatorUserId = (bounty: Bounty): number | undefined => {
   return undefined;
 };
 
+const normalizeCreatorName = (value: unknown): string | undefined => {
+  if (typeof value !== 'string') return undefined;
+
+  const normalized = value.trim().replace(/\s+/g, ' ').toLowerCase();
+  return normalized || undefined;
+};
+
+const getProfileName = (profile: any): string | undefined => {
+  if (!profile) return undefined;
+
+  return (
+    normalizeCreatorName(profile.fullName) ||
+    normalizeCreatorName(profile.full_name) ||
+    normalizeCreatorName([profile.firstName, profile.lastName].filter(Boolean).join(' ')) ||
+    normalizeCreatorName([profile.first_name, profile.last_name].filter(Boolean).join(' '))
+  );
+};
+
+const getCreatorNames = (bounty: Bounty): string[] => {
+  const raw = bounty.raw;
+  const firstContribution = bounty.contributions?.[0];
+
+  return [
+    getProfileName(bounty.createdBy),
+    getProfileName(bounty.createdBy?.authorProfile),
+    getProfileName(raw?.created_by),
+    getProfileName(raw?.created_by?.author_profile),
+    getProfileName(raw?.created_by?.user),
+    getProfileName(raw?.author),
+    getProfileName(raw?.author?.user),
+    getProfileName(firstContribution?.createdBy),
+    getProfileName(firstContribution?.createdBy?.authorProfile),
+    getProfileName(firstContribution?.raw?.user),
+    getProfileName(firstContribution?.raw?.author),
+  ].filter((name): name is string => Boolean(name));
+};
+
 /**
  * Checks if a bounty was created by the ResearchHub Foundation account.
  *
@@ -501,10 +538,14 @@ const getCreatorUserId = (bounty: Bounty): number | undefined => {
  * @returns True if the bounty was created by the Foundation account
  */
 export const isFoundationBounty = (bounty: Bounty): boolean => {
-  if (!FOUNDATION_USER_ID) return false;
-
   const creatorUserId = getCreatorUserId(bounty);
-  return creatorUserId === FOUNDATION_USER_ID;
+  if (FOUNDATION_USER_ID && creatorUserId === FOUNDATION_USER_ID) {
+    return true;
+  }
+
+  // Fall back to the public account name so RHF bounty pricing still renders
+  // correctly when the public Foundation user ID env var is unavailable.
+  return getCreatorNames(bounty).some((name) => name === 'researchhub foundation');
 };
 
 /**

--- a/components/Bounty/lib/bountyUtil.ts
+++ b/components/Bounty/lib/bountyUtil.ts
@@ -545,7 +545,7 @@ export const isFoundationBounty = (bounty: Bounty): boolean => {
 
   // Fall back to the public account name so RHF bounty pricing still renders
   // correctly when the public Foundation user ID env var is unavailable.
-  return getCreatorNames(bounty).some((name) => name === 'researchhub foundation');
+  return getCreatorNames(bounty).includes('researchhub foundation');
 };
 
 /**


### PR DESCRIPTION
## Summary
- make Foundation bounty detection resilient when `NEXT_PUBLIC_FOUNDATION_USER_ID` is unavailable
- fall back to the public `ResearchHub Foundation` account name across the bounty API shapes already handled by `bountyUtil`
- lets existing work header, bounty tab, banner, and bounty card display helpers keep RHF peer-review bounties at the flat `$150` USD amount

Closes ResearchHub/issues#355

## Testing
- `git diff --check`
- attempted `npm ci`, but install is blocked by private Tiptap registry credentials: `403 Forbidden - https://registry.tiptap.dev/@tiptap-pro/extension-unique-id/...`
- attempted `npx -p typescript@5.9.3 tsc --noEmit -p tsconfig.json --pretty false`, but it fails after the blocked install because project dependencies/types are missing
