### PR TITLE
Remove Post/Journal Entries from Moderation Dashboard

### DIFF
--- a/components/Feed/items/FeedItemPaper.tsx
+++ b/components/Feed/items/FeedItemPaper.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { FC, ReactNode } from 'react';
+import { FC } from 'react';
 import Image from 'next/image';
 import { useSearchParams } from 'next/navigation';
 import { FeedPaperContent, FeedEntry } from '@/types/feed';
@@ -14,7 +14,6 @@ import {
 import { FeedItemAbstractSection } from '@/components/Feed/FeedItemAbstractSection';
 import { FeedItemTopicBadges } from '@/components/Feed/FeedItemTopicBadges';
 import { AuthorList } from '@/components/ui/AuthorList';
-import { RiskScoreBadge } from '@/components/Moderators/RiskScoreBadge';
 import { Tooltip } from '@/components/ui/Tooltip';
 import { PopularityScoreTooltip } from '@/components/tooltips/HotScoreTooltip';
 import { PeerReviewTooltip } from '@/components/tooltips/PeerReviewTooltip';
@@ -34,7 +33,6 @@ interface FeedItemPaperProps {
   highlights?: Highlight[];
   showBountyInfo?: boolean;
   abstractCollapsedByDefault?: boolean;
-  footer?: ReactNode;
 }
 
 /**
@@ -51,7 +49,6 @@ export const FeedItemPaper: FC<FeedItemPaperProps> = ({
   highlights,
   showBountyInfo,
   abstractCollapsedByDefault,
-  footer,
 }) => {
   const searchParams = useSearchParams();
   const isDebugMode = searchParams.has('debug');
@@ -99,7 +96,6 @@ export const FeedItemPaper: FC<FeedItemPaperProps> = ({
       onFeedItemClick={onFeedItemClick}
       showBountyInfo={showBountyInfo}
       hideReportButton={false}
-      footer={footer}
       cardImage={
         thumbnailUrl ? (
           <ImageSection
@@ -188,7 +184,6 @@ export const FeedItemPaper: FC<FeedItemPaperProps> = ({
               delimiterClassName="ml-0"
               showAbbreviatedInMobile={true}
               hideExpandButton={true}
-              afterAuthors={<RiskScoreBadge score={entry.riskScore} />}
             />
           )}
           {(entry.timestamp || paper.createdDate) && (

--- a/components/Moderators/PendingModerationList.tsx
+++ b/components/Moderators/PendingModerationList.tsx
@@ -6,7 +6,6 @@ import { Button } from '@/components/ui/Button';
 import { DeclineModal } from '@/components/Moderators/DeclineModal';
 import { FeedItemGrantWithApplicants } from '@/components/Feed/items/FeedItemGrantWithApplicants';
 import { FeedItemPost } from '@/components/Feed/items/FeedItemPost';
-import { FeedItemPaper } from '@/components/Feed/items/FeedItemPaper';
 import {
   PendingModerationService,
   PENDING_MODULE_CONFIG,
@@ -69,16 +68,9 @@ function renderPendingGrantItem(entry: FeedEntry, footer: ReactNode): ReactNode 
 
 function renderFeedItem(module: PendingModule, entry: FeedEntry, footer: ReactNode): ReactNode {
   const commonProps = { entry, showActions: false, footer };
-  switch (module) {
-    case 'funding_opportunities':
-      return renderPendingGrantItem(entry, footer);
-    case 'journal_entries':
-      return <FeedItemPaper {...commonProps} />;
-    case 'proposals':
-    case 'posts':
-    default:
-      return <FeedItemPost {...commonProps} showHeader={false} />;
-  }
+  if (module === 'funding_opportunities') return renderPendingGrantItem(entry, footer);
+
+  return <FeedItemPost {...commonProps} showHeader={false} />;
 }
 
 export function PendingModerationList({ module }: Readonly<PendingModerationListProps>) {

--- a/services/content-moderation.service.ts
+++ b/services/content-moderation.service.ts
@@ -5,7 +5,7 @@ import { GrantModerationService, type PendingWorksResponse } from './grant-moder
 
 export type { PendingWorksResponse };
 
-export type PendingModule = 'funding_opportunities' | 'proposals' | 'posts' | 'journal_entries';
+export type PendingModule = 'funding_opportunities' | 'proposals';
 
 /** Number of pending items per module, as shown on the tab badges. */
 export type PendingModuleCounts = Record<PendingModule, number>;
@@ -24,12 +24,7 @@ interface PendingModuleConfig {
   resourcePath?: string;
 }
 
-export const PENDING_MODULES: PendingModule[] = [
-  'funding_opportunities',
-  'proposals',
-  'posts',
-  'journal_entries',
-];
+export const PENDING_MODULES: PendingModule[] = ['funding_opportunities', 'proposals'];
 
 /** Module shown when none is specified in the URL (the first tab). */
 export const DEFAULT_PENDING_MODULE: PendingModule = PENDING_MODULES[0];
@@ -55,18 +50,6 @@ export const PENDING_MODULE_CONFIG: Record<PendingModule, PendingModuleConfig> =
     itemLabel: 'Proposal',
     feedContentType: 'PREREGISTRATION',
     resourcePath: '/api/researchhubpost',
-  },
-  posts: {
-    tabLabel: 'Posts',
-    itemLabel: 'Post',
-    feedContentType: 'POST',
-    resourcePath: '/api/researchhubpost',
-  },
-  journal_entries: {
-    tabLabel: 'Journal Entries',
-    itemLabel: 'Journal entry',
-    feedContentType: 'PAPER',
-    resourcePath: '/api/paper',
   },
 };
 


### PR DESCRIPTION
## Overview ##

This PR removes post and journal entry moderation items from the moderation dashboard


## Screenshot ##

<img width="1784" height="662" alt="image" src="https://github.com/user-attachments/assets/4841fddf-a221-41a2-b627-5e018461809c" />
