### PR TITLE
Add 301 redirects for `/about/tos` and `/about/privacy`

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -52,6 +52,16 @@ const nextConfig = {
       destination: '/proposal/:id/:path*',
       permanent: true,
     },
+    {
+      source: '/about/tos',
+      destination: '/tos',
+      permanent: true,
+    },
+    {
+      source: '/about/privacy',
+      destination: '/privacy',
+      permanent: true,
+    },
   ],
   headers: async () => [
     {


### PR DESCRIPTION
Fix broken Terms of Service URL with 301 redirect