### PR TITLE
Setting Community Review to Peer Review for Risk Score Audit

### DIFF
--- a/components/profile/riskScoreEvents.utils.ts
+++ b/components/profile/riskScoreEvents.utils.ts
@@ -142,8 +142,7 @@ const DOCUMENT_LABELS: Record<string, string> = {
 
 const COMMENT_LABELS: Record<string, string> = {
   GENERIC_COMMENT: 'Comment',
-  PEER_REVIEW: 'Peer Review',
-  REVIEW: 'Community Review',
+  REVIEW: 'Peer Review',
   ANSWER: 'Answer',
   SUMMARY: 'Summary',
   AUTHOR_UPDATE: 'Author Update',


### PR DESCRIPTION
## Overview ##

This PR fixes showing Peer Review as "Community Review" in the risk score audit.