### PR TITLE
Only use get public for posts on changelog page

### DIFF
--- a/app/changelog/page.tsx
+++ b/app/changelog/page.tsx
@@ -19,7 +19,7 @@ interface PostWithContent {
 
 async function fetchPostWithContent(postId: string): Promise<PostWithContent | null> {
   try {
-    const work = await PostService.get(postId);
+    const work = await PostService.getPublic(postId);
     let content: string | undefined;
 
     if (work.contentUrl) {

--- a/services/post.service.ts
+++ b/services/post.service.ts
@@ -50,6 +50,11 @@ export class PostService {
   private static readonly BASE_PATH = '/api/researchhubpost';
 
   static async get(id: string): Promise<Work> {
+    const response = await ApiClient.get<any>(`${this.BASE_PATH}/${id}/`);
+    return transformPost(response);
+  }
+
+  static async getPublic(id: string): Promise<Work> {
     const response = await ApiClient.getPublic<any>(`${this.BASE_PATH}/${id}/`);
     return transformPost(response);
   }


### PR DESCRIPTION
- The proposals details page is failing for private posts even if you own or have access due to unauthenticated gets. Only use unauthenticated on changelog page