### PR TITLE
Expert Finder: send reply_to as email array for preview/send

### DIFF
--- a/app/expert-finder/components/SendConfirmationModal.tsx
+++ b/app/expert-finder/components/SendConfirmationModal.tsx
@@ -5,7 +5,10 @@ import { Loader2 } from 'lucide-react';
 import { Button } from '@/components/ui/Button';
 import { Input } from '@/components/ui/form/Input';
 import { Modal } from '@/components/ui/form/Modal';
-import { isValidEmail } from '@/utils/validation';
+import {
+  parseAndValidateReplyToInput,
+  REPLY_TO_MAX,
+} from '@/app/expert-finder/lib/parseReplyToAddresses';
 
 /** Modal to confirm a send/preview action; collects Reply-To for the API. */
 export interface SendConfirmationModalProps {
@@ -38,8 +41,9 @@ export function SendConfirmationModal({
   confirmIcon,
   cancelLabel = 'Cancel',
 }: SendConfirmationModalProps) {
-  const replyValid = replyTo.trim() && isValidEmail(replyTo.trim());
-  const canSubmit = !isSubmitting && replyValid;
+  const replyValidation = parseAndValidateReplyToInput(replyTo);
+  const replyError = replyTo.trim() && !replyValidation.valid ? replyValidation.error : undefined;
+  const canSubmit = !isSubmitting && replyValidation.valid;
 
   return (
     <Modal isOpen={isOpen} onClose={() => !isSubmitting && onClose()} title={title}>
@@ -47,16 +51,12 @@ export function SendConfirmationModal({
       <div className="mb-4">
         <Input
           label="Reply To"
-          type="email"
+          type="text"
           value={replyTo}
           onChange={(e) => onReplyToChange(e.target.value)}
-          placeholder="Email address for replies"
-          helperText={'When experts hit Reply, their response goes to this address.'}
-          error={
-            replyTo.trim() && !isValidEmail(replyTo.trim())
-              ? 'Please enter a valid email address'
-              : undefined
-          }
+          placeholder="you@example.com"
+          helperText={`When experts hit Reply, their response goes to these addresses. Separate multiple with commas (max ${REPLY_TO_MAX}).`}
+          error={replyError}
         />
       </div>
       <div className="flex justify-end gap-2">

--- a/app/expert-finder/lib/parseReplyToAddresses.ts
+++ b/app/expert-finder/lib/parseReplyToAddresses.ts
@@ -1,0 +1,36 @@
+import { isValidEmail } from '@/utils/validation';
+
+export const REPLY_TO_MIN = 1;
+export const REPLY_TO_MAX = 10;
+
+export function parseReplyToAddresses(input: string): string[] {
+  return input
+    .split(',')
+    .map((part) => part.trim())
+    .filter((part) => part.length > 0);
+}
+
+export function validateReplyToAddresses(
+  emails: string[]
+): { valid: true } | { valid: false; error: string } {
+  if (emails.length < REPLY_TO_MIN) {
+    return { valid: false, error: 'Please enter at least one Reply To email address.' };
+  }
+  if (emails.length > REPLY_TO_MAX) {
+    return { valid: false, error: `You can add at most ${REPLY_TO_MAX} Reply To addresses.` };
+  }
+  const invalid = emails.find((email) => !isValidEmail(email));
+  if (invalid != null) {
+    return { valid: false, error: `"${invalid}" is not a valid email address.` };
+  }
+  return { valid: true };
+}
+
+export function parseAndValidateReplyToInput(
+  input: string
+): { valid: true; emails: string[] } | { valid: false; error: string } {
+  const emails = parseReplyToAddresses(input);
+  const result = validateReplyToAddresses(emails);
+  if (!result.valid) return result;
+  return { valid: true, emails };
+}

--- a/app/expert-finder/library/[searchId]/outreach/[emailId]/OutreachDetailPageContent.tsx
+++ b/app/expert-finder/library/[searchId]/outreach/[emailId]/OutreachDetailPageContent.tsx
@@ -46,7 +46,7 @@ import {
 } from '@/hooks/useExpertFinder';
 import { useUser } from '@/contexts/UserContext';
 import { toast } from 'react-hot-toast';
-import { isValidEmail } from '@/utils/validation';
+import { parseAndValidateReplyToInput } from '@/app/expert-finder/lib/parseReplyToAddresses';
 import { TAB_OUTREACH } from '@/app/expert-finder/lib/searchDetailTabs';
 import { useOutreachReplyTo } from '@/hooks/useOutreachReplyTo';
 
@@ -182,16 +182,16 @@ export function OutreachDetailPageContent({
 
   const handleSendPreview = async () => {
     if (!emailId || !email) return;
-    const trimmedReplyTo = (replyTo ?? '').trim();
-    if (!trimmedReplyTo || !isValidEmail(trimmedReplyTo)) {
-      setActionError('Please enter a valid Reply To email address.');
+    const replyValidation = parseAndValidateReplyToInput(replyTo ?? '');
+    if (!replyValidation.valid) {
+      setActionError(replyValidation.error);
       return;
     }
     setActionError(null);
     try {
       await previewEmails({
         generated_email_ids: [Number(emailId)],
-        reply_to: trimmedReplyTo,
+        reply_to: replyValidation.emails,
       });
       setShowPreviewConfirm(false);
       toast.success('Preview email sent to your email address.');
@@ -202,16 +202,16 @@ export function OutreachDetailPageContent({
 
   const handleSendToExpert = async () => {
     if (!emailId || !email) return;
-    const trimmedReplyTo = (replyTo ?? '').trim();
-    if (!trimmedReplyTo || !isValidEmail(trimmedReplyTo)) {
-      setActionError('Please enter a valid Reply To email address.');
+    const replyValidation = parseAndValidateReplyToInput(replyTo ?? '');
+    if (!replyValidation.valid) {
+      setActionError(replyValidation.error);
       return;
     }
     setActionError(null);
     try {
       await sendEmails({
         generated_email_ids: [Number(emailId)],
-        reply_to: trimmedReplyTo,
+        reply_to: replyValidation.emails,
       });
       setShowSendToExpertConfirm(false);
       refetch();

--- a/app/expert-finder/library/[searchId]/outreach/components/GeneratedEmailsList.tsx
+++ b/app/expert-finder/library/[searchId]/outreach/components/GeneratedEmailsList.tsx
@@ -26,7 +26,7 @@ import { OutreachMobileCard } from './OutreachMobileCard';
 import { TableSkeleton } from '@/components/ui/Table/TableSkeleton';
 import { ListCardSkeleton } from '@/components/ui/ListCardSkeleton';
 import { toast } from 'react-hot-toast';
-import { isValidEmail } from '@/utils/validation';
+import { parseAndValidateReplyToInput } from '@/app/expert-finder/lib/parseReplyToAddresses';
 import type { GeneratedEmail } from '@/types/expertFinder';
 import { isGeneratedEmailDraftLike } from '@/app/expert-finder/lib/generatedEmailStatus';
 import { cn } from '@/utils/styles';
@@ -180,15 +180,15 @@ export function GeneratedEmailsList({
       toast.error('Select at least one draft to send.');
       return;
     }
-    const trimmedReplyTo = replyTo.trim();
-    if (!trimmedReplyTo || !isValidEmail(trimmedReplyTo)) {
-      toast.error('Please enter a valid Reply To email address.');
+    const replyValidation = parseAndValidateReplyToInput(replyTo);
+    if (!replyValidation.valid) {
+      toast.error(replyValidation.error);
       return;
     }
     try {
       await sendEmails({
         generated_email_ids: ids,
-        reply_to: trimmedReplyTo,
+        reply_to: replyValidation.emails,
       });
       setShowSendConfirm(false);
       toast.success(

--- a/hooks/useExpertFinder.ts
+++ b/hooks/useExpertFinder.ts
@@ -572,7 +572,7 @@ interface UsePreviewEmailsState {
 
 type PreviewEmailsFn = (payload: {
   generated_email_ids: number[];
-  reply_to?: string;
+  reply_to: string[];
 }) => Promise<{ sent: number }>;
 type UsePreviewEmailsReturn = [UsePreviewEmailsState, PreviewEmailsFn];
 
@@ -586,7 +586,7 @@ export function usePreviewEmails(): UsePreviewEmailsReturn {
   const previewEmails = useCallback(
     async (payload: {
       generated_email_ids: number[];
-      reply_to?: string;
+      reply_to: string[];
     }): Promise<{ sent: number }> => {
       setIsLoading(true);
       setError(null);
@@ -616,7 +616,7 @@ interface UseSendEmailsState {
 
 type SendEmailsFn = (payload: {
   generated_email_ids: number[];
-  reply_to?: string;
+  reply_to: string[];
   cc?: string[];
 }) => Promise<{ sent: number }>;
 type UseSendEmailsReturn = [UseSendEmailsState, SendEmailsFn];
@@ -631,7 +631,7 @@ export function useSendEmails(): UseSendEmailsReturn {
   const sendEmails = useCallback(
     async (payload: {
       generated_email_ids: number[];
-      reply_to?: string;
+      reply_to: string[];
       cc?: string[];
     }): Promise<{ sent: number }> => {
       setIsLoading(true);

--- a/services/expertFinder.service.ts
+++ b/services/expertFinder.service.ts
@@ -381,13 +381,13 @@ export class ExpertFinderService {
    */
   static async sendEmails(payload: {
     generated_email_ids: number[];
-    reply_to?: string;
+    reply_to: string[];
     cc?: string[];
   }): Promise<{ sent: number }> {
     const body: Record<string, unknown> = {
       generated_email_ids: payload.generated_email_ids,
+      reply_to: payload.reply_to,
     };
-    if (payload.reply_to != null) body.reply_to = payload.reply_to;
     if (payload.cc != null && payload.cc.length > 0) body.cc = payload.cc;
     const raw = await ApiClient.post<{ sent: number }>(`${this.BASE_PATH}/emails/send/`, body);
     return { sent: raw.sent ?? 0 };
@@ -399,14 +399,12 @@ export class ExpertFinderService {
    */
   static async previewEmails(payload: {
     generated_email_ids: number[];
-    reply_to?: string;
+    reply_to: string[];
   }): Promise<{ sent: number }> {
     const body: Record<string, unknown> = {
       generated_email_ids: payload.generated_email_ids,
+      reply_to: payload.reply_to,
     };
-    if (payload.reply_to != null && payload.reply_to !== '') {
-      body.reply_to = payload.reply_to;
-    }
     const raw = await ApiClient.post<{ sent: number }>(`${this.BASE_PATH}/emails/preview/`, body);
     return { sent: raw.sent ?? 0 };
   }


### PR DESCRIPTION
## What?
- Aligns Expert Finder outreach preview/send with the backend breaking change (https://github.com/ResearchHub/researchhub-backend/pull/3544). `reply_to` is now a required JSON array of email strings (1–10), not a single string.
- Supports multiple Reply-To addresses in the send/preview confirmation modal via comma-separated input.
- Adds client-side parsing and validation before API calls (min 1, max 10, per-email format).

## How?
- Added `parseReplyToAddresses` helper (`app/expert-finder/lib/parseReplyToAddresses.ts`) to split comma-separated input, trim, and validate addresses.
- Updated `ExpertFinderService.previewEmails` / `sendEmails` and `usePreviewEmails` / `useSendEmails` to require and always send `reply_to: string[]`.
