### PR TITLE
Seed blank notes with a schema-valid heading-first document

### DIFF
--- a/app/notebook/[orgSlug]/page.tsx
+++ b/app/notebook/[orgSlug]/page.tsx
@@ -15,10 +15,12 @@ import { useCreateNote, useNoteContent } from '@/hooks/useNote';
 import { NoteCreationPopover } from '@/components/Notebook/NoteCreationPopover';
 import { useUser } from '@/contexts/UserContext';
 
-// An empty document for the "Start blank" funding-opportunity path.
+// An empty document for the "Start blank" funding-opportunity path. The
+// notebook editor's schema is 'heading block+', so the document must open with
+// a heading (the title) followed by at least one block.
 const BLANK_DOCUMENT = {
   type: 'doc',
-  content: [{ type: 'paragraph' }],
+  content: [{ type: 'heading', attrs: { textAlign: 'left', level: 1 } }, { type: 'paragraph' }],
 } as typeof grantTemplate;
 
 export default function OrganizationPage() {


### PR DESCRIPTION
## Problem

The notebook editor's document schema requires `heading block+` (`CustomDocument` in `components/Editor/hooks/useBlockEditor.ts`), but the "Start blank" flow seeded a note whose document was a single empty paragraph — schema-invalid from birth.

ProseMirror never validates loaded content, so the editor looked fine. But any transform that asks the doc for a content match past the first child throws:

```
Called contentMatchAt on a node with invalid content
```

This is what crashed the assistant review overlay (worked around in 4527109c on `notebook-chat-response-streaming`, which made unreviewable bases adopt assistant versions verbatim).

## Fix

Seed an empty heading followed by an empty paragraph. `BLANK_DOCUMENT` is the only blank-doc seed in the codebase and feeds both the blank **proposal** and blank **grant** paths, so both are fixed.

Because granular in-note review only runs on schema-valid documents, this also restores real reviews for blank-born notes users have typed into — not just the absence of the throw.

The placeholder extension needed no change: it already renders `Enter a title...` for an empty heading, so blank notes now open with a sensible title prompt.

## Verification

Created a blank proposal through the real UI (Notebook → Proposal → Start blank) against a dev server, and checked the doc in the live editor:

```js
window.editor.schema.topNodeType.validContent(window.editor.state.doc.content)  // true
// childTypes: ["heading:h1", "paragraph"], schema: "heading block+"
```

The old shape still reproduces the error, so the check isn't passing vacuously:

| | `validContent` | `contentMatchAt(1)` |
|---|---|---|
| New seed | `true` | ok |
| Old single-paragraph seed | `false` | throws `Called contentMatchAt on a node with invalid content` |

Also confirmed past creation:

- `contentMatchAt` succeeds at indices 0, 1 and 2.
- Typing a title lands in the heading and the doc stays valid; `updateNoteTitle` fires its `PATCH` with the right title (that path needs `nodeAt(0)` to be a heading).
- The heading-first JSON is what gets persisted, and a doc reloaded from backend content is still valid — what matters for notes users return to.
- The empty heading renders the `Enter a title...` placeholder.

Note creation still sends the title `Untitled` (the blank heading has no text, so `getDocumentTitle` returns empty and falls back exactly as before) — unchanged behavior.