### PR TITLE
Expert finder: loading state for rerun search and compact source links

### DIFF
--- a/app/expert-finder/library/[searchId]/components/ExpertResultCard.tsx
+++ b/app/expert-finder/library/[searchId]/components/ExpertResultCard.tsx
@@ -89,16 +89,25 @@ export function ExpertResultCard({
             </h3>
             {sources.length > 0
               ? sources.map((src, i) => (
-                  <a
+                  <Tooltip
                     key={`${src.url}-${i}`}
-                    href={src.url}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="inline-flex min-w-0 max-w-full items-center gap-1 text-sm font-medium text-primary-600 hover:text-primary-700 hover:underline"
+                    content={src.text}
+                    position="top"
+                    width="w-72"
+                    className="text-left"
+                    wrapperClassName="inline-flex shrink-0 items-center"
                   >
-                    <span className="truncate">{src.text}</span>
-                    <ExternalLink className="h-3.5 w-3.5 shrink-0 opacity-70" aria-hidden />
-                  </a>
+                    <a
+                      href={src.url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="inline-flex rounded p-0.5 text-primary-600 transition-colors hover:text-primary-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-1"
+                      aria-label={src.text}
+                      title={src.text}
+                    >
+                      <ExternalLink className="h-4 w-4 shrink-0" aria-hidden />
+                    </a>
+                  </Tooltip>
                 ))
               : null}
           </div>
@@ -112,7 +121,7 @@ export function ExpertResultCard({
           ) : null}
         </header>
         {onToggleSelect && (
-          <div className="flex shrink-0 items-center justify-end pt-0.5">
+          <div className="flex shrink-0 items-center justify-end pt-1">
             <Checkbox
               checked={selected ?? false}
               onCheckedChange={() => onToggleSelect(index)}

--- a/app/expert-finder/library/new/components/AdvancedConfig.tsx
+++ b/app/expert-finder/library/new/components/AdvancedConfig.tsx
@@ -5,6 +5,7 @@ import type { FieldErrors, UseFormRegister } from 'react-hook-form';
 import { ChevronDown, Settings } from 'lucide-react';
 import { Button } from '@/components/ui/Button';
 import { CollapsibleSection } from '@/components/ui/CollapsibleSection';
+import { Loader } from '@/components/ui/Loader';
 import { Input } from '@/components/ui/form/Input';
 import { Textarea } from '@/components/ui/form/Textarea';
 import { Dropdown, DropdownItem, MultiSelectDropdown } from '@/components/ui/form/Dropdown';
@@ -59,6 +60,7 @@ export function AdvancedConfig({
 }: AdvancedConfigProps) {
   const hideInputType = contentType !== 'paper';
   const [isExpanded, setIsExpanded] = useState(false);
+  const [isLoadingRerun, setIsLoadingRerun] = useState(false);
   const [regionOpen, setRegionOpen] = useState(false);
   const [inputTypeOpen, setInputTypeOpen] = useState(false);
   const [expertCountOpen, setExpertCountOpen] = useState(false);
@@ -92,36 +94,101 @@ export function AdvancedConfig({
       onToggle={() => setIsExpanded(!isExpanded)}
       className="border border-gray-200 rounded-lg p-3 bg-gray-50/50"
     >
-      <div className="grid grid-cols-1 md:!grid-cols-2 gap-4 mt-6">
-        <div className="min-w-0 md:!col-span-2">
-          <Input
-            label="Name your search (Optional)"
-            placeholder="e.g. fMRI-based glymphatic system measurements in mice"
-            value={values.searchName ?? ''}
-            onChange={(e) => onChange({ ...values, searchName: e.target.value })}
-            helperText="Give this search a name to find it easily later."
-          />
-        </div>
+      <div className="relative mt-6" aria-busy={isLoadingRerun}>
+        {isLoadingRerun ? (
+          <div
+            className="absolute inset-0 z-10 flex flex-col items-center justify-center gap-2 rounded-lg bg-white/70"
+            role="status"
+            aria-live="polite"
+          >
+            <Loader size="md" className="text-blue-500" />
+          </div>
+        ) : null}
+        <div
+          className={cn(
+            'grid grid-cols-1 md:!grid-cols-2 gap-4',
+            isLoadingRerun && 'pointer-events-none opacity-60'
+          )}
+        >
+          <div className="min-w-0 md:!col-span-2">
+            <Input
+              label="Name your search (Optional)"
+              placeholder="e.g. fMRI-based glymphatic system measurements in mice"
+              value={values.searchName ?? ''}
+              onChange={(e) => onChange({ ...values, searchName: e.target.value })}
+              helperText="Give this search a name to find it easily later."
+            />
+          </div>
 
-        <div className="min-w-0 md:!col-span-2">
-          <Textarea
-            label="Additional guidance (optional)"
-            helperText={`Steers how experts are identified for this search. ${additionalContextCharCount} / ${additionalContextMaxLength} characters`}
-            error={additionalContextError}
-            {...additionalContextRegister}
-          />
-        </div>
+          <div className="min-w-0 md:!col-span-2">
+            <Textarea
+              label="Additional guidance (optional)"
+              helperText={`Steers how experts are identified for this search. ${additionalContextCharCount} / ${additionalContextMaxLength} characters`}
+              error={additionalContextError}
+              {...additionalContextRegister}
+            />
+          </div>
 
-        {!hideInputType && (
+          {!hideInputType && (
+            <div className="min-w-0">
+              <Dropdown
+                label="Input Type"
+                error={getFieldErrorMessage(errors?.inputType)}
+                helperText={
+                  contentType === 'paper'
+                    ? 'Choose abstract or PDF (PDF only if the paper has one).'
+                    : 'Choose which part of the document to use for finding experts.'
+                }
+                trigger={
+                  <Button
+                    type="button"
+                    variant="outlined"
+                    size="md"
+                    className="w-full justify-between text-left text-gray-900 font-normal"
+                  >
+                    {inputTypeLabel}
+                    <ChevronDown
+                      className={cn(
+                        'ml-2 h-4 w-4 shrink-0 transition-transform',
+                        inputTypeOpen && 'rotate-180'
+                      )}
+                    />
+                  </Button>
+                }
+                className="max-h-60 overflow-y-auto py-1"
+                onOpenChange={setInputTypeOpen}
+              >
+                <div className="py-1 max-h-60 overflow-y-auto">
+                  {(contentType === 'paper'
+                    ? INPUT_TYPE_OPTIONS.filter((o) => o.value === 'abstract' || o.value === 'pdf')
+                    : INPUT_TYPE_OPTIONS.filter((option) => allowedSet.has(option.value))
+                  ).map((option) => {
+                    const enabled = allowedSet.has(option.value);
+                    return (
+                      <DropdownItem
+                        key={option.value}
+                        onClick={() => enabled && onChange({ ...values, inputType: option.value })}
+                        disabled={!enabled}
+                        className={cn(
+                          values.inputType === option.value && 'bg-primary-50 text-primary-900',
+                          !enabled && 'opacity-60 cursor-not-allowed'
+                        )}
+                      >
+                        {option.label}
+                        {!enabled && ' (no PDF)'}
+                      </DropdownItem>
+                    );
+                  })}
+                </div>
+              </Dropdown>
+            </div>
+          )}
+
           <div className="min-w-0">
             <Dropdown
-              label="Input Type"
-              error={getFieldErrorMessage(errors?.inputType)}
-              helperText={
-                contentType === 'paper'
-                  ? 'Choose abstract or PDF (PDF only if the paper has one).'
-                  : 'Choose which part of the document to use for finding experts.'
-              }
+              label="Number of Researchers"
+              error={getFieldErrorMessage(errors?.expertCount)}
+              helperText={`Up to ${values.expertCount} researchers will be found`}
               trigger={
                 <Button
                   type="button"
@@ -129,163 +196,119 @@ export function AdvancedConfig({
                   size="md"
                   className="w-full justify-between text-left text-gray-900 font-normal"
                 >
-                  {inputTypeLabel}
+                  {values.expertCount}
                   <ChevronDown
                     className={cn(
                       'ml-2 h-4 w-4 shrink-0 transition-transform',
-                      inputTypeOpen && 'rotate-180'
+                      expertCountOpen && 'rotate-180'
                     )}
                   />
                 </Button>
               }
               className="max-h-60 overflow-y-auto py-1"
-              onOpenChange={setInputTypeOpen}
+              onOpenChange={setExpertCountOpen}
             >
               <div className="py-1 max-h-60 overflow-y-auto">
-                {(contentType === 'paper'
-                  ? INPUT_TYPE_OPTIONS.filter((o) => o.value === 'abstract' || o.value === 'pdf')
-                  : INPUT_TYPE_OPTIONS.filter((option) => allowedSet.has(option.value))
-                ).map((option) => {
-                  const enabled = allowedSet.has(option.value);
-                  return (
-                    <DropdownItem
-                      key={option.value}
-                      onClick={() => enabled && onChange({ ...values, inputType: option.value })}
-                      disabled={!enabled}
-                      className={cn(
-                        values.inputType === option.value && 'bg-primary-50 text-primary-900',
-                        !enabled && 'opacity-60 cursor-not-allowed'
-                      )}
-                    >
-                      {option.label}
-                      {!enabled && ' (no PDF)'}
-                    </DropdownItem>
-                  );
-                })}
+                {EXPERT_COUNT_OPTIONS.map((option) => (
+                  <DropdownItem
+                    key={option}
+                    onClick={() => onChange({ ...values, expertCount: option })}
+                    className={
+                      values.expertCount === option ? 'bg-primary-50 text-primary-900' : ''
+                    }
+                  >
+                    {option}
+                  </DropdownItem>
+                ))}
               </div>
             </Dropdown>
           </div>
-        )}
 
-        <div className="min-w-0">
-          <Dropdown
-            label="Number of Researchers"
-            error={getFieldErrorMessage(errors?.expertCount)}
-            helperText={`Up to ${values.expertCount} researchers will be found`}
-            trigger={
-              <Button
-                type="button"
-                variant="outlined"
-                size="md"
-                className="w-full justify-between text-left text-gray-900 font-normal"
-              >
-                {values.expertCount}
-                <ChevronDown
-                  className={cn(
-                    'ml-2 h-4 w-4 shrink-0 transition-transform',
-                    expertCountOpen && 'rotate-180'
-                  )}
-                />
-              </Button>
-            }
-            className="max-h-60 overflow-y-auto py-1"
-            onOpenChange={setExpertCountOpen}
-          >
-            <div className="py-1 max-h-60 overflow-y-auto">
-              {EXPERT_COUNT_OPTIONS.map((option) => (
-                <DropdownItem
-                  key={option}
-                  onClick={() => onChange({ ...values, expertCount: option })}
-                  className={values.expertCount === option ? 'bg-primary-50 text-primary-900' : ''}
+          <div className="min-w-0">
+            <MultiSelectDropdown<ExpertiseLevel>
+              label="Expertise Level"
+              error={getFieldErrorMessage(errors?.expertiseLevel)}
+              options={EXPERTISE_LEVEL_OPTIONS}
+              collapseLabelAbove={2}
+              value={values.expertiseLevel.length === 0 ? ['all_levels'] : values.expertiseLevel}
+              onChange={(selected) => {
+                const previousSelection =
+                  values.expertiseLevel.length === 0 ? ['all_levels'] : values.expertiseLevel;
+                const prevHadAll = previousSelection.includes('all_levels');
+                const selectedHasAll = selected.includes('all_levels');
+                const rest = selected.filter((l) => l !== 'all_levels');
+
+                if (selectedHasAll && !prevHadAll) {
+                  onChange({ ...values, expertiseLevel: [] });
+                } else if (selectedHasAll && prevHadAll && rest.length > 0) {
+                  onChange({ ...values, expertiseLevel: rest });
+                } else if (selectedHasAll && rest.length === 0) {
+                  onChange({ ...values, expertiseLevel: [] });
+                } else {
+                  onChange({
+                    ...values,
+                    expertiseLevel: selected.filter((l) => l !== 'all_levels'),
+                  });
+                }
+              }}
+              placeholder="All Levels"
+            />
+          </div>
+
+          <div className="min-w-0">
+            <Dropdown
+              label="Geographic Region"
+              error={getFieldErrorMessage(errors?.region)}
+              trigger={
+                <Button
+                  type="button"
+                  variant="outlined"
+                  size="md"
+                  className="w-full justify-between text-left text-gray-900 font-normal"
                 >
-                  {option}
-                </DropdownItem>
-              ))}
-            </div>
-          </Dropdown>
-        </div>
-
-        <div className="min-w-0">
-          <MultiSelectDropdown<ExpertiseLevel>
-            label="Expertise Level"
-            error={getFieldErrorMessage(errors?.expertiseLevel)}
-            options={EXPERTISE_LEVEL_OPTIONS}
-            collapseLabelAbove={2}
-            value={values.expertiseLevel.length === 0 ? ['all_levels'] : values.expertiseLevel}
-            onChange={(selected) => {
-              const previousSelection =
-                values.expertiseLevel.length === 0 ? ['all_levels'] : values.expertiseLevel;
-              const prevHadAll = previousSelection.includes('all_levels');
-              const selectedHasAll = selected.includes('all_levels');
-              const rest = selected.filter((l) => l !== 'all_levels');
-
-              if (selectedHasAll && !prevHadAll) {
-                onChange({ ...values, expertiseLevel: [] });
-              } else if (selectedHasAll && prevHadAll && rest.length > 0) {
-                onChange({ ...values, expertiseLevel: rest });
-              } else if (selectedHasAll && rest.length === 0) {
-                onChange({ ...values, expertiseLevel: [] });
-              } else {
-                onChange({
-                  ...values,
-                  expertiseLevel: selected.filter((l) => l !== 'all_levels'),
-                });
+                  {regionLabel}
+                  <ChevronDown
+                    className={cn(
+                      'ml-2 h-4 w-4 shrink-0 transition-transform',
+                      regionOpen && 'rotate-180'
+                    )}
+                  />
+                </Button>
               }
-            }}
-            placeholder="All Levels"
-          />
-        </div>
+              className="max-h-60 overflow-y-auto py-1"
+              onOpenChange={setRegionOpen}
+            >
+              <div className="py-1 max-h-60 overflow-y-auto">
+                {REGION_OPTIONS.map((option) => (
+                  <DropdownItem
+                    key={option.value}
+                    onClick={() => onChange({ ...values, region: option.value })}
+                    className={
+                      values.region === option.value ? 'bg-primary-50 text-primary-900' : ''
+                    }
+                  >
+                    {option.label}
+                  </DropdownItem>
+                ))}
+              </div>
+            </Dropdown>
+          </div>
 
-        <div className="min-w-0">
-          <Dropdown
-            label="Geographic Region"
-            error={getFieldErrorMessage(errors?.region)}
-            trigger={
-              <Button
-                type="button"
-                variant="outlined"
-                size="md"
-                className="w-full justify-between text-left text-gray-900 font-normal"
-              >
-                {regionLabel}
-                <ChevronDown
-                  className={cn(
-                    'ml-2 h-4 w-4 shrink-0 transition-transform',
-                    regionOpen && 'rotate-180'
-                  )}
+          <div className="min-w-0 md:!col-span-2 border-t border-gray-200 pt-4 mt-2 space-y-4">
+            <div className="grid grid-cols-1 md:!grid-cols-2 gap-4">
+              <div className="min-w-0">
+                <SearchHistoryDropdown
+                  selectedSearchId={selectedSearchId}
+                  onSearchSelect={onRerunSelect}
+                  onLoadingChange={setIsLoadingRerun}
                 />
-              </Button>
-            }
-            className="max-h-60 overflow-y-auto py-1"
-            onOpenChange={setRegionOpen}
-          >
-            <div className="py-1 max-h-60 overflow-y-auto">
-              {REGION_OPTIONS.map((option) => (
-                <DropdownItem
-                  key={option.value}
-                  onClick={() => onChange({ ...values, region: option.value })}
-                  className={values.region === option.value ? 'bg-primary-50 text-primary-900' : ''}
-                >
-                  {option.label}
-                </DropdownItem>
-              ))}
-            </div>
-          </Dropdown>
-        </div>
-
-        <div className="min-w-0 md:!col-span-2 border-t border-gray-200 pt-4 mt-2 space-y-4">
-          <div className="grid grid-cols-1 md:!grid-cols-2 gap-4">
-            <div className="min-w-0">
-              <SearchHistoryDropdown
-                selectedSearchId={selectedSearchId}
-                onSearchSelect={onRerunSelect}
-              />
-            </div>
-            <div className="min-w-0">
-              <ExcludeExpertsFromSearchesDropdown
-                value={values.excludedSearchIds}
-                onExcludeChange={handleExcludeChange}
-              />
+              </div>
+              <div className="min-w-0">
+                <ExcludeExpertsFromSearchesDropdown
+                  value={values.excludedSearchIds}
+                  onExcludeChange={handleExcludeChange}
+                />
+              </div>
             </div>
           </div>
         </div>

--- a/app/expert-finder/library/new/components/ExpertSearchPicker.tsx
+++ b/app/expert-finder/library/new/components/ExpertSearchPicker.tsx
@@ -21,6 +21,8 @@ export interface ExpertSearchPickerProps {
   helperText?: string;
   placeholder?: string;
   triggerIcon?: React.ReactNode;
+  disabled?: boolean;
+  loadingLabel?: string;
 }
 
 export function ExpertSearchPicker({
@@ -31,6 +33,8 @@ export function ExpertSearchPicker({
   helperText,
   placeholder,
   triggerIcon,
+  disabled = false,
+  loadingLabel,
 }: ExpertSearchPickerProps) {
   const [{ searches, isLoading, error }, fetchSearches] = useExpertSearches({
     limit: LIST_LIMIT,
@@ -87,7 +91,9 @@ export function ExpertSearchPicker({
   const hasSelection = value.length > 0;
 
   let triggerLabel: string;
-  if (mode === 'single') {
+  if (loadingLabel) {
+    triggerLabel = loadingLabel;
+  } else if (mode === 'single') {
     triggerLabel =
       selectedSearch != null ? getSearchDisplayText(selectedSearch) : (placeholder ?? '');
   } else if (value.length === 0) {
@@ -109,7 +115,7 @@ export function ExpertSearchPicker({
           variant="outlined"
           size="md"
           className="w-full justify-between text-left text-gray-900 font-normal"
-          disabled={isLoading && searches.length === 0 && !error}
+          disabled={disabled || (isLoading && searches.length === 0 && !error)}
         >
           <span className="truncate text-sm">{triggerLabel}</span>
           {triggerIcon != null && (

--- a/app/expert-finder/library/new/components/SearchHistoryDropdown.tsx
+++ b/app/expert-finder/library/new/components/SearchHistoryDropdown.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback } from 'react';
+import { useCallback, useState } from 'react';
 import { RotateCcw } from 'lucide-react';
 import { ExpertFinderService } from '@/services/expertFinder.service';
 import { ExpertSearchPicker } from './ExpertSearchPicker';
@@ -9,13 +9,24 @@ import type { ExpertSearchResult } from '@/types/expertFinder';
 export interface SearchHistoryDropdownProps {
   onSearchSelect: (search: ExpertSearchResult | null) => void;
   selectedSearchId: number | null;
+  onLoadingChange?: (loading: boolean) => void;
 }
 
 export function SearchHistoryDropdown({
   onSearchSelect,
   selectedSearchId,
+  onLoadingChange,
 }: SearchHistoryDropdownProps) {
+  const [isLoadingDetails, setIsLoadingDetails] = useState(false);
   const value = selectedSearchId != null ? [selectedSearchId] : [];
+
+  const setLoading = useCallback(
+    (loading: boolean) => {
+      setIsLoadingDetails(loading);
+      onLoadingChange?.(loading);
+    },
+    [onLoadingChange]
+  );
 
   const onChange = useCallback(
     async (searchIds: number[]) => {
@@ -23,6 +34,7 @@ export function SearchHistoryDropdown({
         onSearchSelect(null);
         return;
       }
+      setLoading(true);
       try {
         const full = await ExpertFinderService.getSearch(searchIds[0]);
         onSearchSelect(full);
@@ -30,9 +42,11 @@ export function SearchHistoryDropdown({
         const message = err instanceof Error ? err.message : 'Failed to load search details';
         console.error(message);
         onSearchSelect(null);
+      } finally {
+        setLoading(false);
       }
     },
-    [onSearchSelect]
+    [onSearchSelect, setLoading]
   );
 
   return (
@@ -44,6 +58,8 @@ export function SearchHistoryDropdown({
       helperText="Select a previous search to load its query and configuration."
       placeholder="Select a previous search..."
       triggerIcon={<RotateCcw className="h-4 w-4" />}
+      disabled={isLoadingDetails}
+      loadingLabel={isLoadingDetails ? 'Loading search...' : undefined}
     />
   );
 }


### PR DESCRIPTION
## Why?
- Re-running a previous search fetches full search details with no feedback, so users could edit advanced config before values were applied.
- Expert result source links showed full label text in the card header and used too much horizontal space.

## How?
- Show a loading overlay on the advanced config form and disable the rerun picker while `getSearch` runs.

<img width="924" height="985" alt="image" src="https://github.com/user-attachments/assets/252d20d0-9bd7-4c6b-a84a-42058f91163d" />

- Render source links as icon-only with a tooltip for the label text.

<img width="932" height="745" alt="image" src="https://github.com/user-attachments/assets/d9c407df-e9b3-497c-8188-ebf86138ee21" />
