### PR TITLE
Temporarily disable Expert Finder outreach sending

### DIFF
--- a/app/expert-finder/library/[searchId]/outreach/components/GeneratedEmailsList.tsx
+++ b/app/expert-finder/library/[searchId]/outreach/components/GeneratedEmailsList.tsx
@@ -195,8 +195,8 @@ export function GeneratedEmailsList({
         'Emails are being sent. You can close this window and monitor status in the outreach table.'
       );
       await handleBulkListRefresh();
-    } catch {
-      toast.error('Failed to send emails. Please try again.');
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : 'Failed to send emails. Please try again.');
     }
   };
 

--- a/services/expertFinder.service.ts
+++ b/services/expertFinder.service.ts
@@ -24,6 +24,18 @@ import {
 import type { ContentType, Work } from '@/types/work';
 import { transformUnifiedDocument } from '@/types/work';
 import { assertNever } from '@/utils/assertNever';
+import { ApiError } from './types/api';
+
+// TEMP: Disable outreach while AWS sender provider is broken. Set to false to re-enable.
+const OUTREACH_SENDING_DISABLED = true;
+const OUTREACH_DISABLED_MESSAGE =
+  'Expert outreach is temporarily unavailable. Please try again later.';
+
+function assertExpertFinderOutreachEnabled(): void {
+  if (OUTREACH_SENDING_DISABLED) {
+    throw new ApiError(OUTREACH_DISABLED_MESSAGE, 503);
+  }
+}
 
 // ── API enum values and display labels ─────────────
 
@@ -383,6 +395,7 @@ export class ExpertFinderService {
     reply_to: string[];
     cc?: string[];
   }): Promise<{ sent: number }> {
+    assertExpertFinderOutreachEnabled();
     const body: Record<string, unknown> = {
       generated_email_ids: payload.generated_email_ids,
       reply_to: payload.reply_to,
@@ -400,6 +413,7 @@ export class ExpertFinderService {
     generated_email_ids: number[];
     reply_to: string[];
   }): Promise<{ sent: number }> {
+    assertExpertFinderOutreachEnabled();
     const body: Record<string, unknown> = {
       generated_email_ids: payload.generated_email_ids,
       reply_to: payload.reply_to,
@@ -472,6 +486,7 @@ export class ExpertFinderService {
     grantId: string | number,
     params: { emails: string[]; replyTo?: string; cc?: string[] }
   ): Promise<InviteApplicantsResponse> {
+    assertExpertFinderOutreachEnabled();
     const body: Record<string, unknown> = { emails: params.emails };
     if (params.replyTo) body.reply_to = params.replyTo;
     if (params.cc && params.cc.length) body.cc = params.cc;


### PR DESCRIPTION
## What?
- Temporarily blocks all Expert Finder outbound email actions while the AWS sender provider issue is unresolved
- Covers expert send, preview send, and RFP invite-applicants flows

## How?
- Added `OUTREACH_SENDING_DISABLED` kill switch and `assertExpertFinderOutreachEnabled()` guard in `services/expertFinder.service.ts`
- Guard throws `ApiError` at the start of `sendEmails()`, `previewEmails()`, and `inviteApplicants()` before any network requests