### PR TITLE
Pass `view_as_user_id` when fetching home feed

### DIFF
--- a/components/Feed/Feed.tsx
+++ b/components/Feed/Feed.tsx
@@ -50,6 +50,11 @@ export const Feed: FC<FeedProps> = ({ defaultTab, initialFeedData }) => {
   const orderingParam = searchParams.get('ordering');
   const filterParam = searchParams.get('filter');
   const userIdParam = searchParams.get('user_id');
+  const viewAsUserIdParam = searchParams.get('view_as_user_id');
+  const viewAsUserId =
+    viewAsUserIdParam && !Number.isNaN(Number(viewAsUserIdParam))
+      ? Number(viewAsUserIdParam)
+      : undefined;
   const [ordering, setOrdering] = useState<string | undefined>(
     orderingParam || getDefaultOrdering(defaultTab)
   );
@@ -62,6 +67,7 @@ export const Feed: FC<FeedProps> = ({ defaultTab, initialFeedData }) => {
     ordering,
     filter: filterParam || undefined,
     userId: userIdParam || undefined,
+    viewAsUserId,
   };
 
   const {

--- a/hooks/useFeed.ts
+++ b/hooks/useFeed.ts
@@ -19,6 +19,7 @@ interface UseFeedOptions {
   ordering?: string;
   filter?: string;
   userId?: string;
+  viewAsUserId?: number;
   isDebugMode?: boolean;
   initialData?: {
     entries: FeedEntry[];
@@ -106,7 +107,8 @@ export const useFeed = (activeTab: FeedTab | FundingTab, options: UseFeedOptions
       options.ordering !== currentOptions.ordering ||
       options.isDebugMode !== currentOptions.isDebugMode ||
       options.filter !== currentOptions.filter ||
-      options.userId !== currentOptions.userId;
+      options.userId !== currentOptions.userId ||
+      options.viewAsUserId !== currentOptions.viewAsUserId;
 
     if (relevantOptionsChanged) {
       setCurrentOptions(options);
@@ -148,6 +150,7 @@ export const useFeed = (activeTab: FeedTab | FundingTab, options: UseFeedOptions
         includeHotScoreBreakdown: options.isDebugMode,
         filter: options.filter,
         userId: options.userId,
+        viewAsUserId: options.viewAsUserId,
       });
 
       setEntries(result.entries);
@@ -194,6 +197,7 @@ export const useFeed = (activeTab: FeedTab | FundingTab, options: UseFeedOptions
         includeHotScoreBreakdown: options.isDebugMode,
         filter: options.filter,
         userId: options.userId,
+        viewAsUserId: options.viewAsUserId,
       });
       setEntries((prev) => [...prev, ...result.entries]);
       setHasMore(result.hasMore);

--- a/services/feed.service.ts
+++ b/services/feed.service.ts
@@ -26,6 +26,7 @@ export class FeedService {
     filter?: string;
     status?: string;
     userId?: string;
+    viewAsUserId?: number;
   }): Promise<{ entries: FeedEntry[]; hasMore: boolean }> {
     const queryParams = new URLSearchParams();
     if (params?.page) queryParams.append('page', params.page.toString());
@@ -47,6 +48,9 @@ export class FeedService {
     if (params?.filter) queryParams.append('filter', params.filter);
     if (params?.status) queryParams.append('status', params.status);
     if (params?.userId) queryParams.append('user_id', params.userId);
+    if (params?.viewAsUserId) {
+      queryParams.append('view_as_user_id', params.viewAsUserId.toString());
+    }
 
     // Determine which endpoint to use
     const basePath =


### PR DESCRIPTION
## What?
- Forward the `view_as_user_id` query param to `GET /api/feed/` so moderators can load the feed as another user

## How?
- Add optional `viewAsUserId` to `FeedService.getFeed` and append `view_as_user_id` to the request query string when set
