### PR TITLE
Avoid icon flickering on initial page load

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import localFont from 'next/font/local';
 
 import './globals.css';
+import '@fortawesome/fontawesome-svg-core/styles.css';
 import { Metadata } from 'next';
 import { getServerSession } from 'next-auth';
 import { authOptions } from './api/auth/[...nextauth]/auth.config';

--- a/components/providers/ClientProviders.tsx
+++ b/components/providers/ClientProviders.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { config as fontAwesomeConfig } from '@fortawesome/fontawesome-svg-core';
 import { ReactNode } from 'react';
 import { Session } from 'next-auth';
 import NextAuthProvider from '@/components/providers/NextAuthProvider';
@@ -25,6 +26,10 @@ import { UserListsProvider } from '@/components/UserList/lib/UserListsContext';
 import { LeaderboardProvider } from '@/contexts/LeaderboardContext';
 import { DismissedFeaturesProvider } from '@/contexts/DismissedFeaturesContext';
 import { PendingCountsProvider } from '@/components/Moderators/PendingCountsContext';
+
+// The Font Awesome CSS is bundled via the root layout's stylesheet import.
+// Stop the library from injecting a duplicate <style> tag at hydration.
+fontAwesomeConfig.autoAddCss = false;
 
 interface ClientProvidersProps {
   readonly children: ReactNode;


### PR DESCRIPTION
Font Awesome renders unsized SVGs and injects its CSS only after hydration, which flashes giant icons on first paint. Ship the CSS with the page instead.