### PR TITLE
grouping financial contributions together when applicable

### DIFF
--- a/components/Activity/ActivityPageContent.tsx
+++ b/components/Activity/ActivityPageContent.tsx
@@ -5,6 +5,8 @@ import { usePathname, useSearchParams } from 'next/navigation';
 import { useInView } from 'react-intersection-observer';
 import { ActivityCard } from './cards/ActivityCard';
 import { ActivityCardSkeleton } from './cards/ActivityCardSkeleton';
+import { ActivityFundingGroupCard } from './cards/ActivityFundingGroupCard';
+import { groupActivityRows } from './lib/activityGrouping.utils';
 import { useActivityFeeds } from '@/contexts/ActivityFeedContext';
 import { useFeedScrollTracking } from '@/hooks/useFeedScrollTracking';
 import { getFeedKey } from '@/contexts/NavigationContext';
@@ -41,6 +43,9 @@ export function ActivityPageContent() {
     });
   }, [pathname, restorationTab, searchParams]);
 
+  const rows = useMemo(() => groupActivityRows(entries, { hasMore }), [entries, hasMore]);
+
+  // Tracking stays on the raw entries so the persisted state is grouping-agnostic.
   useFeedScrollTracking({
     feedKey,
     entries,
@@ -62,9 +67,13 @@ export function ActivityPageContent() {
 
   return (
     <div>
-      {entries.map((entry) => (
-        <ActivityCard key={entry.id} entry={entry} />
-      ))}
+      {rows.map((row) =>
+        row.kind === 'funding-group' ? (
+          <ActivityFundingGroupCard key={row.key} row={row} />
+        ) : (
+          <ActivityCard key={row.key} entry={row.entry} />
+        )
+      )}
 
       {(isLoading || isLoadingMore) &&
         [...Array(6)].map((_, i) => <ActivityCardSkeleton key={i} />)}

--- a/components/Activity/cards/ActivityFundingGroupCard.tsx
+++ b/components/Activity/cards/ActivityFundingGroupCard.tsx
@@ -1,0 +1,181 @@
+'use client';
+
+import { FC } from 'react';
+import Link from 'next/link';
+import { AvatarStack } from '@/components/ui/AvatarStack';
+import { AuthorTooltip } from '@/components/ui/AuthorTooltip';
+import { Tooltip } from '@/components/ui/Tooltip';
+import { useCurrencyPreference } from '@/contexts/CurrencyPreferenceContext';
+import { useExchangeRate } from '@/contexts/ExchangeRateContext';
+import { useNavigation } from '@/contexts/NavigationContext';
+import { ContributionAmount } from '../amounts/ContributionAmount';
+import { ActivityWorkActions } from '../work/ActivityWorkActions';
+import { ActivityWorkMetadata } from '../work/ActivityWorkMetadata';
+import { WorkPreviewCard } from '../work/WorkPreviewCard';
+import { getWorkCardPresentation } from '../lib/activityWork.utils';
+import { formatTimeAgo } from '@/utils/date';
+import type { ActivityFundingGroupRow, ActivityFundingTotals } from '../lib/activityGrouping.utils';
+import type { AuthorProfile } from '@/types/authorProfile';
+import type { CurrencyAmount } from '@/utils/currency';
+
+/**
+ * Funder avatars are the same 32px as the lone avatar on a single-actor card, so the
+ * stack outgrows that card's fixed gutter. The work card below therefore carries its
+ * own indent rather than inheriting one from a gutter column.
+ */
+const MAX_VISIBLE_FUNDERS = 3;
+const FUNDER_AVATAR_SPACING = -14;
+
+const MAX_NAMED_FUNDERS = 2;
+
+interface ActivityFundingGroupCardProps {
+  row: ActivityFundingGroupRow;
+}
+
+/** Fold both buckets into the currency the reader has selected. */
+function toPreferredTotal(
+  totals: ActivityFundingTotals,
+  showUSD: boolean,
+  exchangeRate: number
+): CurrencyAmount {
+  if (showUSD) {
+    return { amount: totals.usd + totals.rsc * exchangeRate, currency: 'USD' };
+  }
+  const usdAsRsc = exchangeRate > 0 ? totals.usd / exchangeRate : 0;
+  return { amount: totals.rsc + usdAsRsc, currency: 'RSC' };
+}
+
+const FunderName: FC<{ funder: AuthorProfile }> = ({ funder }) => {
+  const name = funder.fullName || 'Unknown';
+
+  if (!funder.id) {
+    return <span className="font-medium text-gray-900">{name}</span>;
+  }
+
+  return (
+    <AuthorTooltip authorId={funder.id} placement="bottom">
+      <Link href={funder.profileUrl} className="font-medium text-gray-900 hover:text-primary-600">
+        {name}
+      </Link>
+    </AuthorTooltip>
+  );
+};
+
+const FunderSummary: FC<{ funders: AuthorProfile[]; contributionCount: number }> = ({
+  funders,
+  contributionCount,
+}) => {
+  if (funders.length === 1) {
+    return (
+      <>
+        <FunderName funder={funders[0]} />
+        <span className="text-gray-500">{` funded this proposal ${contributionCount} times`}</span>
+      </>
+    );
+  }
+
+  const named = funders.slice(0, MAX_NAMED_FUNDERS);
+  const remaining = funders.length - named.length;
+
+  return (
+    <>
+      {named.map((funder, index) => {
+        const isLastNamed = index === named.length - 1;
+        const separator = isLastNamed && remaining === 0 ? ' and ' : ', ';
+
+        return (
+          <span key={`${funder.id}-${index}`}>
+            {index > 0 && <span className="text-gray-500">{separator}</span>}
+            <FunderName funder={funder} />
+          </span>
+        );
+      })}
+      {remaining > 0 && (
+        <span className="text-gray-500">{` and ${remaining} ${remaining === 1 ? 'other' : 'others'}`}</span>
+      )}
+      <span className="text-gray-500"> funded this proposal</span>
+    </>
+  );
+};
+
+/**
+ * A single row standing in for several contributions to the same fundraise:
+ * a funder facepile, the summed contribution, and one work card.
+ */
+export const ActivityFundingGroupCard: FC<ActivityFundingGroupCardProps> = ({ row }) => {
+  const { entries, latestEntry, work, funders, contributionCount, totals } = row;
+  const { showUSD } = useCurrencyPreference();
+  const { exchangeRate } = useExchangeRate();
+  const { updateLastClickedEntryId } = useNavigation();
+
+  const latestEntryId = String(latestEntry.id);
+  const presentation = getWorkCardPresentation(latestEntry, work, { showUSD, exchangeRate });
+  const total = toPreferredTotal(totals, showUSD, exchangeRate);
+
+  const avatarItems = funders.map((funder) => ({
+    src: funder.profileImage || '',
+    alt: funder.fullName || 'Funder',
+    authorId: funder.id || undefined,
+  }));
+
+  const markEntryClicked = () => {
+    updateLastClickedEntryId(latestEntryId);
+  };
+
+  return (
+    <article
+      className="py-4 border-b border-gray-100 last:border-b-0"
+      data-entry-id={latestEntryId}
+      // Absorbed members keep an anchor here so scroll restoration can find them.
+      data-entry-ids={entries.map((entry) => String(entry.id)).join(' ')}
+    >
+      <div className="flex items-start gap-2.5">
+        <div className="flex-shrink-0 pt-0.5">
+          <AvatarStack
+            items={avatarItems}
+            size="sm"
+            maxItems={MAX_VISIBLE_FUNDERS}
+            spacing={FUNDER_AVATAR_SPACING}
+            showLabel={false}
+          />
+        </div>
+
+        <div className="min-w-0 flex-1 pt-1 text-sm leading-6">
+          <FunderSummary funders={funders} contributionCount={contributionCount} />{' '}
+          <ContributionAmount contribution={total} className="align-middle" />
+        </div>
+
+        <Tooltip
+          content={new Date(latestEntry.timestamp).toLocaleString()}
+          wrapperClassName="flex-shrink-0"
+        >
+          <span className="pt-1 text-xs leading-6 text-gray-400 cursor-default whitespace-nowrap">
+            {formatTimeAgo(latestEntry.timestamp)}
+          </span>
+        </Tooltip>
+      </div>
+
+      {/* Indent matches a single-actor card's 32px avatar plus the 10px flex gap. */}
+      <div className="mt-5 tablet:ml-[42px]">
+        <WorkPreviewCard
+          work={work}
+          brand={presentation.brand}
+          onNavigate={markEntryClicked}
+          showPlaceholder
+        >
+          <WorkPreviewCard.Metadata>
+            <ActivityWorkMetadata work={work} presentation={presentation} />
+          </WorkPreviewCard.Metadata>
+          <WorkPreviewCard.Actions>
+            <ActivityWorkActions
+              entry={latestEntry}
+              work={work}
+              presentation={presentation}
+              onNavigate={markEntryClicked}
+            />
+          </WorkPreviewCard.Actions>
+        </WorkPreviewCard>
+      </div>
+    </article>
+  );
+};

--- a/components/Activity/index.ts
+++ b/components/Activity/index.ts
@@ -3,6 +3,7 @@ export { ActivityCard } from './cards/ActivityCard';
 export { ActivityCardCompact } from './cards/ActivityCardCompact';
 export { ActivityCardHeader } from './cards/ActivityCardHeader';
 export { ActivityCardSkeleton } from './cards/ActivityCardSkeleton';
+export { ActivityFundingGroupCard } from './cards/ActivityFundingGroupCard';
 
 // Feed
 export { ActivityPageContent } from './ActivityPageContent';

--- a/components/Activity/lib/activityGrouping.utils.ts
+++ b/components/Activity/lib/activityGrouping.utils.ts
@@ -1,0 +1,257 @@
+import { getContribution } from './activityDisplay.utils';
+import { getActivityWork, type ActivityWork } from './activityWork.utils';
+import type { AuthorProfile } from '@/types/authorProfile';
+import type { CurrencyAmount } from '@/utils/currency';
+import type { FeedEntry } from '@/types/feed';
+
+/**
+ * How far past an anchor we look for contributions to the same fundraise. Kept
+ * small on purpose: it doubles as the depth of the deferred tail below, and feed
+ * rows are tall enough that a deep tail reaches above the fold.
+ */
+const DEFAULT_LOOKAHEAD = 3;
+
+/** Contributions further apart than this stay separate rows. */
+const DEFAULT_MAX_SPAN_MS = 24 * 60 * 60 * 1000;
+
+const MIN_GROUP_SIZE = 2;
+
+export interface ActivityFundingTotals {
+  usd: number;
+  rsc: number;
+}
+
+export interface ActivityEntryRow {
+  kind: 'entry';
+  key: string;
+  entry: FeedEntry;
+}
+
+/**
+ * Several contributions to one fundraise, collapsed into a single row so the feed
+ * shows one work card instead of repeating the same artwork once per funder.
+ */
+export interface ActivityFundingGroupRow {
+  kind: 'funding-group';
+  key: string;
+  /** Members in feed order. */
+  entries: FeedEntry[];
+  /** Newest member, used for the timestamp and the work card's vote/share actions. */
+  latestEntry: FeedEntry;
+  /** Taken from the newest member so the fundraise progress snapshot is current. */
+  work: ActivityWork;
+  /** Distinct funders, in the order they appear in the feed. */
+  funders: AuthorProfile[];
+  /** Exceeds `funders.length` when someone contributed more than once. */
+  contributionCount: number;
+  totals: ActivityFundingTotals;
+}
+
+export type ActivityRow = ActivityEntryRow | ActivityFundingGroupRow;
+
+export interface GroupActivityRowsOptions {
+  lookahead?: number;
+  maxSpanMs?: number;
+  /** Whether more pages are pending; when true the tail is left ungrouped. */
+  hasMore?: boolean;
+}
+
+interface FundingCandidate {
+  entry: FeedEntry;
+  work: ActivityWork;
+  workKey: string;
+  funder: AuthorProfile;
+  amount?: CurrencyAmount;
+  timestampMs: number;
+}
+
+interface PlannedGroup {
+  groupMembers: FundingCandidate[];
+  /** Positions of the members behind the anchor, which the caller must record. */
+  memberIndexes: number[];
+}
+
+function toEntryRow(entry: FeedEntry): ActivityEntryRow {
+  return { kind: 'entry', key: entry.id, entry };
+}
+
+function resolveWorkKey(work: ActivityWork): string {
+  // The same document reaches us via `related_work` or the content object, which
+  // use different id spaces, so prefer the unified id whenever it is present.
+  return work.unifiedDocumentId != null
+    ? `unified:${work.unifiedDocumentId}`
+    : `${work.documentType}:${work.id}`;
+}
+
+/**
+ * Funding contributions only. Tips and bounty payouts (`FUNDINGACTIVITY`) target a
+ * review rather than a fundraise and credit the recipient rather than the actor,
+ * so they never join a group.
+ *
+ * Requires a resolvable work and nothing more: contribution payloads carry the
+ * fundraise only when the API includes it on `related_work`, and a group renders
+ * the same presentation an ungrouped card would either way.
+ */
+function toFundingCandidate(entry: FeedEntry): FundingCandidate | null {
+  if (entry.activityAction !== 'fundraise_contribution') return null;
+
+  const work = getActivityWork(entry);
+  if (!work) return null;
+
+  const timestampMs = Date.parse(entry.timestamp);
+  if (Number.isNaN(timestampMs)) return null;
+
+  return {
+    entry,
+    work,
+    workKey: resolveWorkKey(work),
+    funder: entry.content.createdBy,
+    amount: getContribution(entry),
+    timestampMs,
+  };
+}
+
+function toGroupRow(groupMembers: FundingCandidate[]): ActivityFundingGroupRow {
+  const funders: AuthorProfile[] = [];
+  const seenFunderIds = new Set<number>();
+  const totals: ActivityFundingTotals = { usd: 0, rsc: 0 };
+
+  for (const member of groupMembers) {
+    // Unresolved profiles share id 0, so they are never folded into each other.
+    const funderId = member.funder.id;
+    if (!funderId || !seenFunderIds.has(funderId)) {
+      if (funderId) seenFunderIds.add(funderId);
+      funders.push(member.funder);
+    }
+
+    if (member.amount) {
+      if (member.amount.currency === 'USD') {
+        totals.usd += member.amount.amount;
+      } else {
+        totals.rsc += member.amount.amount;
+      }
+    }
+  }
+
+  const [first] = groupMembers;
+  const latest = groupMembers.reduce((newest, member) =>
+    member.timestampMs > newest.timestampMs ? member : newest
+  );
+
+  return {
+    kind: 'funding-group',
+    key: `funding-group:${first.workKey}:${first.entry.id}`,
+    entries: groupMembers.map((member) => member.entry),
+    latestEntry: latest.entry,
+    work: latest.work,
+    funders,
+    contributionCount: groupMembers.length,
+    totals,
+  };
+}
+
+/**
+ * Whether `candidate` can join the group led by `groupAnchor`: the same proposal,
+ * and close enough in time that presenting them as one row stays honest.
+ */
+function canJoinGroup(
+  groupAnchor: FundingCandidate,
+  candidate: FundingCandidate,
+  maxSpanMs: number
+): boolean {
+  if (candidate.workKey !== groupAnchor.workKey) return false;
+  return Math.abs(candidate.timestampMs - groupAnchor.timestampMs) <= maxSpanMs;
+}
+
+/**
+ * The group starting at `anchorIndex`, or null when none starts there: the entry is
+ * not a contribution, it sits in the deferred tail, or nobody joined it.
+ *
+ * Plans without recording anything, so a group that never materializes leaves no
+ * trace and its would-be members stay free to start groups of their own.
+ */
+function planGroupAt(
+  candidates: (FundingCandidate | null)[],
+  anchorIndex: number,
+  options: {
+    lookahead: number;
+    maxSpanMs: number;
+    groupedIndexes: ReadonlySet<number>;
+    firstDeferredIndex: number;
+  }
+): PlannedGroup | null {
+  const groupAnchor = candidates[anchorIndex];
+  if (!groupAnchor) return null;
+  if (anchorIndex >= options.firstDeferredIndex) return null;
+
+  const { lookahead, maxSpanMs, groupedIndexes } = options;
+  const lookaheadEnd = Math.min(candidates.length, anchorIndex + 1 + lookahead);
+  const groupMembers = [groupAnchor];
+  const memberIndexes: number[] = [];
+
+  for (let index = anchorIndex + 1; index < lookaheadEnd; index++) {
+    if (groupedIndexes.has(index)) continue;
+
+    // Skipping other kinds of activity rather than stopping at them is what lets a
+    // group form across unrelated entries sitting between two contributions.
+    const candidate = candidates[index];
+    if (candidate && canJoinGroup(groupAnchor, candidate, maxSpanMs)) {
+      groupMembers.push(candidate);
+      memberIndexes.push(index);
+    }
+  }
+
+  return groupMembers.length >= MIN_GROUP_SIZE ? { groupMembers, memberIndexes } : null;
+}
+
+/**
+ * Collapse nearby contributions to the same fundraise into a single row.
+ *
+ * Each group is led by an anchor: the first contribution of a burst. The anchor's
+ * position becomes the row's position, and its proposal decides what may join.
+ *
+ * Pure and deterministic by design: the feed persists raw entries for scroll
+ * restoration, so the same entries must always produce the same layout.
+ */
+export function groupActivityRows(
+  entries: FeedEntry[],
+  options?: GroupActivityRowsOptions
+): ActivityRow[] {
+  const lookahead = options?.lookahead ?? DEFAULT_LOOKAHEAD;
+  const maxSpanMs = options?.maxSpanMs ?? DEFAULT_MAX_SPAN_MS;
+
+  // One slot per entry, keeping positions aligned with `entries` for the lookahead.
+  const candidates = entries.map(toFundingCandidate);
+
+  // An anchor cannot be trusted until its whole lookahead window is loaded, since
+  // the next page could still add members to it, and growing a row the reader has
+  // already scrolled past shifts the feed under them. While more pages are pending
+  // the last `lookahead` entries are therefore deferred: they render on their own,
+  // and become eligible to anchor a group once the window behind them fills in.
+  const firstDeferredIndex = options?.hasMore ? entries.length - lookahead : entries.length;
+
+  const rows: ActivityRow[] = [];
+  const groupedIndexes = new Set<number>();
+
+  for (let i = 0; i < entries.length; i++) {
+    if (groupedIndexes.has(i)) continue;
+
+    const group = planGroupAt(candidates, i, {
+      lookahead,
+      maxSpanMs,
+      groupedIndexes,
+      firstDeferredIndex,
+    });
+
+    if (group) {
+      for (const index of group.memberIndexes) {
+        groupedIndexes.add(index);
+      }
+      rows.push(toGroupRow(group.groupMembers));
+    } else {
+      rows.push(toEntryRow(entries[i]));
+    }
+  }
+
+  return rows;
+}

--- a/hooks/useFeedScrollTracking.ts
+++ b/hooks/useFeedScrollTracking.ts
@@ -63,8 +63,10 @@ export const useFeedScrollTracking = ({
       if (scrollContainerRef?.current) {
         // First, try to scroll to the last clicked entry if available
         if (lastClickedEntryId) {
+          // Grouped rows stand in for several entries and list every member id in
+          // `data-entry-ids`, so match either the row itself or a member of it.
           const clickedElement = document.querySelector(
-            `[data-entry-id="${lastClickedEntryId}"]`
+            `[data-entry-id="${lastClickedEntryId}"], [data-entry-ids~="${lastClickedEntryId}"]`
           ) as HTMLElement;
 
           if (clickedElement) {


### PR DESCRIPTION
When there are nearby funding contributions in a list, group them together:

<img width="663" height="327" alt="image" src="https://github.com/user-attachments/assets/aa5d4ff2-9a6c-4374-96d6-c9dd29e0b262" />
