### PR TITLE
[Notebook] In-note version diff review infrastructure

### DIFF
--- a/components/Notebook/NoteReview/NoteReviewControls.tsx
+++ b/components/Notebook/NoteReview/NoteReviewControls.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import { Check, X } from 'lucide-react';
+
+interface NoteReviewControlsProps {
+  readonly changeCount: number;
+  /** Keep the incoming version's side: deletes the struck ranges. */
+  readonly onAccept: () => void;
+  /** Keep the reader's side: deletes the inserted ranges. */
+  readonly onReject: () => void;
+}
+
+/**
+ * The floating controls for an in-note diff review: the unresolved change
+ * count with a green check to accept and a red x to reject. Positioning is
+ * the host's concern — render this inside whatever container floats it over
+ * the document.
+ */
+export function NoteReviewControls({ changeCount, onAccept, onReject }: NoteReviewControlsProps) {
+  return (
+    <div className="pointer-events-auto flex max-w-full items-center gap-2.5 rounded-full border border-gray-200 bg-white/95 py-1.5 pl-4 pr-1.5 shadow-lg backdrop-blur">
+      <p className="text-xs font-medium text-gray-700">
+        {changeCount === 1 ? '1 assistant change' : `${changeCount} assistant changes`}
+      </p>
+      <div className="flex shrink-0 items-center gap-0.5">
+        <button
+          type="button"
+          onClick={onAccept}
+          title="Accept the assistant’s changes"
+          className="rounded-md p-1 text-emerald-600 transition-colors hover:bg-emerald-50 hover:text-emerald-700"
+        >
+          <Check className="h-5 w-5" aria-hidden="true" strokeWidth={2.5} />
+          <span className="sr-only">Accept the assistant’s changes</span>
+        </button>
+        <button
+          type="button"
+          onClick={onReject}
+          title="Reject the assistant’s changes"
+          className="rounded-md p-1 text-red-600 transition-colors hover:bg-red-50 hover:text-red-700"
+        >
+          <X className="h-5 w-5" aria-hidden="true" strokeWidth={2.5} />
+          <span className="sr-only">Reject the assistant’s changes</span>
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/components/Notebook/NoteReview/noteDiffOverlay.ts
+++ b/components/Notebook/NoteReview/noteDiffOverlay.ts
@@ -213,6 +213,10 @@ export function beginNoteDiffReview(
   resolveNoteDiffReview(editor, 'reject');
 
   const older = editor.state.doc;
+  // Both endpoints are carried so a live text selection survives arming,
+  // direction included; non-text selections degrade to the nearest text
+  // range (TextSelection.between).
+  const selectionAnchor = editor.state.selection.anchor;
   const selectionHead = editor.state.selection.head;
   const changes = computeNoteDiffChanges(editor.schema, older, incoming);
 
@@ -220,8 +224,9 @@ export function beginNoteDiffReview(
     if (!older.eq(incoming)) {
       const tr = editor.state.tr;
       tr.replaceWith(0, older.content.size, incoming.content);
-      const pos = Math.min(selectionHead, tr.doc.content.size);
-      tr.setSelection(TextSelection.near(tr.doc.resolve(pos)));
+      const anchor = Math.min(selectionAnchor, tr.doc.content.size);
+      const head = Math.min(selectionHead, tr.doc.content.size);
+      tr.setSelection(TextSelection.between(tr.doc.resolve(anchor), tr.doc.resolve(head)));
       dispatchSilently(editor, tr);
     }
     return 0;
@@ -264,9 +269,10 @@ export function beginNoteDiffReview(
     }
   }
 
-  const mapped = mapOlderPosToMerged(selectionHead, changes, removedSizes);
-  const pos = Math.max(0, Math.min(mapped, tr.doc.content.size));
-  tr.setSelection(TextSelection.near(tr.doc.resolve(pos)));
+  const clamp = (pos: number) => Math.max(0, Math.min(pos, tr.doc.content.size));
+  const anchor = clamp(mapOlderPosToMerged(selectionAnchor, changes, removedSizes));
+  const head = clamp(mapOlderPosToMerged(selectionHead, changes, removedSizes));
+  tr.setSelection(TextSelection.between(tr.doc.resolve(anchor), tr.doc.resolve(head)));
   dispatchSilently(editor, tr);
 
   editor.unregisterPlugin(overlayKey);

--- a/components/Notebook/NoteReview/noteDiffOverlay.ts
+++ b/components/Notebook/NoteReview/noteDiffOverlay.ts
@@ -246,13 +246,21 @@ export function beginNoteDiffReview(
  * over. Resolution alone can leave the live count untouched — accepting
  * keeps a pair's inserted span, rejecting keeps its removed one — so the
  * closing zero has to be published here; the plugin's apply never sees it.
+ *
+ * The zero stays quiet when a new overlay is already installed by the time
+ * the microtask runs: the review was replaced (begin folding into a newer
+ * version), not closed, and the caller already holds the replacement's
+ * count — a late zero would wrongly dismiss the live review.
  */
 function teardownOverlay(editor: Editor): void {
   const state = overlayKey.getState(editor.state);
   editor.unregisterPlugin(overlayKey);
   if (state && state.changeCount > 0 && state.onChangeCountUpdate) {
     const callback = state.onChangeCountUpdate;
-    queueMicrotask(() => callback(0));
+    queueMicrotask(() => {
+      if (overlayKey.getState(editor.state)) return;
+      callback(0);
+    });
   }
 }
 

--- a/components/Notebook/NoteReview/noteDiffOverlay.ts
+++ b/components/Notebook/NoteReview/noteDiffOverlay.ts
@@ -1,0 +1,291 @@
+import type { Editor } from '@tiptap/core';
+import type { Node as ProseMirrorNode } from '@tiptap/pm/model';
+import { Plugin, PluginKey, TextSelection, type Transaction } from '@tiptap/pm/state';
+import { Transform } from '@tiptap/pm/transform';
+import { Decoration, DecorationSet } from '@tiptap/pm/view';
+import { computeNoteDiffChanges, type NoteDiffChange } from './noteVersionDiff';
+
+const INSERTED_CLASS = 'rounded-sm bg-emerald-100 box-decoration-clone text-emerald-950';
+const REMOVED_CLASS =
+  'rounded-sm bg-red-50 box-decoration-clone text-red-800 line-through decoration-red-400/70';
+
+/**
+ * A live region of the review document. Both kinds are real, editable
+ * content: `removed` is the reader's overwritten content spliced back in
+ * (struck through), `inserted` is what the assistant added (highlighted).
+ * Positions are mapped along as the user keeps editing; `changeId` groups the
+ * removed/inserted pair born from one changed region.
+ */
+interface LiveSpan {
+  readonly changeId: number;
+  readonly kind: 'inserted' | 'removed';
+  readonly from: number;
+  readonly to: number;
+}
+
+interface OverlayState {
+  readonly spans: readonly LiveSpan[];
+  readonly changeCount: number;
+  readonly decorations: DecorationSet;
+}
+
+interface OverlayOptions {
+  /**
+   * The number of unresolved changed regions shifted — the user edited a
+   * whole region away, or a resolution deleted one side of every pair.
+   * Delivered on a microtask, never during a dispatch.
+   */
+  readonly onChangeCountUpdate?: (count: number) => void;
+}
+
+const overlayKey = new PluginKey<OverlayState>('noteDiffOverlay');
+
+function countChanges(spans: readonly LiveSpan[]): number {
+  return new Set(spans.map((span) => span.changeId)).size;
+}
+
+function buildDecorations(doc: ProseMirrorNode, spans: readonly LiveSpan[]): DecorationSet {
+  const decorations = spans.map((span) =>
+    span.kind === 'inserted'
+      ? Decoration.inline(span.from, span.to, {
+          class: INSERTED_CLASS,
+          title: 'Added by the assistant',
+        })
+      : Decoration.inline(span.from, span.to, {
+          class: REMOVED_CLASS,
+          title: 'Removed by the assistant',
+        })
+  );
+  return DecorationSet.create(doc, decorations);
+}
+
+/**
+ * Map a span through a document change; null once it has been edited away.
+ *
+ * Inserted spans are inclusive on both edges, so typing at either boundary
+ * joins the assistant's section; removed spans are exclusive, so at the
+ * shared removed→inserted boundary the inserted side wins and text typed
+ * right before struck content stays neutral. Neutral text survives both
+ * Accept and Reject; text inside a section shares its section's fate.
+ */
+function mapSpan(span: LiveSpan, tr: Transaction): LiveSpan | null {
+  const inclusive = span.kind === 'inserted';
+  const from = tr.mapping.map(span.from, inclusive ? -1 : 1);
+  const to = tr.mapping.map(span.to, inclusive ? 1 : -1);
+  return from < to ? { ...span, from, to } : null;
+}
+
+/**
+ * The in-note review: the document itself is the merge of both versions —
+ * the assistant's version with the reader's overwritten content spliced back
+ * in — and this plugin tracks which ranges belong to which side. Everything
+ * stays editable throughout; edits inside a range grow that range. The
+ * merged document must never be persisted as-is: saves go through
+ * noteDiffPersistableDoc, which strips the removed (struck) ranges so the
+ * server only ever sees the accept-projection.
+ */
+function buildOverlayPlugin(
+  initial: readonly LiveSpan[],
+  options: OverlayOptions
+): Plugin<OverlayState> {
+  return new Plugin<OverlayState>({
+    key: overlayKey,
+    state: {
+      init: (_config, state) => ({
+        spans: initial,
+        changeCount: countChanges(initial),
+        decorations: buildDecorations(state.doc, initial),
+      }),
+      apply: (tr, previous) => {
+        if (!tr.docChanged) return previous;
+        const spans = previous.spans
+          .map((span) => mapSpan(span, tr))
+          .filter((span): span is LiveSpan => span != null);
+        const changeCount = countChanges(spans);
+        if (changeCount !== previous.changeCount && options.onChangeCountUpdate) {
+          const callback = options.onChangeCountUpdate;
+          queueMicrotask(() => callback(changeCount));
+        }
+        return { spans, changeCount, decorations: buildDecorations(tr.doc, spans) };
+      },
+    },
+    props: {
+      decorations(state) {
+        return overlayKey.getState(state)?.decorations;
+      },
+    },
+  });
+}
+
+/**
+ * Map a position in the pre-review document to the merged review document.
+ * Neutral text shifts by the surrounding regions' size drift; a position
+ * inside overwritten content lands inside its struck (removed) range.
+ */
+function mapOlderPosToMerged(
+  pos: number,
+  changes: readonly NoteDiffChange[],
+  removedSizes: readonly number[]
+): number {
+  let drift = 0; // newer-doc position minus older-doc position, after processed regions
+  let removedBefore = 0; // merged-doc size of removed content spliced in before this point
+  for (let i = 0; i < changes.length; i++) {
+    const change = changes[i];
+    if (pos < change.fromA) break;
+    if (pos <= change.toA) {
+      return change.fromB + removedBefore + Math.min(pos - change.fromA, removedSizes[i]);
+    }
+    drift = change.toB - change.toA;
+    removedBefore += removedSizes[i];
+  }
+  return pos + drift + removedBefore;
+}
+
+function dispatchSilently(editor: Editor, tr: Transaction): void {
+  // Programmatic content application: not an undo step, not a user edit —
+  // autosave and the dirty tracking must not fire for it.
+  tr.setMeta('addToHistory', false);
+  tr.setMeta('preventUpdate', true);
+  editor.view.dispatch(tr);
+}
+
+/**
+ * Turn an incoming assistant version into an in-note review on the live
+ * editor. The document becomes the assistant's version with every piece of
+ * content it overwrote spliced back in as struck-through, still-editable
+ * text; the selection is carried over so this can fire mid-keystroke.
+ *
+ * Returns the number of changed regions. Zero means nothing reviewable: the
+ * incoming version differed at most in formatting (marks are invisible to
+ * the changeset), which is applied verbatim — no overlay is installed.
+ *
+ * If a review is already active it is first folded back to the reader's
+ * side (reject semantics), so the new diff is always mine-vs-latest rather
+ * than a diff against a half-merged document.
+ */
+export function beginNoteDiffReview(
+  editor: Editor,
+  incoming: ProseMirrorNode,
+  options: OverlayOptions = {}
+): number {
+  resolveNoteDiffReview(editor, 'reject');
+
+  const older = editor.state.doc;
+  const selectionHead = editor.state.selection.head;
+  const changes = computeNoteDiffChanges(editor.schema, older, incoming);
+
+  if (changes.length === 0) {
+    if (!older.eq(incoming)) {
+      const tr = editor.state.tr;
+      tr.replaceWith(0, older.content.size, incoming.content);
+      const pos = Math.min(selectionHead, tr.doc.content.size);
+      tr.setSelection(TextSelection.near(tr.doc.resolve(pos)));
+      dispatchSilently(editor, tr);
+    }
+    return 0;
+  }
+
+  const tr = editor.state.tr;
+  tr.replaceWith(0, older.content.size, incoming.content);
+
+  // Splice each overwritten slice back in at the position that replaced it,
+  // descending so earlier positions stay valid. Sizes are measured from the
+  // document because fitting an open slice can resize it.
+  const removedSizes: number[] = new Array(changes.length).fill(0);
+  for (let i = changes.length - 1; i >= 0; i--) {
+    const change = changes[i];
+    if (change.toA <= change.fromA) continue;
+    const slice = older.slice(change.fromA, change.toA);
+    const sizeBefore = tr.doc.content.size;
+    tr.replace(change.fromB, change.fromB, slice);
+    removedSizes[i] = tr.doc.content.size - sizeBefore;
+  }
+
+  const spans: LiveSpan[] = [];
+  let spliced = 0;
+  for (let i = 0; i < changes.length; i++) {
+    const change = changes[i];
+    const removedFrom = change.fromB + spliced;
+    spliced += removedSizes[i];
+    if (removedSizes[i] > 0) {
+      spans.push({
+        changeId: i,
+        kind: 'removed',
+        from: removedFrom,
+        to: removedFrom + removedSizes[i],
+      });
+    }
+    const insertedFrom = change.fromB + spliced;
+    const insertedTo = change.toB + spliced;
+    if (insertedTo > insertedFrom) {
+      spans.push({ changeId: i, kind: 'inserted', from: insertedFrom, to: insertedTo });
+    }
+  }
+
+  const mapped = mapOlderPosToMerged(selectionHead, changes, removedSizes);
+  const pos = Math.max(0, Math.min(mapped, tr.doc.content.size));
+  tr.setSelection(TextSelection.near(tr.doc.resolve(pos)));
+  dispatchSilently(editor, tr);
+
+  editor.unregisterPlugin(overlayKey);
+  editor.registerPlugin(buildOverlayPlugin(spans, options));
+  return changes.length;
+}
+
+/**
+ * Resolve an active review in place: Accept deletes the struck (removed)
+ * ranges, Reject deletes the inserted ones. Everything else — including
+ * whatever the user typed while reviewing — stays exactly where it is, and
+ * text typed inside a range shares that range's fate. Returns false when no
+ * review is active.
+ */
+export function resolveNoteDiffReview(
+  editor: Editor | null,
+  decision: 'accept' | 'reject'
+): boolean {
+  if (!editor || editor.isDestroyed) return false;
+  const state = overlayKey.getState(editor.state);
+  if (!state) return false;
+  const losingKind = decision === 'accept' ? 'removed' : 'inserted';
+  const losing = state.spans
+    .filter((span) => span.kind === losingKind)
+    .sort((a, b) => b.from - a.from);
+  if (losing.length > 0) {
+    const tr = editor.state.tr;
+    for (const span of losing) {
+      tr.delete(span.from, span.to);
+    }
+    dispatchSilently(editor, tr);
+  }
+  editor.unregisterPlugin(overlayKey);
+  return true;
+}
+
+/** Take the overlay down without touching the document (unmount cleanup). */
+export function endNoteDiffReview(editor: Editor | null): void {
+  if (!editor || editor.isDestroyed) return;
+  editor.unregisterPlugin(overlayKey);
+}
+
+/**
+ * The document a save should persist. While a review is active the editor
+ * holds the merged document, whose struck ranges are content the assistant's
+ * version — the server's newest — already dropped; persisting them would
+ * resurrect content nobody chose. Strips them so saves always write the
+ * accept-projection; the reader's side becomes durable through the explicit
+ * save on Reject. Null when no review is active (persist the document as-is).
+ */
+export function noteDiffPersistableDoc(editor: Editor | null): ProseMirrorNode | null {
+  if (!editor || editor.isDestroyed) return null;
+  const state = overlayKey.getState(editor.state);
+  if (!state) return null;
+  const removed = state.spans
+    .filter((span) => span.kind === 'removed')
+    .sort((a, b) => b.from - a.from);
+  if (removed.length === 0) return editor.state.doc;
+  const transform = new Transform(editor.state.doc);
+  for (const span of removed) {
+    transform.delete(span.from, span.to);
+  }
+  return transform.doc;
+}

--- a/components/Notebook/NoteReview/noteDiffOverlay.ts
+++ b/components/Notebook/NoteReview/noteDiffOverlay.ts
@@ -161,26 +161,26 @@ function buildOverlayPlugin(
 
 /**
  * Map a position in the pre-review document to the merged review document.
- * Neutral text shifts by the surrounding regions' size drift; a position
- * inside overwritten content lands inside its struck (removed) range.
+ * Neutral text shifts by the cumulative size drift of earlier regions; a
+ * position inside overwritten content lands inside its struck (removed)
+ * range.
  */
 function mapOlderPosToMerged(
   pos: number,
   changes: readonly NoteDiffChange[],
-  removedSizes: readonly number[]
+  removedSizes: readonly number[],
+  insertedSizes: readonly number[]
 ): number {
-  let drift = 0; // newer-doc position minus older-doc position, after processed regions
-  let removedBefore = 0; // merged-doc size of removed content spliced in before this point
+  let shift = 0; // merged-doc position minus older-doc position, after processed regions
   for (let i = 0; i < changes.length; i++) {
     const change = changes[i];
     if (pos < change.fromA) break;
     if (pos <= change.toA) {
-      return change.fromB + removedBefore + Math.min(pos - change.fromA, removedSizes[i]);
+      return change.fromA + shift + Math.min(pos - change.fromA, removedSizes[i]);
     }
-    drift = change.toB - change.toA;
-    removedBefore += removedSizes[i];
+    shift += removedSizes[i] + insertedSizes[i] - (change.toA - change.fromA);
   }
-  return pos + drift + removedBefore;
+  return pos + shift;
 }
 
 function dispatchSilently(editor: Editor, tr: Transaction): void {
@@ -222,6 +222,9 @@ export function beginNoteDiffReview(
 
   if (changes.length === 0) {
     if (!older.eq(incoming)) {
+      // Verbatim apply (mark-only difference): the one remaining
+      // whole-document replace, and it costs the undo stack — with no
+      // changed regions there is nothing to localize the edit to.
       const tr = editor.state.tr;
       tr.replaceWith(0, older.content.size, incoming.content);
       const anchor = Math.min(selectionAnchor, tr.doc.content.size);
@@ -232,46 +235,51 @@ export function beginNoteDiffReview(
     return 0;
   }
 
+  // The merged document is built with one local replace per changed region,
+  // never a whole-document swap: prosemirror-history maps its stored steps
+  // through this transaction even though the transaction itself is excluded
+  // from history, so keeping the edits local preserves the reader's undo
+  // stack everywhere outside the changed regions. Each region becomes the
+  // overwritten old content (struck) followed by the assistant's new
+  // content. Descending, so earlier positions stay valid; sizes are
+  // measured from the document because fitting a slice can resize it.
   const tr = editor.state.tr;
-  tr.replaceWith(0, older.content.size, incoming.content);
-
-  // Splice each overwritten slice back in at the position that replaced it,
-  // descending so earlier positions stay valid. Sizes are measured from the
-  // document because fitting an open slice can resize it.
   const removedSizes: number[] = new Array(changes.length).fill(0);
+  const insertedSizes: number[] = new Array(changes.length).fill(0);
   for (let i = changes.length - 1; i >= 0; i--) {
     const change = changes[i];
-    if (change.toA <= change.fromA) continue;
-    const slice = older.slice(change.fromA, change.toA);
-    const sizeBefore = tr.doc.content.size;
-    tr.replace(change.fromB, change.fromB, slice);
-    removedSizes[i] = tr.doc.content.size - sizeBefore;
+    let sizeBefore = tr.doc.content.size;
+    tr.replace(change.fromA, change.toA, incoming.slice(change.fromB, change.toB));
+    insertedSizes[i] = tr.doc.content.size - sizeBefore + (change.toA - change.fromA);
+    if (change.toA > change.fromA) {
+      sizeBefore = tr.doc.content.size;
+      tr.replace(change.fromA, change.fromA, older.slice(change.fromA, change.toA));
+      removedSizes[i] = tr.doc.content.size - sizeBefore;
+    }
   }
 
   const spans: LiveSpan[] = [];
-  let spliced = 0;
+  let shift = 0;
   for (let i = 0; i < changes.length; i++) {
     const change = changes[i];
-    const removedFrom = change.fromB + spliced;
-    spliced += removedSizes[i];
+    const start = change.fromA + shift;
     if (removedSizes[i] > 0) {
+      spans.push({ changeId: i, kind: 'removed', from: start, to: start + removedSizes[i] });
+    }
+    if (insertedSizes[i] > 0) {
       spans.push({
         changeId: i,
-        kind: 'removed',
-        from: removedFrom,
-        to: removedFrom + removedSizes[i],
+        kind: 'inserted',
+        from: start + removedSizes[i],
+        to: start + removedSizes[i] + insertedSizes[i],
       });
     }
-    const insertedFrom = change.fromB + spliced;
-    const insertedTo = change.toB + spliced;
-    if (insertedTo > insertedFrom) {
-      spans.push({ changeId: i, kind: 'inserted', from: insertedFrom, to: insertedTo });
-    }
+    shift += removedSizes[i] + insertedSizes[i] - (change.toA - change.fromA);
   }
 
   const clamp = (pos: number) => Math.max(0, Math.min(pos, tr.doc.content.size));
-  const anchor = clamp(mapOlderPosToMerged(selectionAnchor, changes, removedSizes));
-  const head = clamp(mapOlderPosToMerged(selectionHead, changes, removedSizes));
+  const anchor = clamp(mapOlderPosToMerged(selectionAnchor, changes, removedSizes, insertedSizes));
+  const head = clamp(mapOlderPosToMerged(selectionHead, changes, removedSizes, insertedSizes));
   tr.setSelection(TextSelection.between(tr.doc.resolve(anchor), tr.doc.resolve(head)));
   dispatchSilently(editor, tr);
 

--- a/components/Notebook/NoteReview/noteDiffOverlay.ts
+++ b/components/Notebook/NoteReview/noteDiffOverlay.ts
@@ -27,6 +27,9 @@ interface OverlayState {
   readonly spans: readonly LiveSpan[];
   readonly changeCount: number;
   readonly decorations: DecorationSet;
+  // Kept in state so teardown can publish the closing zero (see
+  // teardownOverlay); the plugin's own apply only sees live edits.
+  readonly onChangeCountUpdate?: (count: number) => void;
 }
 
 interface OverlayOptions {
@@ -95,6 +98,7 @@ function buildOverlayPlugin(
         spans: initial,
         changeCount: countChanges(initial),
         decorations: buildDecorations(state.doc, initial),
+        onChangeCountUpdate: options.onChangeCountUpdate,
       }),
       apply: (tr, previous) => {
         if (!tr.docChanged) return previous;
@@ -106,7 +110,12 @@ function buildOverlayPlugin(
           const callback = options.onChangeCountUpdate;
           queueMicrotask(() => callback(changeCount));
         }
-        return { spans, changeCount, decorations: buildDecorations(tr.doc, spans) };
+        return {
+          spans,
+          changeCount,
+          decorations: buildDecorations(tr.doc, spans),
+          onChangeCountUpdate: previous.onChangeCountUpdate,
+        };
       },
     },
     props: {
@@ -233,6 +242,21 @@ export function beginNoteDiffReview(
 }
 
 /**
+ * Unregister the overlay and tell the change-count listener the review is
+ * over. Resolution alone can leave the live count untouched — accepting
+ * keeps a pair's inserted span, rejecting keeps its removed one — so the
+ * closing zero has to be published here; the plugin's apply never sees it.
+ */
+function teardownOverlay(editor: Editor): void {
+  const state = overlayKey.getState(editor.state);
+  editor.unregisterPlugin(overlayKey);
+  if (state && state.changeCount > 0 && state.onChangeCountUpdate) {
+    const callback = state.onChangeCountUpdate;
+    queueMicrotask(() => callback(0));
+  }
+}
+
+/**
  * Resolve an active review in place: Accept deletes the struck (removed)
  * ranges, Reject deletes the inserted ones. Everything else — including
  * whatever the user typed while reviewing — stays exactly where it is, and
@@ -257,14 +281,14 @@ export function resolveNoteDiffReview(
     }
     dispatchSilently(editor, tr);
   }
-  editor.unregisterPlugin(overlayKey);
+  teardownOverlay(editor);
   return true;
 }
 
 /** Take the overlay down without touching the document (unmount cleanup). */
 export function endNoteDiffReview(editor: Editor | null): void {
   if (!editor || editor.isDestroyed) return;
-  editor.unregisterPlugin(overlayKey);
+  teardownOverlay(editor);
 }
 
 /**

--- a/components/Notebook/NoteReview/noteDiffOverlay.ts
+++ b/components/Notebook/NoteReview/noteDiffOverlay.ts
@@ -23,13 +23,24 @@ interface LiveSpan {
   readonly to: number;
 }
 
+/**
+ * One review's channel to its host, shared by reference between the plugin
+ * state and teardown. Closing it silences any count still waiting on a
+ * microtask — after that only the closing zero may speak — and
+ * `lastDelivered` records what the host actually heard (seeded with what
+ * begin() returned), which is what the closing zero must undo.
+ */
+interface OverlaySession {
+  readonly onChangeCountUpdate?: (count: number) => void;
+  lastDelivered: number;
+  closed: boolean;
+}
+
 interface OverlayState {
   readonly spans: readonly LiveSpan[];
   readonly changeCount: number;
   readonly decorations: DecorationSet;
-  // Kept in state so teardown can publish the closing zero (see
-  // teardownOverlay); the plugin's own apply only sees live edits.
-  readonly onChangeCountUpdate?: (count: number) => void;
+  readonly session: OverlaySession;
 }
 
 interface OverlayOptions {
@@ -45,6 +56,23 @@ const overlayKey = new PluginKey<OverlayState>('noteDiffOverlay');
 
 function countChanges(spans: readonly LiveSpan[]): number {
   return new Set(spans.map((span) => span.changeId)).size;
+}
+
+/**
+ * Deliver a live count on a microtask, never during a dispatch. A session
+ * closed before delivery stays quiet: the dispatch that moved the count was
+ * part of closing (or replacing) the review, and teardown owns the final
+ * word — publishing regardless would let a folded review's dying zero
+ * dismiss its replacement's controls.
+ */
+function publishCount(session: OverlaySession, count: number): void {
+  const callback = session.onChangeCountUpdate;
+  if (!callback) return;
+  queueMicrotask(() => {
+    if (session.closed) return;
+    session.lastDelivered = count;
+    callback(count);
+  });
 }
 
 function buildDecorations(doc: ProseMirrorNode, spans: readonly LiveSpan[]): DecorationSet {
@@ -91,6 +119,12 @@ function buildOverlayPlugin(
   initial: readonly LiveSpan[],
   options: OverlayOptions
 ): Plugin<OverlayState> {
+  const session: OverlaySession = {
+    onChangeCountUpdate: options.onChangeCountUpdate,
+    // What begin() reports synchronously — the host's starting knowledge.
+    lastDelivered: countChanges(initial),
+    closed: false,
+  };
   return new Plugin<OverlayState>({
     key: overlayKey,
     state: {
@@ -98,7 +132,7 @@ function buildOverlayPlugin(
         spans: initial,
         changeCount: countChanges(initial),
         decorations: buildDecorations(state.doc, initial),
-        onChangeCountUpdate: options.onChangeCountUpdate,
+        session,
       }),
       apply: (tr, previous) => {
         if (!tr.docChanged) return previous;
@@ -106,15 +140,14 @@ function buildOverlayPlugin(
           .map((span) => mapSpan(span, tr))
           .filter((span): span is LiveSpan => span != null);
         const changeCount = countChanges(spans);
-        if (changeCount !== previous.changeCount && options.onChangeCountUpdate) {
-          const callback = options.onChangeCountUpdate;
-          queueMicrotask(() => callback(changeCount));
+        if (changeCount !== previous.changeCount) {
+          publishCount(previous.session, changeCount);
         }
         return {
           spans,
           changeCount,
           decorations: buildDecorations(tr.doc, spans),
-          onChangeCountUpdate: previous.onChangeCountUpdate,
+          session: previous.session,
         };
       },
     },
@@ -242,21 +275,25 @@ export function beginNoteDiffReview(
 }
 
 /**
- * Unregister the overlay and tell the change-count listener the review is
- * over. Resolution alone can leave the live count untouched — accepting
- * keeps a pair's inserted span, rejecting keeps its removed one — so the
- * closing zero has to be published here; the plugin's apply never sees it.
- *
- * The zero stays quiet when a new overlay is already installed by the time
- * the microtask runs: the review was replaced (begin folding into a newer
- * version), not closed, and the caller already holds the replacement's
- * count — a late zero would wrongly dismiss the live review.
+ * Unregister the overlay and settle what the change-count listener is told.
+ * The session closes first, silencing any count still waiting on a
+ * microtask (see publishCount). The closing zero is then owed whenever the
+ * host last heard a nonzero count — judged from `lastDelivered`, not the
+ * document, because resolution alone can leave the live count untouched
+ * (accepting keeps a pair's inserted span, rejecting keeps its removed
+ * one). The zero itself stays quiet when a new overlay is already installed
+ * by the time its microtask runs: the review was replaced (begin folding
+ * into a newer version), not closed, and the caller already holds the
+ * replacement's count.
  */
 function teardownOverlay(editor: Editor): void {
   const state = overlayKey.getState(editor.state);
   editor.unregisterPlugin(overlayKey);
-  if (state && state.changeCount > 0 && state.onChangeCountUpdate) {
-    const callback = state.onChangeCountUpdate;
+  if (!state) return;
+  const { session } = state;
+  session.closed = true;
+  const callback = session.onChangeCountUpdate;
+  if (callback && session.lastDelivered > 0) {
     queueMicrotask(() => {
       if (overlayKey.getState(editor.state)) return;
       callback(0);

--- a/components/Notebook/NoteReview/noteVersionDiff.ts
+++ b/components/Notebook/NoteReview/noteVersionDiff.ts
@@ -48,15 +48,63 @@ function alignmentDoc(schema: Schema, doc: ProseMirrorNode): ProseMirrorNode {
 }
 
 /**
+ * Move a position to the outer edge of its enclosing textblock (paragraph,
+ * heading, code block). Positions between blocks — parent is the doc or a
+ * wrapper like a list item — stay put.
+ */
+function blockStart(doc: ProseMirrorNode, pos: number): number {
+  const $pos = doc.resolve(pos);
+  return $pos.parent.isTextblock ? $pos.before($pos.depth) : pos;
+}
+
+function blockEnd(doc: ProseMirrorNode, pos: number): number {
+  const $pos = doc.resolve(pos);
+  return $pos.parent.isTextblock ? $pos.after($pos.depth) : pos;
+}
+
+/**
+ * Widen each changed region to whole blocks, merging regions whose widened
+ * ranges overlap (several edits inside one paragraph become one change).
+ * The widened prefix and suffix are identical text on both sides — outside
+ * a change the documents align — so every pair keeps the changeset
+ * invariant that [fromA, toA) was replaced by [fromB, toB). A side left
+ * sitting between blocks (a purely inserted or purely removed block) stays
+ * degenerate: there is nothing on that side to widen over.
+ */
+function expandChangesToBlocks(
+  docA: ProseMirrorNode,
+  docB: ProseMirrorNode,
+  changes: readonly NoteDiffChange[]
+): readonly NoteDiffChange[] {
+  const merged: Array<{ fromA: number; toA: number; fromB: number; toB: number }> = [];
+  for (const change of changes) {
+    const fromA = blockStart(docA, change.fromA);
+    const toA = blockEnd(docA, change.toA);
+    const fromB = blockStart(docB, change.fromB);
+    const toB = blockEnd(docB, change.toB);
+    const last = merged[merged.length - 1];
+    if (last && (fromA < last.toA || fromB < last.toB)) {
+      last.toA = Math.max(last.toA, toA);
+      last.toB = Math.max(last.toB, toB);
+    } else {
+      merged.push({ fromA, toA, fromB, toB });
+    }
+  }
+  return merged;
+}
+
+/**
  * Diff two documents that share a schema into replaced regions.
  *
  * The backend stores version snapshots, not editing steps, so steps are first
  * recreated (recreateTransform), condensed into replaced ranges
- * (prosemirror-changeset), then merged to word boundaries for presentation.
- * Alignment runs on id-stripped copies; since attrs never change a node's
- * size, the resulting positions are valid in the real documents. Changes are
- * ascending and non-overlapping. Formatting-only changes produce no regions:
- * the changeset tracks content, not marks.
+ * (prosemirror-changeset), then widened to whole blocks for review: a change
+ * anywhere inside a paragraph presents the entire old block against the
+ * entire new one, and edits meeting inside one block merge into a single
+ * region. Alignment runs on id-stripped copies; since attrs never change a
+ * node's size, the resulting positions are valid in the real documents.
+ * Changes are ascending and non-overlapping. Formatting-only changes produce
+ * no regions: the changeset tracks content, not marks.
  */
 export function computeNoteDiffChanges(
   schema: Schema,
@@ -70,5 +118,9 @@ export function computeNoteDiffChanges(
   const changeSet = ChangeSet.create(docA).addSteps(tr.doc, tr.mapping.maps, 0);
   const changes = simplifyChanges(changeSet.changes, docB);
 
-  return changes.map(({ fromA, toA, fromB, toB }) => ({ fromA, toA, fromB, toB }));
+  return expandChangesToBlocks(
+    docA,
+    docB,
+    changes.map(({ fromA, toA, fromB, toB }) => ({ fromA, toA, fromB, toB }))
+  );
 }

--- a/components/Notebook/NoteReview/noteVersionDiff.ts
+++ b/components/Notebook/NoteReview/noteVersionDiff.ts
@@ -1,0 +1,74 @@
+import { recreateTransform } from '@fellow/prosemirror-recreate-transform';
+import { ChangeSet, simplifyChanges } from '@tiptap/pm/changeset';
+import type { Node as ProseMirrorNode, Schema } from '@tiptap/pm/model';
+
+/**
+ * Node types the editor's UniqueID extension stamps `id` attrs onto (see
+ * extension-kit.ts). Ids are volatile across writers — the assistant rebuilds
+ * content server-side without preserving them — so on otherwise identical
+ * nodes they'd register as a change and must not take part in the diff.
+ */
+const UNIQUE_ID_TYPES = new Set(['paragraph', 'heading', 'blockquote', 'codeBlock', 'table']);
+
+interface JsonNode {
+  readonly type?: string;
+  readonly attrs?: Readonly<Record<string, unknown>>;
+  readonly content?: readonly JsonNode[];
+  readonly [key: string]: unknown;
+}
+
+/**
+ * One changed region between two versions of a document: [fromA, toA) in the
+ * older document was replaced by [fromB, toB) in the newer one. Either side
+ * may be empty (a pure insertion or a pure removal, never both).
+ */
+export interface NoteDiffChange {
+  readonly fromA: number;
+  readonly toA: number;
+  readonly fromB: number;
+  readonly toB: number;
+}
+
+function stripUniqueIds(node: JsonNode): JsonNode {
+  let next = node;
+  if (next.type != null && UNIQUE_ID_TYPES.has(next.type) && next.attrs && 'id' in next.attrs) {
+    const attrs = { ...next.attrs };
+    delete attrs.id;
+    next = { ...next, attrs };
+  }
+  if (next.content != null && next.content.length > 0) {
+    next = { ...next, content: next.content.map(stripUniqueIds) };
+  }
+  return next;
+}
+
+/** A copy of the document with volatile ids dropped, used only for alignment. */
+function alignmentDoc(schema: Schema, doc: ProseMirrorNode): ProseMirrorNode {
+  return schema.nodeFromJSON(stripUniqueIds(doc.toJSON()));
+}
+
+/**
+ * Diff two documents that share a schema into replaced regions.
+ *
+ * The backend stores version snapshots, not editing steps, so steps are first
+ * recreated (recreateTransform), condensed into replaced ranges
+ * (prosemirror-changeset), then merged to word boundaries for presentation.
+ * Alignment runs on id-stripped copies; since attrs never change a node's
+ * size, the resulting positions are valid in the real documents. Changes are
+ * ascending and non-overlapping. Formatting-only changes produce no regions:
+ * the changeset tracks content, not marks.
+ */
+export function computeNoteDiffChanges(
+  schema: Schema,
+  older: ProseMirrorNode,
+  newer: ProseMirrorNode
+): readonly NoteDiffChange[] {
+  const docA = alignmentDoc(schema, older);
+  const docB = alignmentDoc(schema, newer);
+
+  const tr = recreateTransform(docA, docB, { complexSteps: true, wordDiffs: true });
+  const changeSet = ChangeSet.create(docA).addSteps(tr.doc, tr.mapping.maps, 0);
+  const changes = simplifyChanges(changeSet.changes, docB);
+
+  return changes.map(({ fromA, toA, fromB, toB }) => ({ fromA, toA, fromB, toB }));
+}

--- a/contexts/NotebookContext.tsx
+++ b/contexts/NotebookContext.tsx
@@ -12,6 +12,7 @@ import {
 import { NoteService } from '@/services/note.service';
 import { OrganizationService } from '@/services/organization.service';
 import type { Note, NoteWithContent } from '@/types/note';
+import type { ID } from '@/types/root';
 import type { OrganizationUsers } from '@/types/organization';
 import { useOrganizationContext } from './OrganizationContext';
 import { Editor } from '@tiptap/core';
@@ -37,7 +38,7 @@ interface NotebookContextType {
   isLoadingNote: boolean;
   noteError: Error | null;
   loadNote: (noteId: string) => Promise<void>;
-  updateNoteTitle: (newTitle: string) => void;
+  updateNoteTitle: (newTitle: string, noteId: ID) => void;
 
   // Editor state
   editor: Editor | null;
@@ -183,30 +184,29 @@ export function NotebookProvider({ children, noteId: explicitNoteId }: NotebookP
     }
   }, []);
 
-  const updateNoteTitle = useCallback(
-    (newTitle: string) => {
-      if (!activeNoteId) return;
+  // The save that reports a title can complete — or a pending autosave can
+  // flush — after the user moved to another note, so the reported id is the
+  // only trustworthy scope: both the list row and the current note update
+  // only when they are the note that actually saved.
+  const updateNoteTitle = useCallback((newTitle: string, noteId: ID) => {
+    if (noteId == null) return;
+    const savedId = noteId.toString();
 
-      setNotes((prevNotes) =>
-        prevNotes.map((note) =>
-          note.id.toString() === activeNoteId
-            ? {
-                ...note,
-                title: newTitle,
-              }
-            : note
-        )
-      );
+    setNotes((prevNotes) =>
+      prevNotes.map((note) =>
+        note.id.toString() === savedId
+          ? {
+              ...note,
+              title: newTitle,
+            }
+          : note
+      )
+    );
 
-      // The save that reports a title can complete after the user moved to
-      // another note; `prev` is whatever note is current by then, so only
-      // the note this callback's render was titled for may be updated.
-      setCurrentNote((prev) =>
-        prev && prev.id.toString() === activeNoteId ? { ...prev, title: newTitle } : prev
-      );
-    },
-    [activeNoteId]
-  );
+    setCurrentNote((prev) =>
+      prev && prev.id.toString() === savedId ? { ...prev, title: newTitle } : prev
+    );
+  }, []);
 
   const refreshAll = useCallback(async () => {
     if (!selectedOrg?.slug || !selectedOrg?.id) return;

--- a/contexts/NotebookContext.tsx
+++ b/contexts/NotebookContext.tsx
@@ -198,11 +198,14 @@ export function NotebookProvider({ children, noteId: explicitNoteId }: NotebookP
         )
       );
 
-      if (currentNote) {
-        setCurrentNote((prev) => (prev ? { ...prev, title: newTitle } : null));
-      }
+      // The save that reports a title can complete after the user moved to
+      // another note; `prev` is whatever note is current by then, so only
+      // the note this callback's render was titled for may be updated.
+      setCurrentNote((prev) =>
+        prev && prev.id.toString() === activeNoteId ? { ...prev, title: newTitle } : prev
+      );
     },
-    [activeNoteId, currentNote]
+    [activeNoteId]
   );
 
   const refreshAll = useCallback(async () => {

--- a/hooks/useNote.ts
+++ b/hooks/useNote.ts
@@ -283,7 +283,12 @@ interface UseUpdateNoteState {
 }
 
 interface UpdateNoteOptions {
-  onTitleUpdate?: (newTitle: string) => void;
+  /**
+   * Reports the note the title belongs to: a save can complete (or a pending
+   * autosave flush) after the user moved to another note, so consumers must
+   * scope their state updates to `noteId` rather than whatever is current.
+   */
+  onTitleUpdate?: (newTitle: string, noteId: ID) => void;
   debounceMs?: number;
   registeredReportProposalId?: number | null;
   /**
@@ -350,7 +355,7 @@ export const useUpdateNote = (noteId: ID, options: UpdateNoteOptions = {}): UseU
             noteId,
             title: payload.title,
           }).then(() => {
-            options.onTitleUpdate?.(payload.title);
+            options.onTitleUpdate?.(payload.title, noteId);
           })
         );
       }
@@ -413,13 +418,27 @@ export const useUpdateNote = (noteId: ID, options: UpdateNoteOptions = {}): UseU
     []
   );
 
+  // The one debouncer serves whichever note the still-mounted layout shows,
+  // so a pending autosave may belong to a note the user already left. That
+  // write must not be discarded: scheduling or superseding only owns the
+  // same note's pending save — a foreign one is flushed first, persisting
+  // its edits in request order ahead of the new work.
+  const pendingSaveNoteIdRef = useRef<ID | null>(null);
+
   const debouncedUpdate = useRef<
     DebouncedFunc<(editor: Editor, noteId: ID, registeredReportProposalId?: number | null) => void>
   >(
     debounce((editor: Editor, noteId: ID, registeredReportProposalId?: number | null) => {
+      pendingSaveNoteIdRef.current = null;
       void queueSave(editor, noteId, registeredReportProposalId);
     }, options.debounceMs ?? 2000)
   );
+
+  const flushForeignPendingSave = useCallback((noteId: ID) => {
+    if (pendingSaveNoteIdRef.current != null && pendingSaveNoteIdRef.current !== noteId) {
+      debouncedUpdate.current.flush();
+    }
+  }, []);
 
   const updateNote = useCallback(
     (editor: Editor) => {
@@ -427,29 +446,35 @@ export const useUpdateNote = (noteId: ID, options: UpdateNoteOptions = {}): UseU
         console.error('Editor is undefined in updateNote');
         return;
       }
+      flushForeignPendingSave(noteId);
+      pendingSaveNoteIdRef.current = noteId;
       debouncedUpdate.current(editor, noteId, options.registeredReportProposalId);
     },
-    [noteId, options.registeredReportProposalId]
+    [noteId, options.registeredReportProposalId, flushForeignPendingSave]
   );
 
   /**
    * Persist immediately and report success — for moments where the save is
    * itself the user's action (keeping their version over an assistant's) and
    * a debounced fire-and-forget write would let the UI acknowledge a choice
-   * the server never heard about. Cancels any scheduled autosave and queues
-   * behind any in-flight one.
+   * the server never heard about. Cancels any autosave scheduled for this
+   * note (its own save supersedes it) and queues behind any in-flight one.
    */
   const saveNoteNow = useCallback(
     (editor: Editor): Promise<boolean> => {
+      flushForeignPendingSave(noteId);
       debouncedUpdate.current.cancel();
+      pendingSaveNoteIdRef.current = null;
       return queueSave(editor, noteId, options.registeredReportProposalId);
     },
-    [noteId, options.registeredReportProposalId, queueSave]
+    [noteId, options.registeredReportProposalId, queueSave, flushForeignPendingSave]
   );
 
   useEffect(() => {
     return () => {
-      debouncedUpdate.current.cancel();
+      // Unmounting with an autosave still scheduled: persist it rather than
+      // drop the user's last edits.
+      debouncedUpdate.current.flush();
     };
   }, []);
 

--- a/hooks/useNote.ts
+++ b/hooks/useNote.ts
@@ -398,14 +398,15 @@ export const useUpdateNote = (noteId: ID, options: UpdateNoteOptions = {}): UseU
         console.error('Editor or noteId is undefined in queueSave', { editor, noteId });
         return Promise.resolve(false);
       }
-      // The payload is captured now, when the save is requested. A queued
-      // save that serialized once its turn came could instead read a review
-      // installed meanwhile (see docToPersist) and persist the side the
-      // caller's action had just decided against.
+      // Payload and save are both captured now, when the save is requested.
+      // A queued save that serialized once its turn came could instead read
+      // a review installed meanwhile (see docToPersist) and persist the side
+      // the caller's action had just decided against; resolving the save fn
+      // late would likewise report through whichever note's callbacks
+      // (onTitleUpdate) the still-mounted layout holds by then.
       const payload = buildSavePayloadRef.current(editor, registeredReportProposalId);
-      const run = saveChainRef.current
-        .catch(() => undefined)
-        .then(() => performSaveRef.current(payload, noteId));
+      const save = performSaveRef.current;
+      const run = saveChainRef.current.catch(() => undefined).then(() => save(payload, noteId));
       saveChainRef.current = run;
       return run;
     },

--- a/hooks/useNote.ts
+++ b/hooks/useNote.ts
@@ -372,11 +372,28 @@ export const useUpdateNote = (noteId: ID, options: UpdateNoteOptions = {}): UseU
   const performSaveRef = useRef(performSave);
   performSaveRef.current = performSave;
 
+  // Saves reach the server strictly in the order they were requested.
+  // cancel() cannot recall an autosave whose request is already in flight,
+  // and an immediate save overtaking it would let the older payload commit
+  // last — re-persisting content the user's action just superseded.
+  const saveChainRef = useRef<Promise<unknown>>(Promise.resolve());
+
+  const queueSave = useCallback(
+    (editor: Editor, noteId: ID, registeredReportProposalId?: number | null): Promise<boolean> => {
+      const run = saveChainRef.current
+        .catch(() => undefined)
+        .then(() => performSaveRef.current(editor, noteId, registeredReportProposalId));
+      saveChainRef.current = run;
+      return run;
+    },
+    []
+  );
+
   const debouncedUpdate = useRef<
     DebouncedFunc<(editor: Editor, noteId: ID, registeredReportProposalId?: number | null) => void>
   >(
     debounce((editor: Editor, noteId: ID, registeredReportProposalId?: number | null) => {
-      void performSaveRef.current(editor, noteId, registeredReportProposalId);
+      void queueSave(editor, noteId, registeredReportProposalId);
     }, options.debounceMs ?? 2000)
   );
 
@@ -395,14 +412,15 @@ export const useUpdateNote = (noteId: ID, options: UpdateNoteOptions = {}): UseU
    * Persist immediately and report success — for moments where the save is
    * itself the user's action (keeping their version over an assistant's) and
    * a debounced fire-and-forget write would let the UI acknowledge a choice
-   * the server never heard about. Supersedes any scheduled autosave.
+   * the server never heard about. Cancels any scheduled autosave and queues
+   * behind any in-flight one.
    */
   const saveNoteNow = useCallback(
     (editor: Editor): Promise<boolean> => {
       debouncedUpdate.current.cancel();
-      return performSaveRef.current(editor, noteId, options.registeredReportProposalId);
+      return queueSave(editor, noteId, options.registeredReportProposalId);
     },
-    [noteId, options.registeredReportProposalId]
+    [noteId, options.registeredReportProposalId, queueSave]
   );
 
   useEffect(() => {

--- a/hooks/useNote.ts
+++ b/hooks/useNote.ts
@@ -299,32 +299,43 @@ type UpdateNoteFn = (editor: Editor) => void;
 type SaveNoteNowFn = (editor: Editor) => Promise<boolean>;
 type UseUpdateNoteReturn = [UseUpdateNoteState, UpdateNoteFn, SaveNoteNowFn];
 
+/**
+ * A save serialized at the moment it was requested. Queued saves upload
+ * this frozen payload rather than re-reading the editor, whose document may
+ * have moved on (e.g. into a new review) by the time the chain gets there.
+ */
+interface NoteSavePayload {
+  readonly json: unknown;
+  readonly html: string;
+  readonly plainText: string;
+  readonly title: string;
+}
+
 export const useUpdateNote = (noteId: ID, options: UpdateNoteOptions = {}): UseUpdateNoteReturn => {
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<Error | null>(null);
   const titleRef = useRef<string>('');
 
-  const performSave = async (
+  const buildSavePayload = (
     editor: Editor,
-    noteId: ID,
     registeredReportProposalId?: number | null
-  ): Promise<boolean> => {
-    if (!editor || !noteId) {
-      console.error('Editor or noteId is undefined in performSave', { editor, noteId });
-      return false;
-    }
-
+  ): NoteSavePayload => {
     // Serialize from the persistable document, which may differ from the
     // editor's live one (see UpdateNoteOptions.docToPersist).
     const doc = options.docToPersist?.(editor) ?? editor.state.doc;
     const json = mergeRegisteredReportPrefill(doc.toJSON(), registeredReportProposalId);
-    const html = getHTMLFromFragment(doc.content, editor.schema);
-    const plainText = getText(doc, {
-      blockSeparator: '\n\n',
-      textSerializers: getTextSerializersFromSchema(editor.schema),
-    });
-    const newTitle = getDocumentTitle(json) || '';
+    return {
+      json,
+      html: getHTMLFromFragment(doc.content, editor.schema),
+      plainText: getText(doc, {
+        blockSeparator: '\n\n',
+        textSerializers: getTextSerializersFromSchema(editor.schema),
+      }),
+      title: getDocumentTitle(json) || '',
+    };
+  };
 
+  const performSave = async (payload: NoteSavePayload, noteId: ID): Promise<boolean> => {
     setIsLoading(true);
     setError(null);
 
@@ -332,14 +343,14 @@ export const useUpdateNote = (noteId: ID, options: UpdateNoteOptions = {}): UseU
       const promises: Promise<any>[] = [];
 
       // Only update title if it changed
-      if (newTitle !== titleRef.current) {
-        titleRef.current = newTitle;
+      if (payload.title !== titleRef.current) {
+        titleRef.current = payload.title;
         promises.push(
           NoteService.updateNoteTitle({
             noteId,
-            title: newTitle,
+            title: payload.title,
           }).then(() => {
-            options.onTitleUpdate?.(newTitle);
+            options.onTitleUpdate?.(payload.title);
           })
         );
       }
@@ -348,9 +359,9 @@ export const useUpdateNote = (noteId: ID, options: UpdateNoteOptions = {}): UseU
       promises.push(
         NoteService.updateNoteContent({
           note: noteId,
-          full_src: html || '',
-          plain_text: plainText || '',
-          full_json: JSON.stringify(json),
+          full_src: payload.html || '',
+          plain_text: payload.plainText || '',
+          full_json: JSON.stringify(payload.json),
         })
       );
 
@@ -367,8 +378,11 @@ export const useUpdateNote = (noteId: ID, options: UpdateNoteOptions = {}): UseU
     }
   };
 
-  // The debounce wrapper is created once — route through a ref so it always
-  // runs the current render's save (fresh options and callbacks).
+  // The once-created debounce and queue route through refs so they always
+  // run the current render's serialization and save (fresh options and
+  // callbacks).
+  const buildSavePayloadRef = useRef(buildSavePayload);
+  buildSavePayloadRef.current = buildSavePayload;
   const performSaveRef = useRef(performSave);
   performSaveRef.current = performSave;
 
@@ -380,9 +394,18 @@ export const useUpdateNote = (noteId: ID, options: UpdateNoteOptions = {}): UseU
 
   const queueSave = useCallback(
     (editor: Editor, noteId: ID, registeredReportProposalId?: number | null): Promise<boolean> => {
+      if (!editor || !noteId) {
+        console.error('Editor or noteId is undefined in queueSave', { editor, noteId });
+        return Promise.resolve(false);
+      }
+      // The payload is captured now, when the save is requested. A queued
+      // save that serialized once its turn came could instead read a review
+      // installed meanwhile (see docToPersist) and persist the side the
+      // caller's action had just decided against.
+      const payload = buildSavePayloadRef.current(editor, registeredReportProposalId);
       const run = saveChainRef.current
         .catch(() => undefined)
-        .then(() => performSaveRef.current(editor, noteId, registeredReportProposalId));
+        .then(() => performSaveRef.current(payload, noteId));
       saveChainRef.current = run;
       return run;
     },

--- a/hooks/useNote.ts
+++ b/hooks/useNote.ts
@@ -9,8 +9,10 @@ import {
 } from '@/types/note';
 import { ID } from '@/types/root';
 import { Editor } from '@tiptap/react';
+import { getHTMLFromFragment, getText, getTextSerializersFromSchema } from '@tiptap/core';
+import type { Node as ProseMirrorNode } from '@tiptap/pm/model';
 import { debounce, DebouncedFunc } from 'lodash-es';
-import { getDocumentTitleFromEditor } from '@/components/Editor/lib/utils/documentTitle';
+import { getDocumentTitle } from '@/components/Editor/lib/utils/documentTitle';
 import { mergeRegisteredReportPrefill } from '@/utils/registeredReportPrefill';
 
 export interface UseNoteOptions {
@@ -284,69 +286,97 @@ interface UpdateNoteOptions {
   onTitleUpdate?: (newTitle: string) => void;
   debounceMs?: number;
   registeredReportProposalId?: number | null;
+  /**
+   * The document a save should persist, when it isn't the editor's current
+   * one — the notebook uses this to strip in-note review content (assistant
+   * diff ranges pending a decision) out of saves. Defaults to the editor's
+   * live document.
+   */
+  docToPersist?: (editor: Editor) => ProseMirrorNode;
 }
 
 type UpdateNoteFn = (editor: Editor) => void;
-type UseUpdateNoteReturn = [UseUpdateNoteState, UpdateNoteFn];
+type SaveNoteNowFn = (editor: Editor) => Promise<boolean>;
+type UseUpdateNoteReturn = [UseUpdateNoteState, UpdateNoteFn, SaveNoteNowFn];
 
 export const useUpdateNote = (noteId: ID, options: UpdateNoteOptions = {}): UseUpdateNoteReturn => {
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<Error | null>(null);
   const titleRef = useRef<string>('');
 
-  const debouncedUpdate = useRef<
-    DebouncedFunc<
-      (editor: Editor, noteId: ID, registeredReportProposalId?: number | null) => Promise<void>
-    >
-  >(
-    debounce(async (editor: Editor, noteId: ID, registeredReportProposalId?: number | null) => {
-      if (!editor || !noteId) {
-        console.error('Editor or noteId is undefined in debouncedUpdate', { editor, noteId });
-        return;
-      }
+  const performSave = async (
+    editor: Editor,
+    noteId: ID,
+    registeredReportProposalId?: number | null
+  ): Promise<boolean> => {
+    if (!editor || !noteId) {
+      console.error('Editor or noteId is undefined in performSave', { editor, noteId });
+      return false;
+    }
 
-      const json = mergeRegisteredReportPrefill(editor.getJSON(), registeredReportProposalId);
-      const html = editor.getHTML();
-      const newTitle = getDocumentTitleFromEditor(editor) || '';
+    // Serialize from the persistable document, which may differ from the
+    // editor's live one (see UpdateNoteOptions.docToPersist).
+    const doc = options.docToPersist?.(editor) ?? editor.state.doc;
+    const json = mergeRegisteredReportPrefill(doc.toJSON(), registeredReportProposalId);
+    const html = getHTMLFromFragment(doc.content, editor.schema);
+    const plainText = getText(doc, {
+      blockSeparator: '\n\n',
+      textSerializers: getTextSerializersFromSchema(editor.schema),
+    });
+    const newTitle = getDocumentTitle(json) || '';
 
-      setIsLoading(true);
-      setError(null);
+    setIsLoading(true);
+    setError(null);
 
-      try {
-        const promises: Promise<any>[] = [];
+    try {
+      const promises: Promise<any>[] = [];
 
-        // Only update title if it changed
-        if (newTitle !== titleRef.current) {
-          titleRef.current = newTitle;
-          promises.push(
-            NoteService.updateNoteTitle({
-              noteId,
-              title: newTitle,
-            }).then(() => {
-              options.onTitleUpdate?.(newTitle);
-            })
-          );
-        }
-
-        // Always update content
+      // Only update title if it changed
+      if (newTitle !== titleRef.current) {
+        titleRef.current = newTitle;
         promises.push(
-          NoteService.updateNoteContent({
-            note: noteId,
-            full_src: html || '',
-            plain_text: editor.getText() || '',
-            full_json: JSON.stringify(json),
+          NoteService.updateNoteTitle({
+            noteId,
+            title: newTitle,
+          }).then(() => {
+            options.onTitleUpdate?.(newTitle);
           })
         );
-
-        await Promise.all(promises);
-      } catch (err) {
-        const errorMsg = err instanceof NoteError ? err.message : 'Failed to update note';
-        const error = new Error(errorMsg);
-        setError(error);
-        console.error('Error updating note:', error);
-      } finally {
-        setIsLoading(false);
       }
+
+      // Always update content
+      promises.push(
+        NoteService.updateNoteContent({
+          note: noteId,
+          full_src: html || '',
+          plain_text: plainText || '',
+          full_json: JSON.stringify(json),
+        })
+      );
+
+      await Promise.all(promises);
+      return true;
+    } catch (err) {
+      const errorMsg = err instanceof NoteError ? err.message : 'Failed to update note';
+      const error = new Error(errorMsg);
+      setError(error);
+      console.error('Error updating note:', error);
+      return false;
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  // The debounce wrapper is created once — route through a ref so it always
+  // runs the current render's save (fresh options and callbacks).
+  const performSaveRef = useRef(performSave);
+  performSaveRef.current = performSave;
+
+  const debouncedUpdate = useRef<
+    DebouncedFunc<(editor: Editor, noteId: ID, registeredReportProposalId?: number | null) => void>
+  >(
+    debounce((editor: Editor, noteId: ID, registeredReportProposalId?: number | null) => {
+      void performSaveRef.current(editor, noteId, registeredReportProposalId);
     }, options.debounceMs ?? 2000)
   );
 
@@ -361,13 +391,27 @@ export const useUpdateNote = (noteId: ID, options: UpdateNoteOptions = {}): UseU
     [noteId, options.registeredReportProposalId]
   );
 
+  /**
+   * Persist immediately and report success — for moments where the save is
+   * itself the user's action (keeping their version over an assistant's) and
+   * a debounced fire-and-forget write would let the UI acknowledge a choice
+   * the server never heard about. Supersedes any scheduled autosave.
+   */
+  const saveNoteNow = useCallback(
+    (editor: Editor): Promise<boolean> => {
+      debouncedUpdate.current.cancel();
+      return performSaveRef.current(editor, noteId, options.registeredReportProposalId);
+    },
+    [noteId, options.registeredReportProposalId]
+  );
+
   useEffect(() => {
     return () => {
       debouncedUpdate.current.cancel();
     };
   }, []);
 
-  return [{ isLoading, error }, updateNote];
+  return [{ isLoading, error }, updateNote, saveNoteNow];
 };
 
 interface UseMakeNotePrivateState {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@amplitude/analytics-browser": "^2.17.11",
         "@coinbase/onchainkit": "^1.1.2",
         "@elastic/apm-rum": "^5.17.0",
+        "@fellow/prosemirror-recreate-transform": "^1.2.3",
         "@floating-ui/dom": "^1.6.0",
         "@fontsource/inter": "^5.1.0",
         "@fortawesome/fontawesome-svg-core": "^6.7.2",
@@ -2745,6 +2746,21 @@
         "@farcaster/miniapp-sdk": "^0.2.3",
         "@wagmi/core": "^2.14.1",
         "viem": "^2.21.55"
+      }
+    },
+    "node_modules/@fellow/prosemirror-recreate-transform": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@fellow/prosemirror-recreate-transform/-/prosemirror-recreate-transform-1.2.3.tgz",
+      "integrity": "sha512-LdvMirDXtZWNv2DSpUVh1L7OxV/8PopzCwL4XJdd8UW4MMXywlcnCUzOz2TuNTMoTNnbOPBQ2JJlaAG/hg6sdQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "diff": "^5.1.0",
+        "prosemirror-model": "^1.18.1",
+        "prosemirror-transform": "^1.7.0",
+        "rfc6902": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/@floating-ui/core": {
@@ -11012,6 +11028,15 @@
       "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
       "license": "Apache-2.0"
     },
+    "node_modules/diff": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.2.tgz",
+      "integrity": "sha512-vtcDfH3TOjP8UekytvnHH1o1P4FcUdt4eQ1Y+Abap1tk/OB2MWQvcwS2ClCd1zuIhc3JKOx6p3kod8Vfys3E+A==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
     "node_modules/dijkstrajs": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/dijkstrajs/-/dijkstrajs-1.0.3.tgz",
@@ -16885,6 +16910,12 @@
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/rfc6902": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/rfc6902/-/rfc6902-5.3.0.tgz",
+      "integrity": "sha512-8x9uqKB5FeC3jhdtmBtI2Z2GR0+VE1VLbQ7Luy5RcnCxUa4+Z1n8w2G1D+GevkRUT33nbbfpAK5O4LhRbnaIPQ==",
+      "license": "MIT"
     },
     "node_modules/rfdc": {
       "version": "1.4.1",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@amplitude/analytics-browser": "^2.17.11",
     "@coinbase/onchainkit": "^1.1.2",
     "@elastic/apm-rum": "^5.17.0",
+    "@fellow/prosemirror-recreate-transform": "^1.2.3",
     "@floating-ui/dom": "^1.6.0",
     "@fontsource/inter": "^5.1.0",
     "@fortawesome/fontawesome-svg-core": "^6.7.2",


### PR DESCRIPTION
## What

Editor infrastructure for reviewing an incoming version of a note **inside the note itself** — no consumer wired up yet; the notebook assistant chat (#1022) stacks on top of this.

- **`components/Notebook/NoteReview/noteVersionDiff.ts`** — diffs two versions of a document into replaced regions. The backend stores snapshots, not steps, so steps are recreated (`@fellow/prosemirror-recreate-transform`, new dependency) and condensed with `prosemirror-changeset`, ignoring the volatile UniqueID `id` attrs.
- **`components/Notebook/NoteReview/noteDiffOverlay.ts`** — the review itself. `beginNoteDiffReview` makes the incoming version the live document with everything it overwrote spliced back in as struck, still-editable text, and its additions highlighted (selection carried over, so it can fire mid-keystroke). Every range stays editable and is position-mapped through further typing: edits inside a range grow that range and share its fate. `resolveNoteDiffReview` settles positionally — **accept** deletes the struck ranges, **reject** deletes the inserted ones — and editing every region away resolves the review by itself (live change-count callback).
- **`components/Notebook/NoteReview/NoteReviewControls.tsx`** — the floating review controls: the unresolved change count with a green check (accept all) and a red x (reject all); hosts own the positioning.
- **`hooks/useNote.ts`** — the merged document must never be persisted verbatim (its struck ranges are content the incoming version dropped). `useUpdateNote` gains a `docToPersist` hook so hosts can strip them via `noteDiffPersistableDoc`, plus `saveNoteNow`: an immediate, success-reporting save for choices that must become durable at once.

## Why

Agent/collaborator edits shouldn't silently replace what someone is typing, and a modal "review" step shouldn't freeze the document. This makes review a property of the document — everything stays editable the whole time — with a save projection that guarantees pending-removal content never leaks into a version.

<img width="720" height="527" alt="Screenshot 2026-08-13 at 11 36 08 AM" src="https://github.com/user-attachments/assets/a0186d89-0c0d-4125-875f-c95c50cfe22c" />

