### PR TITLE
Scope expert "emailed before" warnings to document and search

### DIFF
--- a/app/expert-finder/library/[searchId]/components/ExpertResultCard.tsx
+++ b/app/expert-finder/library/[searchId]/components/ExpertResultCard.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState } from 'react';
+import Link from 'next/link';
 import { Award, Building2, ExternalLink, GraduationCap, Info, Mail, Pencil } from 'lucide-react';
 import { Alert } from '@/components/ui/Alert';
 import { Button } from '@/components/ui/Button';
@@ -9,6 +10,11 @@ import { Tooltip } from '@/components/ui/Tooltip';
 import { cn } from '@/utils/styles';
 import { formatTimestamp } from '@/utils/date';
 import type { ExpertResult } from '@/types/expertFinder';
+import {
+  buildExpertSearchHref,
+  buildOutreachDocumentHref,
+  outreachDocumentLabel,
+} from '@/types/expertFinder';
 import { ExpertFormModal } from './ExpertFormModal';
 
 interface ExpertResultCardProps {
@@ -55,7 +61,10 @@ export function ExpertResultCard({
 
   const [notesExpanded, setNotesExpanded] = useState(false);
   const showNotesToggle = notes.length > NOTES_READ_MORE_MIN_LENGTH || notesExpanded;
-  const emailedBefore = Boolean(expert.lastEmailSentAt);
+  const emailedForCurrentDocument = expert.emailedForCurrentDocument;
+  const emailedOnOtherDocuments = expert.emailedOnOtherDocuments ?? [];
+  const hasOutreachHistory =
+    Boolean(emailedForCurrentDocument) || emailedOnOtherDocuments.length > 0;
 
   return (
     <article
@@ -63,7 +72,7 @@ export function ExpertResultCard({
         'flex h-full min-h-0 flex-col rounded-lg border bg-white p-5 shadow-sm',
         selected
           ? 'border-primary-600 ring-2 ring-primary-200'
-          : emailedBefore
+          : hasOutreachHistory
             ? 'border-yellow-300'
             : 'border-gray-200'
       )}
@@ -207,13 +216,70 @@ export function ExpertResultCard({
           </div>
         ) : null}
 
-        {expert.lastEmailSentAt ? (
+        {emailedForCurrentDocument ? (
           <Alert variant="warning" className="py-2.5 px-3">
-            Emailed before
+            Emailed for this RFP
+            {emailedForCurrentDocument.searchId > 0 &&
+            String(emailedForCurrentDocument.searchId) !== searchId ? (
+              <>
+                {' · '}
+                <Link
+                  href={buildExpertSearchHref(emailedForCurrentDocument.searchId)}
+                  className="font-medium underline-offset-2 hover:underline"
+                >
+                  Search #{emailedForCurrentDocument.searchId}
+                </Link>
+              </>
+            ) : null}
             <span className="font-normal text-yellow-800/90">
               {' '}
-              · {formatTimestamp(expert.lastEmailSentAt)}
+              · {formatTimestamp(emailedForCurrentDocument.sentAt)}
             </span>
+          </Alert>
+        ) : null}
+
+        {emailedOnOtherDocuments.length > 0 ? (
+          <Alert variant="info" className="py-2.5 px-3">
+            <div className="space-y-1">
+              <p>
+                {emailedOnOtherDocuments.length === 1
+                  ? 'Emailed on another document'
+                  : 'Emailed on other documents'}
+              </p>
+              <ul className="space-y-1 font-normal">
+                {emailedOnOtherDocuments.map((entry) => {
+                  const documentHref = buildOutreachDocumentHref(entry);
+                  const documentLabel = outreachDocumentLabel(entry);
+
+                  return (
+                    <li key={`${entry.unifiedDocumentId}-${entry.sentAt}`}>
+                      {documentHref ? (
+                        <Link
+                          href={documentHref}
+                          className="font-medium underline-offset-2 hover:underline"
+                        >
+                          {documentLabel}
+                        </Link>
+                      ) : (
+                        <span>{documentLabel}</span>
+                      )}
+                      {entry.searchId > 0 ? (
+                        <>
+                          <span className="text-blue-800/90"> · </span>
+                          <Link
+                            href={buildExpertSearchHref(entry.searchId)}
+                            className="font-medium underline-offset-2 hover:underline"
+                          >
+                            Search #{entry.searchId}
+                          </Link>
+                        </>
+                      ) : null}
+                      <span className="text-blue-800/90"> · {formatTimestamp(entry.sentAt)}</span>
+                    </li>
+                  );
+                })}
+              </ul>
+            </div>
           </Alert>
         ) : null}
       </div>

--- a/types/expertFinder.ts
+++ b/types/expertFinder.ts
@@ -4,6 +4,8 @@ import { createTransformer } from './transformer';
 import type { InputType, SearchStatus } from '@/services/expertFinder.service';
 import type { AuthorProfile } from './authorProfile';
 import { transformAuthorProfile } from './authorProfile';
+import { buildWorkUrl } from '@/utils/url';
+import { mapApiDocumentTypeToClientType, type ApiDocumentType } from '@/utils/contentTypeMapping';
 
 export interface CreatedByInfo {
   userId: number;
@@ -23,6 +25,21 @@ export interface ExpertSourceLink {
   text: string;
 }
 
+export interface ExpertEmailedForCurrentDocument {
+  sentAt: string;
+  searchId: number;
+}
+
+export interface ExpertEmailedOnOtherDocument {
+  unifiedDocumentId: number;
+  documentType: string;
+  title: string;
+  slug: string;
+  id: number;
+  sentAt: string;
+  searchId: number;
+}
+
 /** Single expert as displayed in the app (detail/list rows). */
 export interface ExpertResult {
   expertId: number | null;
@@ -36,8 +53,10 @@ export interface ExpertResult {
   affiliation: string;
   expertise: string;
   email: string;
-  /** ISO timestamp when an outreach email was last sent to this expert (any search), if known. */
+  /** @deprecated Legacy global timestamp; do not use for "emailed before" UI. */
   lastEmailSentAt: string | null;
+  emailedForCurrentDocument: ExpertEmailedForCurrentDocument | null;
+  emailedOnOtherDocuments: ExpertEmailedOnOtherDocument[];
   notes?: string;
   sources?: ExpertSourceLink[] | null;
 }
@@ -137,6 +156,74 @@ function parseExpertId(raw: any): number | null {
   return Number.isInteger(n) && n >= 1 ? n : null;
 }
 
+function transformEmailedForCurrentDocument(raw: unknown): ExpertEmailedForCurrentDocument | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const obj = raw as Record<string, unknown>;
+  const sentAt = obj.sent_at != null ? String(obj.sent_at).trim() : '';
+  if (!sentAt) return null;
+  const searchId = Number(obj.search_id);
+  return {
+    sentAt,
+    searchId: Number.isInteger(searchId) ? searchId : 0,
+  };
+}
+
+function transformEmailedOnOtherDocument(raw: unknown): ExpertEmailedOnOtherDocument | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const obj = raw as Record<string, unknown>;
+  const id = Number(obj.id);
+  const sentAt = obj.sent_at != null ? String(obj.sent_at).trim() : '';
+  if (!Number.isInteger(id) || id < 1 || !sentAt) return null;
+  const unifiedDocumentId = Number(obj.unified_document_id);
+  const searchId = Number(obj.search_id);
+  return {
+    unifiedDocumentId: Number.isInteger(unifiedDocumentId) ? unifiedDocumentId : 0,
+    documentType: String(obj.document_type ?? '').trim(),
+    title: String(obj.title ?? '').trim(),
+    slug: String(obj.slug ?? '').trim(),
+    id,
+    sentAt,
+    searchId: Number.isInteger(searchId) ? searchId : 0,
+  };
+}
+
+function transformEmailedOnOtherDocuments(raw: unknown): ExpertEmailedOnOtherDocument[] {
+  if (!Array.isArray(raw)) return [];
+  const out: ExpertEmailedOnOtherDocument[] = [];
+  for (const item of raw) {
+    const entry = transformEmailedOnOtherDocument(item);
+    if (entry) out.push(entry);
+  }
+  return out;
+}
+
+export function buildOutreachDocumentHref(entry: ExpertEmailedOnOtherDocument): string | null {
+  const contentType = mapApiDocumentTypeToClientType(
+    entry.documentType.toUpperCase() as ApiDocumentType
+  );
+  if (!contentType || entry.id < 1) return null;
+
+  const href = buildWorkUrl({
+    id: entry.id,
+    slug: entry.slug || undefined,
+    contentType,
+  });
+  return href === '#' ? null : href;
+}
+
+export function buildExpertSearchHref(searchId: number): string {
+  if (!Number.isInteger(searchId) || searchId < 1) return '#';
+  return `/expert-finder/library/${searchId}`;
+}
+
+export function outreachDocumentLabel(entry: ExpertEmailedOnOtherDocument): string {
+  const title = entry.title.trim();
+  if (title) return title;
+  const slug = entry.slug.trim();
+  if (slug) return slug;
+  return `${entry.documentType || 'Document'} #${entry.id}`;
+}
+
 export function transformExpertResult(raw: any): ExpertResult {
   const sourcesRaw = Array.isArray(raw.sources) ? raw.sources : null;
   const sources = sourcesRaw
@@ -169,6 +256,8 @@ export function transformExpertResult(raw: any): ExpertResult {
       raw.last_email_sent_at != null && String(raw.last_email_sent_at).trim() !== ''
         ? String(raw.last_email_sent_at).trim()
         : null,
+    emailedForCurrentDocument: transformEmailedForCurrentDocument(raw.emailed_for_current_document),
+    emailedOnOtherDocuments: transformEmailedOnOtherDocuments(raw.emailed_on_other_documents),
     notes: raw.notes ?? raw.recommendation_notes,
     sources: sources?.length ? sources : null,
   };


### PR DESCRIPTION
## What?
- Fix false "Eailed before" warnings when an expert was emailed on a different RFP/document
- Add links to the related document and expert search from outreach history rows
- Apply yellow card border for any prior outreach (current or other document)
<img width="808" height="1006" alt="image" src="https://github.com/user-attachments/assets/b6a3d463-2ca0-4147-b796-55fbd861ec35" />
