### PR TITLE
Add changelog posts 32354, 32355, and 32356

### DIFF
--- a/constants/changelog.ts
+++ b/constants/changelog.ts
@@ -5,6 +5,9 @@
  * automatically invalidates the seen-flag for all users.
  */
 export const CHANGELOG_POST_IDS = [
+  '32356',
+  '32355',
+  '32354',
   '32306',
   '32298',
   '32266',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds three new changelog post IDs to the changelog page:

- `32356` (latest — drives the "new changelog" indicator)
- `32355`
- `32354`

## Changes

- Updated `constants/changelog.ts` to include the new post IDs at the top of `CHANGELOG_POST_IDS`

## Test plan

- [ ] Verify `/changelog` loads and displays the three new entries
- [ ] Confirm the footer "new changelog" indicator appears for users who haven't seen the latest entry
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-07563750-151a-4e51-800d-9816949b3108"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-07563750-151a-4e51-800d-9816949b3108"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

