### PR TITLE
update text copy on endowment video

### DIFF
--- a/app/endowment/components/EndowmentHowItWorks.tsx
+++ b/app/endowment/components/EndowmentHowItWorks.tsx
@@ -56,7 +56,7 @@ function VideoBlock() {
           aria-label="Play how it works video"
         >
           <span className="endowment-video-pill">
-            <Play className="w-3 h-3" aria-hidden /> Watch · 3 min
+            <Play className="w-3 h-3" aria-hidden /> Watch &lt; 1 min
           </span>
           <span className="endowment-play-cluster">
             <span className="endowment-play-btn">
@@ -65,7 +65,7 @@ function VideoBlock() {
             <span className="endowment-video-text">
               <span className="endowment-video-title">How the ResearchHub Endowment works</span>
               <span className="endowment-video-sub">
-                From RSC deposit to funded research, the full mechanism in 3 minutes.
+                From RSC deposit to funded research, the full mechanism in under a minute.
               </span>
             </span>
           </span>


### PR DESCRIPTION
## Issue
Text over endowment video says "3 min" twice but the video is about 37 seconds
<img width="1216" height="668" alt="Screenshot 2026-05-21 at 12 14 36 PM" src="https://github.com/user-attachments/assets/9b124228-35c6-473a-8b35-bcd6111e002a" />

## Fix
update text copy on endowment video to say under a minute
<img width="1156" height="667" alt="Screenshot 2026-05-21 at 12 12 20 PM" src="https://github.com/user-attachments/assets/6e2c9482-ba31-419e-8fe5-0cbad6851d5f" />
