### PR TITLE
Bugfix: Hiding View Source button for censored/declined content on risk score audit

### DIFF
--- a/components/profile/RiskScoreEvents.tsx
+++ b/components/profile/RiskScoreEvents.tsx
@@ -19,6 +19,7 @@ import { Button } from '@/components/ui/Button';
 import {
   EVENT_TYPE_OPTIONS,
   formatEventRowLabel,
+  isContentRemovedEvent,
 } from '@/components/profile/riskScoreEvents.utils';
 
 type DeltaFilter = 'all' | 'true' | 'false';
@@ -128,6 +129,7 @@ export function RiskScoreEvents({
           const toneStyle = DELTA_TONE_STYLES[tone];
           const isExpanded = expandedId === event.id;
           const hasDetail = !!event.sourceDetail;
+          const isContentRemoved = isContentRemovedEvent(event.eventType);
 
           const rowClassName = cn(
             'w-full flex items-center justify-between py-2.5 px-3 border-l-2 rounded-none rounded-r-md text-sm text-left transition-colors',
@@ -186,7 +188,7 @@ export function RiskScoreEvents({
                       {truncateText(event.sourceDetail.text)}
                     </p>
                   )}
-                  {event.sourceDetail.url && (
+                  {event.sourceDetail.url && !isContentRemoved && (
                     <a
                       href={event.sourceDetail.url}
                       target="_blank"

--- a/components/profile/riskScoreEvents.utils.ts
+++ b/components/profile/riskScoreEvents.utils.ts
@@ -60,6 +60,7 @@ interface RiskScoreEventMeta {
   tooltip?: string;
   mixedTooltip?: string;
   isPersonaVerification?: boolean;
+  isContentRemoved?: boolean;
 }
 
 const RISK_SCORE_EVENT_META: Record<RiskScoreEventType, RiskScoreEventMeta> = {
@@ -72,11 +73,13 @@ const RISK_SCORE_EVENT_META: Record<RiskScoreEventType, RiskScoreEventMeta> = {
     action: 'Declined',
     tooltip:
       'A paper, proposal, or funding opportunity the user authored was declined by a moderator',
+    isContentRemoved: true,
   },
   CONTENT_CENSORED: {
     action: 'Censored',
     tooltip: 'A paper, post, or comment by the user was removed for policy violations',
     mixedTooltip: 'User has had content both censored and restored',
+    isContentRemoved: true,
   },
   BOUNTY_AWARDED: {
     action: 'Bounty Awarded',
@@ -159,6 +162,10 @@ export function getEventLabel(eventType: string): string {
 
 export function isPersonaVerificationEvent(eventType: string): boolean {
   return metaFor(eventType)?.isPersonaVerification ?? false;
+}
+
+export function isContentRemovedEvent(eventType: string): boolean {
+  return metaFor(eventType)?.isContentRemoved ?? false;
 }
 
 export const EVENT_TYPE_OPTIONS: { label: string; value: string }[] = [


### PR DESCRIPTION
## Overview ##

This PR fixes a small bug that shows the View Source button on censored/declined content.