### PR TITLE
Fail CI on ProseMirror schema drift

### DIFF
--- a/.github/workflows/schema-check.yml
+++ b/.github/workflows/schema-check.yml
@@ -1,0 +1,70 @@
+name: ProseMirror Schema Check
+
+# Fails when schemas/prosemirror/ is out of date — i.e. an editor extension
+# change (or a TipTap dependency bump) landed without a regenerated schema.
+# The export is byte-deterministic, so a plain diff is a reliable check.
+# See schemas/prosemirror/README.md.
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  schema-drift:
+    runs-on: ubuntu-latest
+    env:
+      TIPTAP_PRO_TOKEN: ${{ secrets.TIPTAP_PRO_TOKEN }}
+      FONTAWESOME_NPM_AUTH_TOKEN: ${{ secrets.FONTAWESOME_NPM_AUTH_TOKEN }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Check registry secrets
+        run: |
+          if [ -z "$TIPTAP_PRO_TOKEN" ] || [ -z "$FONTAWESOME_NPM_AUTH_TOKEN" ]; then
+            echo "::error::Missing TIPTAP_PRO_TOKEN and/or FONTAWESOME_NPM_AUTH_TOKEN repo secrets; npm ci needs them for the private TipTap Pro and Font Awesome registries."
+            exit 1
+          fi
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+
+      # Same registry mapping developers keep in their local .npmrc; the
+      # ${VAR} references are expanded by npm itself from the job env.
+      - name: Configure private npm registries
+        run: |
+          {
+            echo '@tiptap-pro:registry=https://registry.tiptap.dev/'
+            echo '//registry.tiptap.dev/:_authToken=${TIPTAP_PRO_TOKEN}'
+            echo '@awesome.me:registry=https://npm.fontawesome.com/'
+            echo '@fortawesome:registry=https://npm.fontawesome.com/'
+            echo '//npm.fontawesome.com/:_authToken=${FONTAWESOME_NPM_AUTH_TOKEN}'
+          } > .npmrc
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Export ProseMirror schemas
+        run: npm run schema:export
+
+      - name: Fail on schema drift
+        run: |
+          if [ -n "$(git status --porcelain -- schemas/prosemirror/)" ]; then
+            echo '::error::schemas/prosemirror/ is out of date. Run `npm run schema:export` and commit the result (see schemas/prosemirror/README.md).'
+            echo
+            echo 'Drift:'
+            git status --porcelain -- schemas/prosemirror/
+            git diff -- schemas/prosemirror/
+            exit 1
+          fi
+          echo 'Schemas are up to date.'

--- a/package.json
+++ b/package.json
@@ -152,6 +152,7 @@
       "prettier --write --ignore-path .gitignore",
       "eslint --fix --no-warn-ignored"
     ],
-    "**/*.{ts,tsx}": "bash -c 'npm run type-check'"
+    "**/*.{ts,tsx}": "bash -c 'npm run type-check'",
+    "{components/Editor/extensions/**/*.{ts,tsx},components/Comment/lib/**/*.{ts,tsx},scripts/export-prosemirror-schema.ts}": "bash -c 'npm run schema:export && git add schemas/prosemirror'"
   }
 }

--- a/schemas/prosemirror/README.md
+++ b/schemas/prosemirror/README.md
@@ -31,8 +31,15 @@ Output is deterministic — rerunning without extension changes produces
 byte-identical files. **Any change to an editor's extensions (adding,
 removing, or reconfiguring — configuration can alter attribute defaults) must
 be accompanied by a regenerated schema**, and the backend copy updated.
-Enforcement via CI diff is a planned follow-up; until then this is by
-convention.
+
+Two layers enforce this:
+
+- **Pre-commit**: committing a change under `components/Editor/extensions/`,
+  `components/Comment/lib/`, or to the export script regenerates the schemas
+  and stages them automatically (see `lint-staged` in `package.json`).
+- **CI**: `.github/workflows/schema-check.yml` reruns the export on every PR
+  and fails on any diff in this directory. It also catches drift the
+  pre-commit globs can't see — e.g. a TipTap version bump changing a spec.
 
 ## What the export contains
 


### PR DESCRIPTION
Follow-up to #1040 (stacked on its branch; GitHub will retarget to `main` when #1040 merges and its branch is deleted).

## What this adds

- **CI enforcement** — `.github/workflows/schema-check.yml` runs `npm ci` + `npm run schema:export` on every PR and push to `main`, and fails if that leaves any diff or untracked file under `schemas/prosemirror/`. The export is byte-deterministic, so any drift means an editor extension change (or a TipTap dependency bump) landed without regenerated schemas.
- **Pre-commit regeneration** — a `lint-staged` entry regenerates and stages the schemas whenever staged changes touch `components/Editor/extensions/`, `components/Comment/lib/`, or the export script, so in the common case drift never reaches CI. Dependency-driven drift (e.g. a TipTap bump) is intentionally left to the CI check, since commit-time node_modules may not reflect an edited lockfile.
- **README** — replaces the "enforcement is a planned follow-up" note with the actual mechanisms.

## ⚠️ Action required before the check can pass

`npm ci` in CI needs auth for the two private registries. Add these repo secrets (values are the same tokens as in your local `.npmrc` / Vercel env):

```bash
gh secret set TIPTAP_PRO_TOKEN --repo ResearchHub/web
gh secret set FONTAWESOME_NPM_AUTH_TOKEN --repo ResearchHub/web
```

The workflow fails early with a clear message while they're missing. (Note: like any secret-dependent check, it won't work for PRs from forks — fine for this repo's branch-based flow.)

## Verification

- Ran `npm run schema:export` on a clean checkout of this branch: both JSON files byte-identical to what's committed (determinism + freshness confirmed).
- Simulated the pre-commit path: staged a schema-affecting edit (removed `Underline` from the comment extensions), ran the new lint-staged entry — `comment-editor.json` was regenerated with the `underline` mark dropped and staged automatically.
- Glob matching tested against micromatch with positive/negative path cases (extension sources match; unrelated editor UI files, CSS, and the CJS stub don't).
- Workflow YAML parse-validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)