### PR TITLE
Migrate paper author autocomplete off deprecated person/people search endpoints

### DIFF
--- a/services/author.service.ts
+++ b/services/author.service.ts
@@ -7,19 +7,6 @@ import {
 import { ApiClient } from './client';
 import { User, transformUser } from '@/types/user';
 
-interface AuthorResponse {
-  id: number;
-  first_name: string;
-  last_name: string;
-  slug: string;
-  profile_image?: string;
-  description?: string;
-}
-
-interface AuthorsApiResponse {
-  results: AuthorResponse[];
-}
-
 interface FollowResponse {
   id: number;
   content_type: string;
@@ -54,15 +41,6 @@ interface AuthorAchievementsResponse {
   // Add any other fields that come from the API
 }
 
-export interface Author {
-  id: number;
-  name: string;
-  slug: string;
-  imageUrl?: string;
-  description?: string;
-}
-
-// Add this interface for the update payload
 export interface AuthorUpdatePayload {
   first_name?: string;
   last_name?: string;
@@ -87,22 +65,10 @@ export interface AuthorUpdateParams extends AuthorUpdatePayload {
 }
 
 export class AuthorService {
-  private static readonly BASE_PATH = '/api/search/person';
   private static readonly AUTHORS_PATH = '/api/author';
 
   // Cache to store previously fetched author data
   private static authorCache: Record<number, User> = {};
-
-  static async getAuthors(): Promise<Author[]> {
-    const response = await ApiClient.get<AuthorsApiResponse>(`${this.BASE_PATH}/`);
-    return response.results.map((author) => ({
-      id: author.id,
-      name: author.first_name + ' ' + author.last_name,
-      slug: author.slug,
-      imageUrl: author.profile_image,
-      description: author.description,
-    }));
-  }
 
   static async getFollowedAuthors(): Promise<number[]> {
     const response = await ApiClient.get<FollowResponse[]>('/api/author/following/');

--- a/services/search.service.ts
+++ b/services/search.service.ts
@@ -9,8 +9,9 @@ import {
   PersonSearchResult,
   SearchFilters,
   SearchSortOption,
+  UserSuggestion,
+  mapUserSuggestionToAuthorSuggestion,
 } from '@/types/search';
-import { transformAuthorSuggestions } from '@/types/search';
 import { transformTopic } from '@/types/topic';
 import { Institution } from '@/app/paper/create/components/InstitutionAutocomplete';
 import { FeedEntry, transformFeedEntry } from '@/types/feed';
@@ -81,7 +82,6 @@ export const transformInstitutions = (response: any): Institution[] => {
 
 export class SearchService {
   private static readonly BASE_PATH = '/api';
-  private static readonly PEOPLE_SUGGEST_PATH = '/api/search/people/suggest';
   private static readonly INSTITUTIONS_SUGGEST_PATH = '/api/search/institutions/suggest';
   private static readonly DEFAULT_INDICES: EntityType[] = ['hub', 'paper', 'user', 'post'];
 
@@ -488,11 +488,13 @@ export class SearchService {
   }
 
   static async suggestPeople(query: string): Promise<AuthorSuggestion[]> {
-    const response = await ApiClient.get<any>(
-      `${this.PEOPLE_SUGGEST_PATH}/?suggestion_phrases__completion=${encodeURIComponent(query)}`
-    );
+    const suggestions = await this.getSuggestions(query, 'user');
 
-    return transformAuthorSuggestions(response);
+    return suggestions
+      .filter(
+        (s): s is UserSuggestion => (s.entityType === 'user' || s.entityType === 'author') && !!s.id
+      )
+      .map(mapUserSuggestionToAuthorSuggestion);
   }
 
   static async suggestInstitutions(query: string): Promise<Institution[]> {

--- a/types/search.ts
+++ b/types/search.ts
@@ -261,39 +261,20 @@ export interface AuthorSuggestion {
   education: string[];
 }
 
-export const transformAuthorSuggestion = (raw: any): AuthorSuggestion => {
+export function mapUserSuggestionToAuthorSuggestion(suggestion: UserSuggestion): AuthorSuggestion {
+  const profile = suggestion.authorProfile;
   return {
-    id: raw.id,
-    fullName: raw.full_name || `${raw.first_name} ${raw.last_name}`.trim(),
-    profileImage: raw.profile_image,
-    institutions: Array.isArray(raw.institutions) ? raw.institutions : [],
-    education: Array.isArray(raw.education) ? raw.education : [],
-    headline: raw?.author_profile?.headline?.title,
-    reputationHubs: Array.isArray(raw.reputation_hubs) ? raw.reputation_hubs : [],
-    userId: raw.user_id,
-    createdDate: raw.created_date,
+    id: profile?.id ?? suggestion.id!,
+    fullName: suggestion.displayName,
+    profileImage: profile?.profileImage,
+    headline: profile?.headline,
+    userId: profile?.userId,
+    createdDate: suggestion.createdDate,
+    institutions: [],
+    education: [],
+    reputationHubs: [],
   };
-};
-
-export const transformAuthorSuggestions = (raw: any): AuthorSuggestion[] => {
-  const authorSuggestions: AuthorSuggestion[] = [];
-  const suggestions = raw.suggestion_phrases__completion;
-
-  if (Array.isArray(suggestions)) {
-    suggestions.forEach((suggestion: any) => {
-      if (suggestion.options && Array.isArray(suggestion.options)) {
-        suggestion.options.forEach((option: any) => {
-          if (option._source) {
-            const parsed = transformAuthorSuggestion(option._source);
-            authorSuggestions.push(parsed);
-          }
-        });
-      }
-    });
-  }
-
-  return authorSuggestions;
-};
+}
 
 export interface ApiDocumentSearchResult {
   id: number;


### PR DESCRIPTION
## What/Why?
- Backend removed(https://github.com/ResearchHub/researchhub-backend/pull/3561) `/api/search/person/` and `/api/search/people/` when dropping the OpenSearch `person` index; only registered users are searchable for people/autocomplete now.
- Align paper author search with the rest of the app (notebook, mentions, user pickers), which already use unified `/api/search/suggest/?index=user`.

## How?
- Rewrote `SearchService.suggestPeople()` to delegate to `getSuggestions(query, 'user')` instead of `/api/search/people/suggest/`.
- Added `mapUserSuggestionToAuthorSuggestion()` so `AuthorSearch` keeps its existing `AuthorSuggestion` shape without UI changes.
- Removed dead `AuthorService.getAuthors()` and `/api/search/person` usage (no callers).
- Removed legacy `transformAuthorSuggestions` helpers that parsed the old Elasticsearch completion payload.