### PR TITLE
[Expert Finder] Multi-channel outreach completion

### DIFF
--- a/app/expert-finder/lib/outreachChannels.ts
+++ b/app/expert-finder/lib/outreachChannels.ts
@@ -8,7 +8,6 @@ export const OUTREACH_CHANNEL_LABELS: Record<OutreachChannel, string> = {
   email: 'Email',
   linkedin: 'LinkedIn',
   x: 'X',
-  other: 'Other',
 };
 
 export const OUTREACH_CHANNEL_OPTIONS: { value: OutreachChannel; label: string }[] =
@@ -17,11 +16,8 @@ export const OUTREACH_CHANNEL_OPTIONS: { value: OutreachChannel; label: string }
     label: OUTREACH_CHANNEL_LABELS[value],
   }));
 
-export function getOutreachChannelLabel(
-  channel: OutreachChannel | '' | null | undefined
-): string | null {
-  if (!channel) return null;
-  return OUTREACH_CHANNEL_LABELS[channel] ?? null;
+export function getOutreachChannelLabels(channels: OutreachChannel[] | null | undefined): string[] {
+  return (channels ?? []).map((channel) => OUTREACH_CHANNEL_LABELS[channel]);
 }
 
 /** Open Gmail compose (browser) with to/subject; body is copied separately for rich paste. */

--- a/app/expert-finder/library/[searchId]/outreach/[emailId]/OutreachDetailPageContent.tsx
+++ b/app/expert-finder/library/[searchId]/outreach/[emailId]/OutreachDetailPageContent.tsx
@@ -25,8 +25,7 @@ import { Input } from '@/components/ui/form/Input';
 import { Badge } from '@/components/ui/Badge';
 import { BaseMenu, BaseMenuItem } from '@/components/ui/form/BaseMenu';
 import { ConfirmationModal } from '@/components/ui/form/ConfirmationModal';
-import { RadioGroup } from '@/components/ui/form/RadioGroup';
-import { Textarea } from '@/components/ui/form/Textarea';
+import { Checkbox } from '@/components/ui/form/Checkbox';
 import {
   getGeneratedEmailStatusPresentation,
   isGeneratedEmailBounced,
@@ -44,7 +43,7 @@ import {
 import { toast } from 'react-hot-toast';
 import { TAB_OUTREACH } from '@/app/expert-finder/lib/searchDetailTabs';
 import {
-  getOutreachChannelLabel,
+  getOutreachChannelLabels,
   OUTREACH_CHANNEL_OPTIONS,
 } from '@/app/expert-finder/lib/outreachChannels';
 import type { OutreachChannel } from '@/types/expertFinder';
@@ -72,9 +71,7 @@ export function OutreachDetailPageContent({
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const [showCloseConfirm, setShowCloseConfirm] = useState(false);
   const [showMarkSentConfirm, setShowMarkSentConfirm] = useState(false);
-  const [closeNotes, setCloseNotes] = useState('');
-  const [markSentNotes, setMarkSentNotes] = useState('');
-  const [markSentChannel, setMarkSentChannel] = useState<OutreachChannel | ''>('');
+  const [markSentChannels, setMarkSentChannels] = useState<OutreachChannel[]>([]);
   const [actionError, setActionError] = useState<string | null>(null);
   const [editSubject, setEditSubject] = useState('');
   const [editBody, setEditBody] = useState('');
@@ -123,6 +120,23 @@ export function OutreachDetailPageContent({
     isDraftLike &&
     (editSubject !== (email.emailSubject ?? '') || editBody !== (email.emailBody ?? ''));
 
+  const openMarkSentConfirm = (preselected?: OutreachChannel) => {
+    const existing = email?.channels ?? [];
+    setMarkSentChannels(
+      preselected && !existing.includes(preselected) ? [...existing, preselected] : [...existing]
+    );
+    setShowMarkSentConfirm(true);
+  };
+
+  const toggleMarkSentChannel = (channel: OutreachChannel, checked: boolean) => {
+    setMarkSentChannels((prev) => {
+      if (checked) {
+        return prev.includes(channel) ? prev : [...prev, channel];
+      }
+      return prev.filter((c) => c !== channel);
+    });
+  };
+
   const handleSaveDraft = async () => {
     if (!emailId || !hasEdits) return;
     setActionError(null);
@@ -140,23 +154,20 @@ export function OutreachDetailPageContent({
 
   const handleMarkSentSubmit = async () => {
     if (!emailId) return;
-    if (!markSentChannel) {
-      setActionError('Select how you sent this outreach.');
+    if (markSentChannels.length === 0) {
+      setActionError('Select at least one channel.');
       return;
     }
     setActionError(null);
     try {
-      const notes = markSentNotes.trim();
       await updateEmail(emailId, {
         status: 'sent',
-        channel: markSentChannel,
-        ...(notes ? { notes } : {}),
+        channels: markSentChannels,
       });
       setShowMarkSentConfirm(false);
-      setMarkSentNotes('');
-      setMarkSentChannel('');
+      setMarkSentChannels([]);
       refetch();
-      toast.success('Marked as sent.');
+      toast.success(email?.status === 'sent' ? 'Channels updated.' : 'Marked as sent.');
     } catch (e) {
       setActionError(e instanceof Error ? e.message : 'Failed to update');
     }
@@ -164,8 +175,7 @@ export function OutreachDetailPageContent({
 
   const closeMarkSentConfirm = () => {
     setShowMarkSentConfirm(false);
-    setMarkSentChannel('');
-    setMarkSentNotes('');
+    setMarkSentChannels([]);
   };
 
   const handleDelete = async () => {
@@ -184,13 +194,10 @@ export function OutreachDetailPageContent({
     if (!emailId) return;
     setActionError(null);
     try {
-      const notes = closeNotes.trim();
       await updateEmail(emailId, {
         status: 'closed',
-        ...(notes ? { notes } : {}),
       });
       setShowCloseConfirm(false);
-      setCloseNotes('');
       refetch();
       toast.success('Marked as closed.');
     } catch (e) {
@@ -222,8 +229,9 @@ export function OutreachDetailPageContent({
   const isSent = email.status === 'sent';
   const statusPresentation = getGeneratedEmailStatusPresentation(email.status, email.openCount);
   const pipelineBusy = isGeneratedEmailPipelineBusy(email.status);
-  const showOutreachMoreMenu = !isClosed && !isSent;
-  const channelLabel = getOutreachChannelLabel(email.channel);
+  const showOutreachMoreMenu = !isClosed;
+  const channelLabels = isSent ? getOutreachChannelLabels(email.channels) : [];
+  const showChannelActions = !isClosed && (isDraftLike || isSent);
 
   const displaySubject = isDraftLike ? editSubject : (email.emailSubject ?? '');
   const displayTitle = displaySubject || `Outreach for ${email.expertName}`;
@@ -323,7 +331,11 @@ export function OutreachDetailPageContent({
           <div className="hidden sm:!block">{neighborNavBar}</div>
           <div className="flex flex-wrap items-center gap-2 justify-start md:!justify-end">
             <Badge variant={statusPresentation.variant}>{statusPresentation.label}</Badge>
-            {isSent && channelLabel ? <Badge variant="default">via {channelLabel}</Badge> : null}
+            {channelLabels.map((label) => (
+              <Badge key={label} variant="default">
+                via {label}
+              </Badge>
+            ))}
             {isGeneratedEmailBounced(email.status) && email.bouncedAt && (
               <span className="text-xs text-gray-500">
                 Bounced on {formatExactTime(email.bouncedAt)}
@@ -352,28 +364,28 @@ export function OutreachDetailPageContent({
                   </button>
                 }
               >
-                {isDraftLike && (
+                {(isDraftLike || isSent) && (
                   <BaseMenuItem
                     disabled={isUpdating}
                     onSelect={() => {
-                      setMarkSentNotes('');
-                      setShowMarkSentConfirm(true);
+                      openMarkSentConfirm();
                     }}
                   >
                     <Mail className="h-4 w-4 mr-2 shrink-0 text-amber-600" aria-hidden />
-                    <span>Mark as sent</span>
+                    <span>{isSent ? 'Update channels' : 'Mark as sent'}</span>
                   </BaseMenuItem>
                 )}
-                <BaseMenuItem
-                  disabled={isUpdating}
-                  onSelect={() => {
-                    setCloseNotes('');
-                    setShowCloseConfirm(true);
-                  }}
-                >
-                  <Octagon className="h-4 w-4 mr-2 shrink-0" aria-hidden />
-                  <span>Mark as closed</span>
-                </BaseMenuItem>
+                {!isSent && (
+                  <BaseMenuItem
+                    disabled={isUpdating}
+                    onSelect={() => {
+                      setShowCloseConfirm(true);
+                    }}
+                  >
+                    <Octagon className="h-4 w-4 mr-2 shrink-0" aria-hidden />
+                    <span>Mark as closed</span>
+                  </BaseMenuItem>
+                )}
                 {isDraftLike && (
                   <BaseMenuItem disabled={isDeleting} onSelect={() => setShowDeleteConfirm(true)}>
                     <Trash2 className="h-4 w-4 mr-2 shrink-0 text-red-600" aria-hidden />
@@ -436,13 +448,6 @@ export function OutreachDetailPageContent({
           )}
         </div>
 
-        {(isClosed || email.status === 'sent') && email.notes?.trim() ? (
-          <div className="rounded-lg border border-gray-200 bg-gray-50 px-4 py-3">
-            <p className="text-xs font-semibold text-gray-600 uppercase tracking-wide">Notes</p>
-            <p className="text-sm text-gray-800 mt-1 whitespace-pre-wrap">{email.notes}</p>
-          </div>
-        ) : null}
-
         <div>
           <div>
             <label className="block text-sm font-semibold text-gray-700 mb-1">Outreach body</label>
@@ -490,13 +495,14 @@ export function OutreachDetailPageContent({
         </div>
       </BaseSection>
 
-      {isDraftLike && (
+      {showChannelActions && (
         <div className="flex justify-end pt-2">
           <OutreachChannelActions
             expertEmail={email.expertEmail}
             emailSubject={displaySubject}
-            emailBody={editBody}
+            emailBody={isDraftLike ? editBody : (email.emailBody ?? '')}
             sources={email.sources}
+            onChannelOpened={openMarkSentConfirm}
           />
         </div>
       )}
@@ -517,54 +523,46 @@ export function OutreachDetailPageContent({
       <ConfirmationModal
         isOpen={showMarkSentConfirm}
         onClose={closeMarkSentConfirm}
-        title="Mark as sent?"
-        description="Confirm after you sent this from your personal inbox or social account."
+        title={isSent ? 'Update channels?' : 'Mark as sent?'}
+        description={
+          isSent
+            ? 'Select every channel you used for this outreach.'
+            : 'Confirm after you sent this from your personal inbox or social account. Select every channel you used.'
+        }
         descriptionClassName="mb-3"
-        confirmLabel="Mark as sent"
+        confirmLabel={isSent ? 'Save channels' : 'Mark as sent'}
         confirmClassName="gap-2 bg-amber-500 text-white hover:bg-amber-600"
         confirmIcon={<Mail className="h-4 w-4" aria-hidden />}
         isConfirming={isUpdating}
-        confirmDisabled={!markSentChannel}
+        confirmDisabled={markSentChannels.length === 0}
         onConfirm={() => void handleMarkSentSubmit()}
       >
-        <RadioGroup
-          label="Channel"
-          required
-          size="sm"
-          className="mb-4"
-          value={markSentChannel}
-          onChange={(value) => setMarkSentChannel(value as OutreachChannel)}
-          options={OUTREACH_CHANNEL_OPTIONS}
-        />
-        <Textarea
-          label="Notes (optional)"
-          value={markSentNotes}
-          onChange={(e) => setMarkSentNotes(e.target.value)}
-          placeholder="Optional context for your team"
-          rows={3}
-          className="mb-4"
-        />
+        <fieldset className="mb-4 space-y-2">
+          <legend className="text-sm font-medium text-gray-700 mb-2">
+            Channels <span className="text-gray-700">*</span>
+          </legend>
+          {OUTREACH_CHANNEL_OPTIONS.map((option) => (
+            <Checkbox
+              key={option.value}
+              id={`mark-sent-channel-${option.value}`}
+              label={option.label}
+              checked={markSentChannels.includes(option.value)}
+              onCheckedChange={(checked) => toggleMarkSentChannel(option.value, checked)}
+            />
+          ))}
+        </fieldset>
       </ConfirmationModal>
 
       <ConfirmationModal
         isOpen={showCloseConfirm}
         onClose={() => setShowCloseConfirm(false)}
         title="Mark as closed?"
-        description="This retires the outreach draft (inactive). You can add an optional note for your team."
+        description="This retires the outreach draft (inactive)."
         descriptionClassName="mb-3"
         confirmLabel="Mark closed"
         isConfirming={isUpdating}
         onConfirm={() => void handleCloseEmail()}
-      >
-        <Textarea
-          label="Notes (optional)"
-          value={closeNotes}
-          onChange={(e) => setCloseNotes(e.target.value)}
-          placeholder="e.g. Replaced by outreach id 456"
-          rows={3}
-          className="mb-4"
-        />
-      </ConfirmationModal>
+      />
     </div>
   );
 }

--- a/app/expert-finder/library/[searchId]/outreach/[emailId]/OutreachDetailPageContent.tsx
+++ b/app/expert-finder/library/[searchId]/outreach/[emailId]/OutreachDetailPageContent.tsx
@@ -44,6 +44,7 @@ import { toast } from 'react-hot-toast';
 import { TAB_OUTREACH } from '@/app/expert-finder/lib/searchDetailTabs';
 import {
   getOutreachChannelLabels,
+  OUTREACH_CHANNEL_LABELS,
   OUTREACH_CHANNEL_OPTIONS,
 } from '@/app/expert-finder/lib/outreachChannels';
 import type { OutreachChannel } from '@/types/expertFinder';
@@ -52,6 +53,14 @@ import { OutreachChannelActions } from '@/app/expert-finder/library/[searchId]/o
 
 function buildOutreachDetailHref(librarySearchId: string, neighborEmailId: number): string {
   return `/expert-finder/library/${librarySearchId}/outreach/${neighborEmailId}`;
+}
+
+function withChannel(
+  existing: OutreachChannel[] | undefined,
+  channel: OutreachChannel
+): OutreachChannel[] {
+  const channels = existing ?? [];
+  return channels.includes(channel) ? [...channels] : [...channels, channel];
 }
 
 export interface OutreachDetailPageContentProps {
@@ -72,6 +81,8 @@ export function OutreachDetailPageContent({
   const [showCloseConfirm, setShowCloseConfirm] = useState(false);
   const [showMarkSentConfirm, setShowMarkSentConfirm] = useState(false);
   const [markSentChannels, setMarkSentChannels] = useState<OutreachChannel[]>([]);
+  const [showChannelConfirm, setShowChannelConfirm] = useState(false);
+  const [confirmChannel, setConfirmChannel] = useState<OutreachChannel | null>(null);
   const [actionError, setActionError] = useState<string | null>(null);
   const [editSubject, setEditSubject] = useState('');
   const [editBody, setEditBody] = useState('');
@@ -120,12 +131,18 @@ export function OutreachDetailPageContent({
     isDraftLike &&
     (editSubject !== (email.emailSubject ?? '') || editBody !== (email.emailBody ?? ''));
 
-  const openMarkSentConfirm = (preselected?: OutreachChannel) => {
-    const existing = email?.channels ?? [];
-    setMarkSentChannels(
-      preselected && !existing.includes(preselected) ? [...existing, preselected] : [...existing]
-    );
+  const openMarkSentConfirm = () => {
+    setMarkSentChannels([...(email?.channels ?? [])]);
     setShowMarkSentConfirm(true);
+  };
+
+  const openChannelConfirm = (channel: OutreachChannel) => {
+    setConfirmChannel(channel);
+    setShowChannelConfirm(true);
+  };
+
+  const closeChannelConfirm = () => {
+    setShowChannelConfirm(false);
   };
 
   const toggleMarkSentChannel = (channel: OutreachChannel, checked: boolean) => {
@@ -152,24 +169,47 @@ export function OutreachDetailPageContent({
     }
   };
 
-  const handleMarkSentSubmit = async () => {
+  const saveChannels = async (channels: OutreachChannel[], successMessage: string) => {
     if (!emailId) return;
-    if (markSentChannels.length === 0) {
-      setActionError('Select at least one channel.');
-      return;
-    }
     setActionError(null);
     try {
       await updateEmail(emailId, {
         status: 'sent',
-        channels: markSentChannels,
+        channels,
       });
-      setShowMarkSentConfirm(false);
-      setMarkSentChannels([]);
       refetch();
-      toast.success(email?.status === 'sent' ? 'Channels updated.' : 'Marked as sent.');
+      toast.success(successMessage);
     } catch (e) {
       setActionError(e instanceof Error ? e.message : 'Failed to update');
+      throw e;
+    }
+  };
+
+  const handleMarkSentSubmit = async () => {
+    if (markSentChannels.length === 0) {
+      setActionError('Select at least one channel.');
+      return;
+    }
+    try {
+      await saveChannels(
+        markSentChannels,
+        email?.status === 'sent' ? 'Channels updated.' : 'Marked as sent.'
+      );
+      setShowMarkSentConfirm(false);
+      setMarkSentChannels([]);
+    } catch {
+      // Error already surfaced via actionError
+    }
+  };
+
+  const handleChannelConfirmSubmit = async () => {
+    if (!confirmChannel) return;
+    const label = OUTREACH_CHANNEL_LABELS[confirmChannel];
+    try {
+      await saveChannels(withChannel(email?.channels, confirmChannel), `Marked ${label} as sent.`);
+      closeChannelConfirm();
+    } catch {
+      // Error already surfaced via actionError
     }
   };
 
@@ -502,7 +542,7 @@ export function OutreachDetailPageContent({
             emailSubject={displaySubject}
             emailBody={isDraftLike ? editBody : (email.emailBody ?? '')}
             sources={email.sources}
-            onChannelOpened={openMarkSentConfirm}
+            onChannelOpened={openChannelConfirm}
           />
         </div>
       )}
@@ -518,6 +558,26 @@ export function OutreachDetailPageContent({
         isConfirming={isDeleting}
         blockDismissWhileConfirming={false}
         onConfirm={handleDelete}
+      />
+
+      <ConfirmationModal
+        isOpen={showChannelConfirm}
+        onClose={closeChannelConfirm}
+        title={
+          confirmChannel
+            ? `Mark ${OUTREACH_CHANNEL_LABELS[confirmChannel]} as sent?`
+            : 'Mark as sent?'
+        }
+        description={
+          confirmChannel
+            ? `Confirm you completed this outreach via ${OUTREACH_CHANNEL_LABELS[confirmChannel]}.`
+            : undefined
+        }
+        confirmLabel="Mark as sent"
+        confirmClassName="gap-2 bg-amber-500 text-white hover:bg-amber-600"
+        confirmIcon={<Mail className="h-4 w-4" aria-hidden />}
+        isConfirming={isUpdating}
+        onConfirm={() => void handleChannelConfirmSubmit()}
       />
 
       <ConfirmationModal

--- a/app/expert-finder/library/[searchId]/outreach/components/OutreachChannelActions.tsx
+++ b/app/expert-finder/library/[searchId]/outreach/components/OutreachChannelActions.tsx
@@ -6,7 +6,7 @@ import { Mail } from 'lucide-react';
 import { toast } from 'react-hot-toast';
 import { Button } from '@/components/ui/Button';
 import { cn } from '@/utils/styles';
-import type { ExpertSourceLink } from '@/types/expertFinder';
+import type { ExpertSourceLink, OutreachChannel } from '@/types/expertFinder';
 import {
   buildGmailComposeHref,
   copyOutreachBodyToClipboard,
@@ -19,6 +19,7 @@ export interface OutreachChannelActionsProps {
   /** HTML message body; copied to clipboard before opening a channel. */
   emailBody?: string;
   sources?: ExpertSourceLink[] | null;
+  onChannelOpened?: (channel: OutreachChannel) => void;
   className?: string;
 }
 
@@ -27,13 +28,14 @@ export function OutreachChannelActions({
   emailSubject,
   emailBody = '',
   sources,
+  onChannelOpened,
   className,
 }: OutreachChannelActionsProps) {
   const email = expertEmail.trim();
   const linkedinUrl = getSourceUrlByNetwork(sources, 'linkedin');
   const xUrl = getSourceUrlByNetwork(sources, 'x');
 
-  const handleSendClick = (url: string) => {
+  const handleSendClick = (channel: OutreachChannel, url: string) => {
     const win = window.open('about:blank', '_blank');
     void (async () => {
       if (emailBody.trim()) {
@@ -50,6 +52,7 @@ export function OutreachChannelActions({
       } else {
         window.open(url, '_blank', 'noopener,noreferrer');
       }
+      onChannelOpened?.(channel);
     })();
   };
 
@@ -62,7 +65,7 @@ export function OutreachChannelActions({
         className="gap-2"
         disabled={!xUrl}
         title={xUrl ? 'Copy body and open X profile' : 'No X profile available'}
-        onClick={() => xUrl && handleSendClick(xUrl)}
+        onClick={() => xUrl && handleSendClick('x', xUrl)}
       >
         <FontAwesomeIcon icon={faXTwitter} className="h-3.5 w-3.5 text-gray-900" aria-hidden />
         Send via X
@@ -76,7 +79,7 @@ export function OutreachChannelActions({
         title={
           linkedinUrl ? 'Copy body and open LinkedIn profile' : 'No LinkedIn profile available'
         }
-        onClick={() => linkedinUrl && handleSendClick(linkedinUrl)}
+        onClick={() => linkedinUrl && handleSendClick('linkedin', linkedinUrl)}
       >
         <FontAwesomeIcon icon={faLinkedin} className="h-3.5 w-3.5 text-[#0077B5]" aria-hidden />
         Send via LinkedIn
@@ -89,7 +92,8 @@ export function OutreachChannelActions({
         disabled={!email}
         title={email ? 'Copy body and open Gmail' : 'No email available'}
         onClick={() =>
-          email && handleSendClick(buildGmailComposeHref({ to: email, subject: emailSubject }))
+          email &&
+          handleSendClick('email', buildGmailComposeHref({ to: email, subject: emailSubject }))
         }
       >
         <Mail className="h-3.5 w-3.5 text-gray-600" aria-hidden />

--- a/app/expert-finder/library/[searchId]/outreach/components/OutreachMobileCard.tsx
+++ b/app/expert-finder/library/[searchId]/outreach/components/OutreachMobileCard.tsx
@@ -11,7 +11,7 @@ import {
 } from '@/app/expert-finder/library/[searchId]/components/GenerateEmailModal';
 import type { GeneratedEmail } from '@/types/expertFinder';
 import { getGeneratedEmailStatusPresentation } from '@/app/expert-finder/lib/generatedEmailStatus';
-import { getOutreachChannelLabel } from '@/app/expert-finder/lib/outreachChannels';
+import { getOutreachChannelLabels } from '@/app/expert-finder/lib/outreachChannels';
 
 const SUBJECT_TRUNCATE_LENGTH = 50;
 
@@ -41,7 +41,7 @@ export function OutreachMobileCard({
   const templateLabel = getTemplateDisplayLabel(email.template);
   const templateDescription = getTemplateDescription(email.template);
   const statusPresentation = getGeneratedEmailStatusPresentation(email.status, email.openCount);
-  const channelLabel = email.status === 'sent' ? getOutreachChannelLabel(email.channel) : null;
+  const channelLabels = email.status === 'sent' ? getOutreachChannelLabels(email.channels) : [];
   const createdByName = email.createdBy?.author?.fullName;
 
   const selectTrailing =
@@ -70,11 +70,11 @@ export function OutreachMobileCard({
         <Badge variant={statusPresentation.variant} size="sm">
           {statusPresentation.label}
         </Badge>
-        {channelLabel ? (
-          <Badge variant="default" size="sm">
+        {channelLabels.map((channelLabel) => (
+          <Badge key={channelLabel} variant="default" size="sm">
             via {channelLabel}
           </Badge>
-        ) : null}
+        ))}
         {templateDescription ? (
           <Tooltip content={templateDescription} width="w-72" position="top">
             <span className="text-xs text-gray-500 truncate max-w-[140px] cursor-help underline decoration-dotted decoration-gray-400 underline-offset-1">

--- a/app/expert-finder/library/[searchId]/outreach/components/OutreachTable.tsx
+++ b/app/expert-finder/library/[searchId]/outreach/components/OutreachTable.tsx
@@ -6,15 +6,19 @@ import { Badge } from '@/components/ui/Badge';
 import { formatTimestamp } from '@/utils/date';
 import type { GeneratedEmail } from '@/types/expertFinder';
 import { getGeneratedEmailStatusPresentation } from '@/app/expert-finder/lib/generatedEmailStatus';
-import { getOutreachChannelLabel } from '@/app/expert-finder/lib/outreachChannels';
+import { getOutreachChannelLabels } from '@/app/expert-finder/lib/outreachChannels';
 
 function statusCell(email: GeneratedEmail) {
   const { label, variant } = getGeneratedEmailStatusPresentation(email.status, email.openCount);
-  const channelLabel = email.status === 'sent' ? getOutreachChannelLabel(email.channel) : null;
+  const channelLabels = email.status === 'sent' ? getOutreachChannelLabels(email.channels) : [];
   return (
     <div className="flex flex-wrap items-center gap-1.5">
       <Badge variant={variant}>{label}</Badge>
-      {channelLabel ? <Badge variant="default">via {channelLabel}</Badge> : null}
+      {channelLabels.map((channelLabel) => (
+        <Badge key={channelLabel} variant="default">
+          via {channelLabel}
+        </Badge>
+      ))}
     </div>
   );
 }

--- a/services/expertFinder.service.ts
+++ b/services/expertFinder.service.ts
@@ -160,7 +160,7 @@ export interface CreateDraftEmailPayload {
   template?: string;
   status?: GeneratedEmailStatus;
   notes?: string;
-  channel?: OutreachChannel | '';
+  channels?: OutreachChannel[];
 }
 
 export type UpdateGeneratedEmailPayload = Partial<CreateDraftEmailPayload>;

--- a/types/expertFinder.ts
+++ b/types/expertFinder.ts
@@ -461,9 +461,9 @@ function transformGeneratedEmailListNavigation(raw: any): GeneratedEmailListNavi
   return { total, position, previousId, nextId };
 }
 
-export type OutreachChannel = 'email' | 'linkedin' | 'x' | 'other';
+export type OutreachChannel = 'email' | 'linkedin' | 'x';
 
-export const OUTREACH_CHANNEL_VALUES = ['email', 'linkedin', 'x', 'other'] as const;
+export const OUTREACH_CHANNEL_VALUES = ['email', 'linkedin', 'x'] as const;
 
 export function parseOutreachChannel(raw: unknown): OutreachChannel | '' {
   const value = String(raw ?? '')
@@ -472,6 +472,13 @@ export function parseOutreachChannel(raw: unknown): OutreachChannel | '' {
   return (OUTREACH_CHANNEL_VALUES as readonly string[]).includes(value)
     ? (value as OutreachChannel)
     : '';
+}
+
+export function parseOutreachChannels(raw: unknown): OutreachChannel[] {
+  if (!Array.isArray(raw)) return [];
+  return raw
+    .map((item) => parseOutreachChannel(item))
+    .filter((channel): channel is OutreachChannel => Boolean(channel));
 }
 
 export interface GeneratedEmail {
@@ -487,7 +494,7 @@ export interface GeneratedEmail {
   template: string | null;
   status: string;
   notes: string;
-  channel: OutreachChannel | '';
+  channels: OutreachChannel[];
   /** Expert profile links for outreach CTAs (LinkedIn, X, etc.). */
   sources: ExpertSourceLink[] | null;
   /** ProposalDraft id this email links to, when generated as a proposal invitation. */
@@ -531,7 +538,7 @@ export const transformGeneratedEmail = createTransformer<any, GeneratedEmail>((r
     template: raw.template ?? '',
     status: raw.status ?? 'draft',
     notes: raw.notes ?? '',
-    channel: parseOutreachChannel(raw.channel),
+    channels: parseOutreachChannels(raw.channels),
     sources: sources?.length ? sources : null,
     bouncedAt: raw.bounced_at ?? null,
     openedAt: raw.opened_at ?? null,


### PR DESCRIPTION
## What?
- Automatically open the mark-as-sent modal when users click Send via Email, LinkedIn, or X
- Allow marking outreach as sent across multiple channels
- Remove notes and the Other channel option from the completion UI

<img width="782" height="481" alt="image" src="https://github.com/user-attachments/assets/87870d30-8fb1-424e-b4e9-4ffd9ecf1ac3" />
