### PR TITLE
Update Learn link

### DIFF
--- a/components/Earn/EarnRightSidebar.tsx
+++ b/components/Earn/EarnRightSidebar.tsx
@@ -103,7 +103,7 @@ export function EarnRightSidebar() {
           <SidebarHeader title="Resources" />
           <div className="space-y-2 pl-1 ml-1">
             <a
-              href="https://blog.researchhub.foundation/researchcoin/"
+              href="https://docs.researchhub.com/researchcoin/what-is-researchcoin"
               target="_blank"
               rel="noopener noreferrer"
               className="flex items-center justify-between text-sm text-primary-600 hover:text-primary-700 transition-colors px-3 py-2 rounded-lg hover:bg-gray-50 -mx-3"

--- a/components/ResearchCoin/ResearchCoinRightSidebar.tsx
+++ b/components/ResearchCoin/ResearchCoinRightSidebar.tsx
@@ -134,7 +134,7 @@ export const ResearchCoinRightSidebar = () => {
           <SidebarHeader title="Resources" />
           <div className="space-y-2 pl-1 ml-1">
             <a
-              href="https://blog.researchhub.foundation/researchcoin/"
+              href="https://docs.researchhub.com/researchcoin/what-is-researchcoin"
               target="_blank"
               rel="noopener noreferrer"
               className="flex items-center justify-between text-sm text-primary-600 hover:text-primary-700 transition-colors px-3 py-2 rounded-lg hover:bg-gray-50 -mx-3"


### PR DESCRIPTION
The "Learn about ResearchCoin" on the ResearchCoin page and the Earn page takes to a broken link. 

Switching the link to our docs:
https://docs.researchhub.com/researchcoin/what-is-researchcoin
<img width="352" height="311" alt="Screenshot 2026-07-14 at 3 33 44 PM" src="https://github.com/user-attachments/assets/8c990111-f0b4-483a-b08d-3ac869d6477f" />
<img width="340" height="461" alt="Screenshot 2026-07-14 at 3 34 00 PM" src="https://github.com/user-attachments/assets/8e619bd1-a149-4d6f-9115-2a8e6732c26c" />
