### PR TITLE
Bugfix: Mobile Wallet Sizing

### DIFF
--- a/app/researchcoin/page.tsx
+++ b/app/researchcoin/page.tsx
@@ -65,13 +65,13 @@ export default function ResearchCoinPage() {
 
   return (
     <PageLayout rightSidebar={<ResearchCoinRightSidebar />}>
-      <div className="w-full">
-        <div className="">
-          <div className="">
+      <div className="w-full min-w-0">
+        <div className="min-w-0">
+          <div className="min-w-0">
             <h1 className="sr-only">My Wallet</h1>
           </div>
-          <div className="flex">
-            <div className="flex-1">
+          <div className="flex min-w-0">
+            <div className="flex-1 min-w-0">
               {/* Banners — show MFA banner if user has funds and no MFA;
                   otherwise fall back to verification banner. Never both. */}
               {(() => {

--- a/components/ResearchCoin/PendingDepositItem.tsx
+++ b/components/ResearchCoin/PendingDepositItem.tsx
@@ -20,9 +20,9 @@ export function PendingDepositItem({ deposit }: PendingDepositItemProps) {
   return (
     <div className="group">
       <div className="relative py-3 rounded-lg px-4 -mx-4">
-        <div className="flex items-center justify-between">
-          <div className="flex gap-3 w-full">
-            <div className="w-[38px] h-[38px] flex items-center justify-center rounded-full bg-orange-50">
+        <div className="flex items-center justify-between min-w-0">
+          <div className="flex gap-3 w-full min-w-0">
+            <div className="w-[38px] h-[38px] flex shrink-0 items-center justify-center rounded-full bg-orange-50">
               <Coins size={18} className="text-orange-600" />
             </div>
 
@@ -30,28 +30,30 @@ export function PendingDepositItem({ deposit }: PendingDepositItemProps) {
               <div className="flex items-center gap-2">
                 <p className="font-medium text-gray-900">Pending Deposit</p>
               </div>
-              <div className="text-xs text-gray-600 mt-0.5 flex items-center gap-2">
+              <div className="text-xs text-gray-600 mt-0.5 flex items-center gap-2 min-w-0">
                 <span>{formattedDate}</span>
                 <span>·</span>
                 <a
                   href={explorerLink}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="inline-flex items-center gap-1 text-primary-600 hover:text-primary-700 transition-colors"
+                  className="inline-flex items-center gap-1 text-primary-600 hover:text-primary-700 transition-colors min-w-0 truncate"
                 >
-                  View transaction
-                  <ExternalLink className="h-3 w-3" />
+                  <span className="truncate">View transaction</span>
+                  <ExternalLink className="h-3 w-3 shrink-0" />
                 </a>
               </div>
             </div>
 
-            <div className="flex flex-col items-end min-w-0 sm:!min-w-[140px]">
+            <div className="flex flex-col items-end w-[88px] min-[360px]:w-[104px] sm:w-[140px] shrink-0 min-w-0">
               <div className="flex items-center justify-end w-full">
-                <div className="flex flex-col items-end">
-                  <span className="text-sm font-bold text-orange-600 truncate">
+                <div className="flex flex-col items-end min-w-0 max-w-full">
+                  <span className="text-sm font-bold text-orange-600 truncate max-w-full">
                     +{deposit.amount} RSC
                   </span>
-                  <span className="text-[11px] text-orange-500 mt-0.5 truncate">Confirming…</span>
+                  <span className="text-[11px] text-orange-500 mt-0.5 truncate max-w-full">
+                    Confirming…
+                  </span>
                 </div>
               </div>
             </div>

--- a/components/ResearchCoin/PendingDepositItem.tsx
+++ b/components/ResearchCoin/PendingDepositItem.tsx
@@ -28,7 +28,7 @@ export function PendingDepositItem({ deposit }: PendingDepositItemProps) {
 
             <div className="flex-1 min-w-0">
               <div className="flex items-center gap-2">
-                <p className="font-medium text-gray-900">Pending Deposit</p>
+                <p className="text-sm sm:text-base font-medium text-gray-900">Pending Deposit</p>
               </div>
               <div className="text-xs text-gray-600 mt-0.5 flex items-center gap-2 min-w-0">
                 <span>{formattedDate}</span>

--- a/components/ResearchCoin/StakingOverview.tsx
+++ b/components/ResearchCoin/StakingOverview.tsx
@@ -81,7 +81,7 @@ export function StakingOverview() {
       <div className="mb-4 mx-auto w-full">
         <div className="bg-white rounded-xl border border-gray-200 overflow-hidden">
           {/* Header */}
-          <div className="px-4 sm:px-6 py-4 flex items-start justify-between gap-3 border-b border-gray-100">
+          <div className="px-4 sm:px-6 py-4 flex flex-col min-[390px]:flex-row min-[390px]:items-start min-[390px]:justify-between gap-3 border-b border-gray-100">
             <div className="flex items-center gap-3 min-w-0">
               <Sprout className="h-7 w-7 sm:h-8 sm:w-8 text-emerald-600 shrink-0" />
               <div className="min-w-0">
@@ -89,7 +89,7 @@ export function StakingOverview() {
                   <span className="sm:hidden">Endowment</span>
                   <span className="hidden sm:inline">ResearchHub Endowment</span>
                 </div>
-                <div className="text-xs text-gray-500 mt-0.5">
+                <div className="text-xs text-gray-500 mt-0.5 min-[390px]:truncate">
                   Earn funding credits by holding ResearchCoin
                 </div>
               </div>
@@ -247,9 +247,9 @@ function StatRow({
 }) {
   const borderClass = isLast ? '' : 'border-b border-gray-100';
   return (
-    <li className={`px-4 sm:px-6 py-3 flex items-center justify-between gap-3 ${borderClass}`}>
-      <div className="text-xs sm:text-sm text-gray-700">{label}</div>
-      <div className="shrink-0">{value}</div>
+    <li className={`px-4 sm:px-6 py-3 flex items-start justify-between gap-3 ${borderClass}`}>
+      <div className="text-xs sm:text-sm text-gray-700 min-w-0 flex-1">{label}</div>
+      <div className="shrink-0 min-w-0 max-w-[52%] overflow-hidden text-right">{value}</div>
     </li>
   );
 }

--- a/components/ResearchCoin/StakingOverview.tsx
+++ b/components/ResearchCoin/StakingOverview.tsx
@@ -90,7 +90,10 @@ export function StakingOverview() {
                   <span className="hidden sm:inline">ResearchHub Endowment</span>
                 </div>
                 <div className="text-xs text-gray-500 mt-0.5 truncate">
-                  Earn funding credits by holding ResearchCoin
+                  <span className="sm:hidden">Earn credits by holding RSC</span>
+                  <span className="hidden sm:inline">
+                    Earn funding credits by holding ResearchCoin
+                  </span>
                 </div>
               </div>
             </div>

--- a/components/ResearchCoin/StakingOverview.tsx
+++ b/components/ResearchCoin/StakingOverview.tsx
@@ -81,21 +81,24 @@ export function StakingOverview() {
       <div className="mb-4 mx-auto w-full">
         <div className="bg-white rounded-xl border border-gray-200 overflow-hidden">
           {/* Header */}
-          <div className="px-4 sm:px-6 py-4 flex flex-col min-[390px]:flex-row min-[390px]:items-start min-[390px]:justify-between gap-3 border-b border-gray-100">
-            <div className="flex items-center gap-3 min-w-0">
+          <div className="px-4 sm:px-6 py-4 flex items-start justify-between gap-3 border-b border-gray-100">
+            <div className="flex items-center gap-3 min-w-0 flex-1">
               <Sprout className="h-7 w-7 sm:h-8 sm:w-8 text-emerald-600 shrink-0" />
               <div className="min-w-0">
                 <div className="text-sm sm:text-base font-bold text-gray-900">
                   <span className="sm:hidden">Endowment</span>
                   <span className="hidden sm:inline">ResearchHub Endowment</span>
                 </div>
-                <div className="text-xs text-gray-500 mt-0.5 min-[390px]:truncate">
+                <div className="text-xs text-gray-500 mt-0.5 truncate">
                   Earn funding credits by holding ResearchCoin
                 </div>
               </div>
             </div>
             {isUserLoading || !user ? (
-              <div className="flex items-center gap-2 shrink-0" aria-label="Loading earning status">
+              <div
+                className="flex items-center gap-2 shrink-0 self-start sm:self-auto"
+                aria-label="Loading earning status"
+              >
                 <span className="h-3 w-16 bg-gray-200 rounded animate-pulse" />
                 <span className="h-6 w-11 bg-gray-200 rounded-full animate-pulse" />
               </div>
@@ -126,10 +129,10 @@ export function StakingOverview() {
                     className="bg-gray-900 text-white border-gray-900 text-left"
                     disableTouchClick
                   >
-                    <div className="flex items-center gap-2 shrink-0">
+                    <div className="flex items-center gap-2 shrink-0 self-start sm:self-auto">
                       <span
                         className={cn(
-                          'text-xs font-semibold',
+                          'hidden sm:inline text-xs font-semibold',
                           switchChecked ? 'text-emerald-700' : 'text-gray-500'
                         )}
                       >

--- a/components/ResearchCoin/StakingOverview.tsx
+++ b/components/ResearchCoin/StakingOverview.tsx
@@ -13,6 +13,7 @@ import { Tooltip } from '@/components/ui/Tooltip';
 import { Switch } from '@/components/ui/Switch';
 import { ResearchCoinIcon } from '@/components/ui/icons/ResearchCoinIcon';
 import { getNextTierDetails, formatFundingCreditsAmount } from './lib/stakingUtil';
+import { stripUsdSuffix } from './lib/display';
 
 const EMPTY = '—';
 
@@ -177,10 +178,12 @@ export function StakingOverview() {
                 value={
                   fundingCreditsTop ? (
                     <div className="text-right">
-                      <div className="text-sm font-bold text-gray-900">{fundingCreditsTop}</div>
+                      <div className="text-sm font-bold text-gray-900">
+                        {stripUsdSuffix(fundingCreditsTop)}
+                      </div>
                       {fundingCreditsBottom && (
                         <div className="text-[11px] text-gray-500 mt-0.5">
-                          {fundingCreditsBottom}
+                          {stripUsdSuffix(fundingCreditsBottom)}
                         </div>
                       )}
                     </div>

--- a/components/ResearchCoin/TransactionFeed.tsx
+++ b/components/ResearchCoin/TransactionFeed.tsx
@@ -159,7 +159,7 @@ export const TransactionFeed = forwardRef<TransactionFeedHandle, TransactionFeed
 
     const canExport = !isLoading && transactions.length > 0 && !isExporting;
     const headerActions = (
-      <div className="flex items-center gap-2 shrink-0">
+      <div className="flex items-center gap-2 shrink-0 min-w-0 w-full sm:w-auto">
         <CurrencyToggle value={feedCurrency} onChange={handleCurrencyChange} />
         <BaseMenu
           align="end"
@@ -298,11 +298,11 @@ export function SectionCard({
   return (
     <div className="mb-4 mx-auto w-full">
       <div className="bg-white rounded-xl border border-gray-200 overflow-hidden">
-        <div className="px-4 sm:px-6 py-4 flex flex-col items-stretch gap-3 border-b border-gray-100 sm:flex-row sm:items-center sm:justify-between">
-          <h2 className="text-sm sm:text-base font-bold text-gray-900">{title}</h2>
+        <div className="px-4 sm:px-6 py-4 flex flex-col items-stretch gap-3 border-b border-gray-100 sm:flex-row sm:items-center sm:justify-between min-w-0">
+          <h2 className="text-sm sm:text-base font-bold text-gray-900 min-w-0">{title}</h2>
           {actions}
         </div>
-        <div className="px-4 sm:px-6 py-4">{children}</div>
+        <div className="px-4 sm:px-6 py-4 min-w-0">{children}</div>
       </div>
     </div>
   );
@@ -324,6 +324,7 @@ function CurrencyToggle({
       activeTab={value}
       onTabChange={(id) => onChange(id as FeedCurrency)}
       size="sm"
+      className="min-w-0 flex-1"
     />
   );
 }

--- a/components/ResearchCoin/TransactionFeedItem.tsx
+++ b/components/ResearchCoin/TransactionFeedItem.tsx
@@ -4,7 +4,7 @@ import { cn } from '@/utils/styles';
 import { colors } from '@/app/styles/colors';
 import { Badge } from '@/components/ui/Badge';
 import { FundingCreditsTooltip } from '@/components/tooltips/FundingCreditsTooltip';
-import { stripResearchHubPrefix, stripUsdSuffix } from './lib/display';
+import { stripMobileTransactionPrefix, stripUsdSuffix } from './lib/display';
 
 interface TransactionFeedItemProps {
   transaction: FormattedTransaction;
@@ -34,7 +34,7 @@ export function TransactionFeedItem({ transaction }: TransactionFeedItemProps) {
                 <div className="flex items-center gap-2 min-w-0 max-w-full">
                   <p className="text-sm sm:text-base font-medium text-gray-900 truncate">
                     <span className="sm:hidden">
-                      {stripResearchHubPrefix(transaction.typeInfo.label)}
+                      {stripMobileTransactionPrefix(transaction.typeInfo.label)}
                     </span>
                     <span className="hidden sm:inline">{transaction.typeInfo.label}</span>
                   </p>

--- a/components/ResearchCoin/TransactionFeedItem.tsx
+++ b/components/ResearchCoin/TransactionFeedItem.tsx
@@ -4,7 +4,7 @@ import { cn } from '@/utils/styles';
 import { colors } from '@/app/styles/colors';
 import { Badge } from '@/components/ui/Badge';
 import { FundingCreditsTooltip } from '@/components/tooltips/FundingCreditsTooltip';
-import { stripUsdSuffix } from './lib/display';
+import { stripResearchHubPrefix, stripUsdSuffix } from './lib/display';
 
 interface TransactionFeedItemProps {
   transaction: FormattedTransaction;
@@ -33,7 +33,10 @@ export function TransactionFeedItem({ transaction }: TransactionFeedItemProps) {
               <div className="flex flex-col sm:!flex-row items-start sm:!items-center gap-2">
                 <div className="flex items-center gap-2 min-w-0 max-w-full">
                   <p className="text-sm sm:text-base font-medium text-gray-900 truncate">
-                    {transaction.typeInfo.label}
+                    <span className="sm:hidden">
+                      {stripResearchHubPrefix(transaction.typeInfo.label)}
+                    </span>
+                    <span className="hidden sm:inline">{transaction.typeInfo.label}</span>
                   </p>
                   {transaction.isLocked &&
                     transaction.isPositive &&

--- a/components/ResearchCoin/TransactionFeedItem.tsx
+++ b/components/ResearchCoin/TransactionFeedItem.tsx
@@ -18,9 +18,9 @@ export function TransactionFeedItem({ transaction }: TransactionFeedItemProps) {
   return (
     <div className="group">
       <div className="relative py-3 rounded-lg px-4 -mx-4">
-        <div className="flex items-center justify-between">
-          <div className="flex gap-3 w-full">
-            <div className="w-[38px] h-[38px] flex items-center justify-center rounded-full bg-gray-50">
+        <div className="flex items-center justify-between min-w-0">
+          <div className="flex gap-3 w-full min-w-0">
+            <div className="w-[38px] h-[38px] flex shrink-0 items-center justify-center rounded-full bg-gray-50">
               {IconComponent ? (
                 <IconComponent size={18} color={iconColor} />
               ) : (
@@ -28,10 +28,10 @@ export function TransactionFeedItem({ transaction }: TransactionFeedItemProps) {
               )}
             </div>
 
-            <div className="flex-1">
+            <div className="flex-1 min-w-0">
               <div className="flex flex-col sm:!flex-row items-start sm:!items-center gap-2">
-                <div className="flex items-center gap-2">
-                  <p className="font-medium text-gray-900">{transaction.typeInfo.label}</p>
+                <div className="flex items-center gap-2 min-w-0 max-w-full">
+                  <p className="font-medium text-gray-900 truncate">{transaction.typeInfo.label}</p>
                   {transaction.isLocked &&
                     transaction.isPositive &&
                     !transaction.typeInfo.hideLockedBadge && (
@@ -50,18 +50,18 @@ export function TransactionFeedItem({ transaction }: TransactionFeedItemProps) {
               <div className="text-xs text-gray-600 mt-0.5">{transaction.formattedDate}</div>
             </div>
 
-            <div className="flex flex-col items-end min-w-0 sm:!min-w-[140px]">
+            <div className="flex flex-col items-end w-[88px] min-[360px]:w-[104px] sm:w-[140px] shrink-0 min-w-0">
               <div className="flex items-center justify-end w-full">
-                <div className="flex flex-col items-end">
+                <div className="flex flex-col items-end min-w-0 max-w-full">
                   <span
                     className={cn(
-                      'text-sm font-bold truncate',
+                      'text-sm font-bold truncate max-w-full',
                       transaction.typeInfo.label === 'Deposit' ? 'text-green-600' : 'text-gray-900'
                     )}
                   >
                     {transaction.formattedAmount}
                   </span>
-                  <span className="text-[11px] text-gray-500 mt-0.5 truncate">
+                  <span className="text-[11px] text-gray-500 mt-0.5 truncate max-w-full">
                     {transaction.formattedUsdValue}
                   </span>
                 </div>

--- a/components/ResearchCoin/TransactionFeedItem.tsx
+++ b/components/ResearchCoin/TransactionFeedItem.tsx
@@ -4,6 +4,7 @@ import { cn } from '@/utils/styles';
 import { colors } from '@/app/styles/colors';
 import { Badge } from '@/components/ui/Badge';
 import { FundingCreditsTooltip } from '@/components/tooltips/FundingCreditsTooltip';
+import { stripUsdSuffix } from './lib/display';
 
 interface TransactionFeedItemProps {
   transaction: FormattedTransaction;
@@ -31,7 +32,9 @@ export function TransactionFeedItem({ transaction }: TransactionFeedItemProps) {
             <div className="flex-1 min-w-0">
               <div className="flex flex-col sm:!flex-row items-start sm:!items-center gap-2">
                 <div className="flex items-center gap-2 min-w-0 max-w-full">
-                  <p className="font-medium text-gray-900 truncate">{transaction.typeInfo.label}</p>
+                  <p className="text-sm sm:text-base font-medium text-gray-900 truncate">
+                    {transaction.typeInfo.label}
+                  </p>
                   {transaction.isLocked &&
                     transaction.isPositive &&
                     !transaction.typeInfo.hideLockedBadge && (
@@ -59,10 +62,10 @@ export function TransactionFeedItem({ transaction }: TransactionFeedItemProps) {
                       transaction.typeInfo.label === 'Deposit' ? 'text-green-600' : 'text-gray-900'
                     )}
                   >
-                    {transaction.formattedAmount}
+                    {stripUsdSuffix(transaction.formattedAmount)}
                   </span>
                   <span className="text-[11px] text-gray-500 mt-0.5 truncate max-w-full">
-                    {transaction.formattedUsdValue}
+                    {stripUsdSuffix(transaction.formattedUsdValue)}
                   </span>
                 </div>
               </div>

--- a/components/ResearchCoin/WalletOverview.tsx
+++ b/components/ResearchCoin/WalletOverview.tsx
@@ -15,6 +15,7 @@ import { formatRSC, formatUsdValue } from '@/utils/number';
 import { Button } from '@/components/ui/Button';
 import { BaseMenu, BaseMenuItem } from '@/components/ui/form/BaseMenu';
 import { ResearchCoinIcon } from '@/components/ui/icons/ResearchCoinIcon';
+import { stripUsdSuffix } from './lib/display';
 
 interface WalletOverviewProps {
   /** Called after a balance-changing action (e.g. withdraw) so the parent can refresh sibling state (transaction feed). */
@@ -101,10 +102,14 @@ export function WalletOverview({ onTransactionSuccess }: WalletOverviewProps) {
                 </div>
               ) : (
                 <div>
-                  <div className="text-[26px] sm:text-[32px] font-bold leading-none text-gray-900 whitespace-nowrap">
-                    {totalPrimary}
-                  </div>
-                  <div className="text-sm text-gray-500 mt-1.5">{totalSecondary}</div>
+                  <ResponsiveUsdLabel
+                    value={totalPrimary}
+                    className="text-[26px] sm:text-[32px] font-bold leading-none text-gray-900 whitespace-nowrap"
+                  />
+                  <ResponsiveUsdLabel
+                    value={totalSecondary}
+                    className="text-sm text-gray-500 mt-1.5"
+                  />
                 </div>
               )}
             </div>
@@ -170,7 +175,10 @@ export function WalletOverview({ onTransactionSuccess }: WalletOverviewProps) {
               }
               name={
                 <span className="inline-flex items-center gap-1.5 min-w-0 max-w-full">
-                  <span className="truncate">Funding Credits</span>
+                  <span className="truncate">
+                    <span className="sm:hidden">Credits</span>
+                    <span className="hidden sm:inline">Funding Credits</span>
+                  </span>
                   <FundingCreditsTooltip>
                     <HelpCircle className="h-[18px] w-[18px] text-gray-500 hover:text-gray-700 cursor-help transition-colors shrink-0" />
                   </FundingCreditsTooltip>
@@ -247,14 +255,22 @@ function AssetRow({ icon, name, subtext, balance, trailing, isLast }: AssetRowPr
 function BalanceCell({ primary, secondary }: { primary: string; secondary?: string }) {
   return (
     <div className="min-w-0">
-      <div className="text-xs sm:text-sm font-bold text-gray-900 leading-tight truncate">
-        {primary}
-      </div>
+      <ResponsiveUsdLabel
+        value={primary}
+        className="text-xs sm:text-sm font-bold text-gray-900 leading-tight truncate"
+      />
       {secondary && (
-        <div className="text-[11px] sm:text-xs text-gray-500 mt-0.5 truncate">{secondary}</div>
+        <ResponsiveUsdLabel
+          value={secondary}
+          className="text-[11px] sm:text-xs text-gray-500 mt-0.5 truncate"
+        />
       )}
     </div>
   );
+}
+
+function ResponsiveUsdLabel({ value, className }: { value: string; className: string }) {
+  return <div className={className}>{stripUsdSuffix(value)}</div>;
 }
 
 function BalanceSkeleton() {

--- a/components/ResearchCoin/WalletOverview.tsx
+++ b/components/ResearchCoin/WalletOverview.tsx
@@ -92,8 +92,8 @@ export function WalletOverview({ onTransactionSuccess }: WalletOverviewProps) {
       <div className="mb-4 mx-auto w-full">
         <div className="bg-white rounded-xl border border-gray-200 overflow-hidden">
           {/* Header bar — total balance + primary Deposit CTA */}
-          <div className="px-4 sm:px-6 py-5 border-b border-gray-100 flex items-center justify-between gap-4">
-            <div className="min-w-0">
+          <div className="px-4 sm:px-6 py-5 border-b border-gray-100 flex flex-col min-[420px]:flex-row min-[420px]:items-center min-[420px]:justify-between gap-4">
+            <div className="min-w-0 w-full">
               {!isBalanceReady ? (
                 <div>
                   <div className="h-9 w-40 bg-gray-100 animate-pulse rounded" />
@@ -108,11 +108,12 @@ export function WalletOverview({ onTransactionSuccess }: WalletOverviewProps) {
                 </div>
               )}
             </div>
-            <div className="flex items-center gap-2 shrink-0">
+            <div className="flex items-center gap-2 shrink-0 w-full min-[420px]:w-auto">
               <Button
                 onClick={() => setIsDepositModalOpen(true)}
                 variant="default"
                 disabled={!isBalanceReady}
+                className="flex-1 min-[420px]:flex-none"
               >
                 <ArrowDownToLine className="h-4 w-4 mr-1.5" />
                 Deposit
@@ -121,6 +122,7 @@ export function WalletOverview({ onTransactionSuccess }: WalletOverviewProps) {
                 onClick={() => setIsWithdrawModalOpen(true)}
                 variant="outlined"
                 disabled={!isBalanceReady}
+                className="flex-1 min-[420px]:flex-none"
               >
                 <ArrowUpFromLine className="h-4 w-4 mr-1.5" />
                 Withdraw
@@ -128,76 +130,74 @@ export function WalletOverview({ onTransactionSuccess }: WalletOverviewProps) {
             </div>
           </div>
 
-          {/* Asset table — fixed columns guarantee alignment across rows */}
-          <table className="w-full border-collapse">
-            <tbody>
-              {/* Row 1 — ResearchCoin */}
-              <AssetRow
-                icon={
-                  <span className="inline-block [&>svg]:w-6 [&>svg]:h-6 sm:[&>svg]:w-8 sm:[&>svg]:h-8">
-                    <ResearchCoinIcon size={32} />
-                  </span>
-                }
-                name="ResearchCoin"
-                balance={
-                  isBalanceReady ? (
-                    <BalanceCell
-                      primary={
-                        showUSD
-                          ? (balance?.formattedUsd ?? '$0.00')
-                          : `${balance?.formatted ?? '0'} RSC`
-                      }
-                      secondary={
-                        showUSD
-                          ? `${balance?.formatted ?? '0'} RSC`
-                          : `${balance?.formattedUsd ?? '$0.00'}`
-                      }
-                    />
-                  ) : (
-                    <BalanceSkeleton />
-                  )
-                }
-                trailing={<CurrencyMenu items={rscMenuItems} />}
-              />
+          {/* Asset rows */}
+          <div>
+            {/* Row 1 - ResearchCoin */}
+            <AssetRow
+              icon={
+                <span className="inline-block [&>svg]:w-6 [&>svg]:h-6 sm:[&>svg]:w-8 sm:[&>svg]:h-8">
+                  <ResearchCoinIcon size={32} />
+                </span>
+              }
+              name="ResearchCoin"
+              balance={
+                isBalanceReady ? (
+                  <BalanceCell
+                    primary={
+                      showUSD
+                        ? (balance?.formattedUsd ?? '$0.00')
+                        : `${balance?.formatted ?? '0'} RSC`
+                    }
+                    secondary={
+                      showUSD
+                        ? `${balance?.formatted ?? '0'} RSC`
+                        : `${balance?.formattedUsd ?? '$0.00'}`
+                    }
+                  />
+                ) : (
+                  <BalanceSkeleton />
+                )
+              }
+              trailing={<CurrencyMenu items={rscMenuItems} />}
+            />
 
-              {/* Row 2 — Funding Credits */}
-              <AssetRow
-                icon={
-                  <span className="inline-block [&>svg]:w-6 [&>svg]:h-6 sm:[&>svg]:w-8 sm:[&>svg]:h-8">
-                    <ResearchCoinIcon size={32} variant="green" outlined />
-                  </span>
-                }
-                name={
-                  <span className="inline-flex items-center gap-1.5">
-                    Funding Credits
-                    <FundingCreditsTooltip>
-                      <HelpCircle className="h-[18px] w-[18px] text-gray-500 hover:text-gray-700 cursor-help transition-colors shrink-0" />
-                    </FundingCreditsTooltip>
-                  </span>
-                }
-                balance={
-                  isBalanceReady ? (
-                    <BalanceCell
-                      primary={
-                        showUSD
-                          ? (lockedBalance?.formattedUsd ?? '$0.00')
-                          : `${lockedBalance?.formatted ?? '0'} RSC`
-                      }
-                      secondary={
-                        showUSD
-                          ? `${lockedBalance?.formatted ?? '0'} RSC`
-                          : `${lockedBalance?.formattedUsd ?? '$0.00'}`
-                      }
-                    />
-                  ) : (
-                    <BalanceSkeleton />
-                  )
-                }
-                trailing={<CurrencyMenu items={fcMenuItems} />}
-                isLast
-              />
-            </tbody>
-          </table>
+            {/* Row 2 - Funding Credits */}
+            <AssetRow
+              icon={
+                <span className="inline-block [&>svg]:w-6 [&>svg]:h-6 sm:[&>svg]:w-8 sm:[&>svg]:h-8">
+                  <ResearchCoinIcon size={32} variant="green" outlined />
+                </span>
+              }
+              name={
+                <span className="inline-flex items-center gap-1.5 min-w-0 max-w-full">
+                  <span className="truncate">Funding Credits</span>
+                  <FundingCreditsTooltip>
+                    <HelpCircle className="h-[18px] w-[18px] text-gray-500 hover:text-gray-700 cursor-help transition-colors shrink-0" />
+                  </FundingCreditsTooltip>
+                </span>
+              }
+              balance={
+                isBalanceReady ? (
+                  <BalanceCell
+                    primary={
+                      showUSD
+                        ? (lockedBalance?.formattedUsd ?? '$0.00')
+                        : `${lockedBalance?.formatted ?? '0'} RSC`
+                    }
+                    secondary={
+                      showUSD
+                        ? `${lockedBalance?.formatted ?? '0'} RSC`
+                        : `${lockedBalance?.formattedUsd ?? '$0.00'}`
+                    }
+                  />
+                ) : (
+                  <BalanceSkeleton />
+                )
+              }
+              trailing={<CurrencyMenu items={fcMenuItems} />}
+              isLast
+            />
+          </div>
         </div>
       </div>
 
@@ -228,27 +228,31 @@ interface AssetRowProps {
 function AssetRow({ icon, name, subtext, balance, trailing, isLast }: AssetRowProps) {
   const borderClass = isLast ? '' : 'border-b border-gray-100';
   return (
-    <tr className={borderClass}>
-      <td className="pl-4 sm:pl-6 py-4 align-middle w-px whitespace-nowrap">{icon}</td>
-      <td className="py-4 pl-3 sm:pl-4 pr-2 align-middle min-w-0">
-        <div className="text-xs sm:text-sm font-semibold text-gray-900 leading-tight">{name}</div>
+    <div className={`flex items-center gap-3 px-4 sm:px-6 py-4 min-w-0 ${borderClass}`}>
+      <div className="shrink-0">{icon}</div>
+      <div className="flex-1 min-w-0 pr-1">
+        <div className="text-xs sm:text-sm font-semibold text-gray-900 leading-tight min-w-0 truncate">
+          {name}
+        </div>
         {subtext && <div className="text-[11px] sm:text-xs text-gray-500 mt-0.5">{subtext}</div>}
-      </td>
-      <td className="py-4 px-2 sm:px-4 align-middle text-left whitespace-nowrap w-px sm:min-w-[140px]">
+      </div>
+      <div className="w-[84px] min-[360px]:w-[104px] sm:w-[140px] shrink-0 text-right min-w-0">
         {balance}
-      </td>
-      <td className="py-4 pr-4 sm:pr-6 align-middle text-right whitespace-nowrap w-px">
-        {trailing}
-      </td>
-    </tr>
+      </div>
+      <div className="shrink-0 -mr-2 sm:mr-0">{trailing}</div>
+    </div>
   );
 }
 
 function BalanceCell({ primary, secondary }: { primary: string; secondary?: string }) {
   return (
-    <div>
-      <div className="text-xs sm:text-sm font-bold text-gray-900 leading-tight">{primary}</div>
-      {secondary && <div className="text-[11px] sm:text-xs text-gray-500 mt-0.5">{secondary}</div>}
+    <div className="min-w-0">
+      <div className="text-xs sm:text-sm font-bold text-gray-900 leading-tight truncate">
+        {primary}
+      </div>
+      {secondary && (
+        <div className="text-[11px] sm:text-xs text-gray-500 mt-0.5 truncate">{secondary}</div>
+      )}
     </div>
   );
 }

--- a/components/ResearchCoin/WalletOverview.tsx
+++ b/components/ResearchCoin/WalletOverview.tsx
@@ -92,7 +92,7 @@ export function WalletOverview({ onTransactionSuccess }: WalletOverviewProps) {
       <div className="mb-4 mx-auto w-full">
         <div className="bg-white rounded-xl border border-gray-200 overflow-hidden">
           {/* Header bar — total balance + primary Deposit CTA */}
-          <div className="px-4 sm:px-6 py-5 border-b border-gray-100 flex flex-col min-[420px]:flex-row min-[420px]:items-center min-[420px]:justify-between gap-4">
+          <div className="px-4 sm:px-6 py-5 border-b border-gray-100 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
             <div className="min-w-0 w-full">
               {!isBalanceReady ? (
                 <div>
@@ -101,19 +101,19 @@ export function WalletOverview({ onTransactionSuccess }: WalletOverviewProps) {
                 </div>
               ) : (
                 <div>
-                  <div className="text-2xl sm:text-[32px] font-bold leading-none text-gray-900">
+                  <div className="text-[26px] sm:text-[32px] font-bold leading-none text-gray-900 whitespace-nowrap">
                     {totalPrimary}
                   </div>
                   <div className="text-sm text-gray-500 mt-1.5">{totalSecondary}</div>
                 </div>
               )}
             </div>
-            <div className="flex items-center gap-2 shrink-0 w-full min-[420px]:w-auto">
+            <div className="flex items-center gap-2 shrink-0 w-full sm:w-auto">
               <Button
                 onClick={() => setIsDepositModalOpen(true)}
                 variant="default"
                 disabled={!isBalanceReady}
-                className="flex-1 min-[420px]:flex-none"
+                className="flex-1 sm:flex-none"
               >
                 <ArrowDownToLine className="h-4 w-4 mr-1.5" />
                 Deposit
@@ -122,7 +122,7 @@ export function WalletOverview({ onTransactionSuccess }: WalletOverviewProps) {
                 onClick={() => setIsWithdrawModalOpen(true)}
                 variant="outlined"
                 disabled={!isBalanceReady}
-                className="flex-1 min-[420px]:flex-none"
+                className="flex-1 sm:flex-none"
               >
                 <ArrowUpFromLine className="h-4 w-4 mr-1.5" />
                 Withdraw

--- a/components/ResearchCoin/lib/display.ts
+++ b/components/ResearchCoin/lib/display.ts
@@ -5,3 +5,7 @@ export function stripUsdSuffix(value: string): string {
 
   return value;
 }
+
+export function stripResearchHubPrefix(value: string): string {
+  return value.replace(/^ResearchHub\s+/i, '');
+}

--- a/components/ResearchCoin/lib/display.ts
+++ b/components/ResearchCoin/lib/display.ts
@@ -6,6 +6,6 @@ export function stripUsdSuffix(value: string): string {
   return value;
 }
 
-export function stripResearchHubPrefix(value: string): string {
-  return value.replace(/^ResearchHub\s+/i, '');
+export function stripMobileTransactionPrefix(value: string): string {
+  return value.replace(/^(ResearchHub|Fundraise)\s+/i, '');
 }

--- a/components/ResearchCoin/lib/display.ts
+++ b/components/ResearchCoin/lib/display.ts
@@ -1,0 +1,7 @@
+export function stripUsdSuffix(value: string): string {
+  if (value.includes('$') && value.endsWith(' USD')) {
+    return value.slice(0, -4);
+  }
+
+  return value;
+}

--- a/components/banners/CalloutBanner.tsx
+++ b/components/banners/CalloutBanner.tsx
@@ -48,29 +48,34 @@ export function CalloutBanner({
   return (
     <div
       className={cn(
-        'mb-6 rounded-lg px-4 py-4 flex items-center gap-4',
+        'mb-6 rounded-lg px-4 py-4 flex flex-col items-stretch gap-3 sm:flex-row sm:items-center sm:gap-4',
         styles.container,
         className
       )}
     >
-      <div
-        className={cn(
-          'shrink-0 h-10 w-10 rounded-full flex items-center justify-center',
-          styles.iconBg,
-          styles.iconColor
-        )}
-      >
-        {icon}
+      <div className="flex items-center gap-3 min-w-0">
+        <div
+          className={cn(
+            'shrink-0 h-10 w-10 rounded-full flex items-center justify-center',
+            styles.iconBg,
+            styles.iconColor
+          )}
+        >
+          {icon}
+        </div>
+        <div className="flex-1 min-w-0 sm:hidden">
+          <h3 className="font-semibold text-sm leading-snug">{title}</h3>
+        </div>
       </div>
-      <div className="flex-1 min-w-0">
-        <h3 className="font-semibold text-sm">{title}</h3>
+      <div className="hidden flex-1 min-w-0 sm:block">
+        <h3 className="font-semibold text-sm leading-snug">{title}</h3>
         <p className="text-sm opacity-90 mt-0.5 hidden sm:block">{description}</p>
       </div>
       <Button
         onClick={onCtaClick}
         size="default"
         className={cn(
-          'shrink-0 font-medium px-4 inline-flex items-center gap-1.5',
+          'shrink-0 font-medium px-4 inline-flex items-center gap-1.5 w-full sm:w-auto',
           styles.ctaButton
         )}
       >

--- a/components/skeletons/TransactionSkeleton.tsx
+++ b/components/skeletons/TransactionSkeleton.tsx
@@ -2,32 +2,32 @@ export function TransactionSkeleton() {
   return (
     <div className="group">
       <div className="relative py-3 transition-all duration-200 rounded-lg px-4 -mx-4">
-        <div className="flex items-center justify-between">
-          <div className="flex gap-3 w-full">
+        <div className="flex items-center justify-between min-w-0">
+          <div className="flex gap-3 w-full min-w-0">
             {/* Icon placeholder */}
-            <div className="w-[38px] h-[38px] flex items-center justify-center rounded-full bg-gray-50">
+            <div className="w-[38px] h-[38px] flex shrink-0 items-center justify-center rounded-full bg-gray-50">
               <div className="h-4 w-4 bg-gray-200 rounded" />
             </div>
 
-            <div className="flex-1">
+            <div className="flex-1 min-w-0">
               {/* Title */}
               <div className="flex items-center gap-2">
-                <p className="h-5 w-24 bg-gray-200 rounded animate-pulse" />
+                <p className="h-5 w-24 max-w-full bg-gray-200 rounded animate-pulse" />
               </div>
               {/* Date */}
               <div className="text-xs mt-1.5">
-                <div className="h-3 w-32 bg-gray-200 rounded animate-pulse" />
+                <div className="h-3 w-32 max-w-full bg-gray-200 rounded animate-pulse" />
               </div>
             </div>
 
             {/* Amount section */}
-            <div className="flex flex-col items-end min-w-[140px]">
+            <div className="flex flex-col items-end w-[88px] min-[360px]:w-[104px] sm:w-[140px] shrink-0 min-w-0">
               <div className="flex items-center justify-end w-full">
-                <div className="flex flex-col items-end">
+                <div className="flex flex-col items-end min-w-0 max-w-full">
                   {/* RSC Amount */}
-                  <div className="h-5 w-24 bg-gray-200 rounded animate-pulse" />
+                  <div className="h-5 w-24 max-w-full bg-gray-200 rounded animate-pulse" />
                   {/* USD Value */}
-                  <div className="h-3 w-16 bg-gray-200 rounded animate-pulse mt-1" />
+                  <div className="h-3 w-16 max-w-full bg-gray-200 rounded animate-pulse mt-1" />
                 </div>
               </div>
             </div>


### PR DESCRIPTION
## Overview ##
This PR fixes some mobile resizing issues for the wallet page, where smaller resolutions do not scale accordingly, cutting off some of the screen.

## Screenshots ##
Before :
<img width="418" height="704" alt="image" src="https://github.com/user-attachments/assets/9cdaf508-ba10-4e3b-a2fd-4fd6dce3ee61" />

After:
<img width="388" height="674" alt="image" src="https://github.com/user-attachments/assets/df96819f-a6b1-4488-9f8d-b7a062fe3bb1" />



