### PR TITLE
[Notebook] Stream assistant output live

### DIFF
--- a/components/Notebook/AgentChat/ActivityFeed.tsx
+++ b/components/Notebook/AgentChat/ActivityFeed.tsx
@@ -156,7 +156,7 @@ function stripMarkdown(text: string): string {
     .replaceAll(/```[a-z]*\n?/g, '')
     .replaceAll(/^#{1,6}\s+/gm, '')
     .replaceAll(/^[-*+]\s+/gm, '')
-    .replaceAll(/\[([^\]]*)\]\([^)]*\)/g, '$1')
+    .replaceAll(/\[([^\][]*)\]\([^()]*\)/g, '$1')
     .replaceAll(/(\*\*|\*|`|~~)/g, '');
 }
 

--- a/components/Notebook/AgentChat/ActivityFeed.tsx
+++ b/components/Notebook/AgentChat/ActivityFeed.tsx
@@ -225,10 +225,12 @@ function ActivityItemBody({
   readonly streaming: boolean;
 }) {
   if (item.type === 'narration') {
+    // Same renderer as the answer bubble, so the live narration preview and
+    // the settled message it becomes read as one continuous surface.
     return (
-      <p className="whitespace-pre-wrap break-words pl-6 leading-relaxed text-gray-500">
-        {item.text}
-      </p>
+      <div className="pl-6">
+        <MarkdownMessage content={item.text} className="text-gray-500" />
+      </div>
     );
   }
   if (item.type === 'thinking') {

--- a/components/Notebook/AgentChat/ActivityFeed.tsx
+++ b/components/Notebook/AgentChat/ActivityFeed.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, type ComponentType } from 'react';
+import { useMemo, useState, type ComponentType } from 'react';
 import {
   Ban,
   BookOpen,
@@ -21,6 +21,7 @@ import {
 } from 'lucide-react';
 import { Loader } from '@/components/ui/Loader';
 import { cn } from '@/utils/styles';
+import { MarkdownMessage } from './MarkdownMessage';
 import type {
   ActivityCallStatus,
   ChatActivityItem,
@@ -146,19 +147,47 @@ function ToolCallRow({ call }: { readonly call: ChatToolCallActivity }) {
 }
 
 /**
+ * Markdown markers dropped for the collapsed one-line preview, where markup
+ * can't render and would read as clutter. Underscores stay: intraword `_`
+ * isn't emphasis, and thinking text is full of snake_case identifiers.
+ */
+function stripMarkdown(text: string): string {
+  return text
+    .replaceAll(/```[a-z]*\n?/g, '')
+    .replaceAll(/^#{1,6}\s+/gm, '')
+    .replaceAll(/^[-*+]\s+/gm, '')
+    .replaceAll(/\[([^\]]*)\]\([^)]*\)/g, '$1')
+    .replaceAll(/(\*\*|\*|`|~~)/g, '');
+}
+
+/**
  * One thinking block, collapsed to a labeled row with a one-line preview.
  * Readable reasoning can grow incrementally and runs up to 4000 chars per
  * block, so rendering it inline like narration would drown the tool rows;
  * the chevron-led button mirrors the settled-turn summary toggle.
+ *
+ * While the block is the one currently receiving stream deltas it stays
+ * expanded so the reasoning is readable as it arrives, then collapses on its
+ * own once the stream moves past it — unless the user has toggled it, which
+ * always wins.
  */
-function ThinkingRow({ item }: { readonly item: ChatThinkingActivity }) {
-  const [expanded, setExpanded] = useState(false);
+function ThinkingRow({
+  item,
+  streaming = false,
+}: {
+  readonly item: ChatThinkingActivity;
+  readonly streaming?: boolean;
+}) {
+  const [userExpanded, setUserExpanded] = useState<boolean | null>(null);
+  const expanded = userExpanded ?? streaming;
+  // Settled rows re-render on every stream delta; strip once per text value.
+  const preview = useMemo(() => stripMarkdown(item.text), [item.text]);
 
   return (
     <div>
       <button
         type="button"
-        onClick={() => setExpanded(!expanded)}
+        onClick={() => setUserExpanded(!expanded)}
         aria-expanded={expanded}
         className="flex w-full items-start gap-2 text-left text-gray-500 transition-colors hover:text-gray-700"
       >
@@ -175,20 +204,26 @@ function ThinkingRow({ item }: { readonly item: ChatThinkingActivity }) {
             Thinking
           </span>
           {/* nowrap collapses the block's newlines, so the preview is one line. */}
-          {!expanded && <span className="min-w-0 truncate text-gray-400">{item.text}</span>}
+          {!expanded && <span className="min-w-0 truncate text-gray-400">{preview}</span>}
         </span>
       </button>
       {expanded && (
-        <p className="mt-1 whitespace-pre-wrap break-words pl-6 italic text-gray-500">
-          {item.text}
-        </p>
+        <div className="mt-1 pl-6">
+          <MarkdownMessage content={item.text} className="italic text-gray-500" />
+        </div>
       )}
     </div>
   );
 }
 
 /** Unknown item types from newer backends render nothing (never crash the feed). */
-function ActivityItemBody({ item }: { readonly item: ChatActivityItem }) {
+function ActivityItemBody({
+  item,
+  streaming,
+}: {
+  readonly item: ChatActivityItem;
+  readonly streaming: boolean;
+}) {
   if (item.type === 'narration') {
     return (
       <p className="whitespace-pre-wrap break-words pl-6 leading-relaxed text-gray-500">
@@ -197,7 +232,7 @@ function ActivityItemBody({ item }: { readonly item: ChatActivityItem }) {
     );
   }
   if (item.type === 'thinking') {
-    return <ThinkingRow item={item} />;
+    return <ThinkingRow item={item} streaming={streaming} />;
   }
   if (item.type === 'tool_call') {
     return <ToolCallRow call={item} />;
@@ -207,6 +242,8 @@ function ActivityItemBody({ item }: { readonly item: ChatActivityItem }) {
 
 interface ActivityFeedProps {
   readonly items: ChatActivityItem[];
+  /** Stream id of the item currently receiving deltas, while the turn is live. */
+  readonly streamingItemId?: string;
   readonly className?: string;
 }
 
@@ -214,22 +251,22 @@ interface ActivityFeedProps {
  * The ordered account of what the agent did during a turn: narration prose
  * between tool calls, and one row per tool call with status + citations.
  */
-export function ActivityFeed({ items, className }: ActivityFeedProps) {
+export function ActivityFeed({ items, streamingItemId, className }: ActivityFeedProps) {
   if (items.length === 0) return null;
 
   return (
     <ol className={cn('space-y-4', className)}>
-      {items.map((item, index) => (
-        // Stream items carry stable ids; durable feed items are append-only,
-        // making their fallback index stable within the settled activity list.
-        // eslint-disable-next-line react/no-array-index-key
-        <li
-          key={'id' in item && typeof item.id === 'string' ? item.id : index}
-          className="text-sm leading-relaxed"
-        >
-          <ActivityItemBody item={item} />
-        </li>
-      ))}
+      {items.map((item, index) => {
+        const id = 'id' in item && typeof item.id === 'string' ? item.id : null;
+        return (
+          // Stream items carry stable ids; durable feed items are append-only,
+          // making their fallback index stable within the settled activity list.
+          // eslint-disable-next-line react/no-array-index-key
+          <li key={id ?? index} className="text-sm leading-relaxed">
+            <ActivityItemBody item={item} streaming={id != null && id === streamingItemId} />
+          </li>
+        );
+      })}
     </ol>
   );
 }

--- a/components/Notebook/AgentChat/ActivityFeed.tsx
+++ b/components/Notebook/AgentChat/ActivityFeed.tsx
@@ -147,7 +147,7 @@ function ToolCallRow({ call }: { readonly call: ChatToolCallActivity }) {
 
 /**
  * One thinking block, collapsed to a labeled row with a one-line preview.
- * Reasoning arrives whole (never streamed) and runs up to 4000 chars per
+ * Readable reasoning can grow incrementally and runs up to 4000 chars per
  * block, so rendering it inline like narration would drown the tool rows;
  * the chevron-led button mirrors the settled-turn summary toggle.
  */
@@ -220,9 +220,13 @@ export function ActivityFeed({ items, className }: ActivityFeedProps) {
   return (
     <ol className={cn('space-y-4', className)}>
       {items.map((item, index) => (
-        // Feed items are append-only and have no ids; index keys are stable here.
+        // Stream items carry stable ids; durable feed items are append-only,
+        // making their fallback index stable within the settled activity list.
         // eslint-disable-next-line react/no-array-index-key
-        <li key={index} className="text-sm leading-relaxed">
+        <li
+          key={'id' in item && typeof item.id === 'string' ? item.id : index}
+          className="text-sm leading-relaxed"
+        >
           <ActivityItemBody item={item} />
         </li>
       ))}

--- a/components/Notebook/AgentChat/ExecutionProgress.tsx
+++ b/components/Notebook/AgentChat/ExecutionProgress.tsx
@@ -66,7 +66,13 @@ interface ExecutionProgressProps {
 export function ExecutionProgress({ execution }: ExecutionProgressProps) {
   const [userExpanded, setUserExpanded] = useState<boolean | null>(null);
 
-  const activity = execution.activity ?? [];
+  // Durable activity is followed by the current provider iteration's
+  // transient preview. A lifecycle refetch replaces the preview with the
+  // newly durable rows/message once the complete turn is recorded.
+  const activity: ChatActivityItem[] = [
+    ...(execution.activity ?? []),
+    ...(execution.stream?.items ?? []),
+  ];
   const active = isActiveExecutionStatus(execution.status);
   // SUCCEEDED can precede the answer landing in `messages`; stay visually live
   // until publication so we never render "done" with no answer bubble.

--- a/components/Notebook/AgentChat/ExecutionProgress.tsx
+++ b/components/Notebook/AgentChat/ExecutionProgress.tsx
@@ -128,7 +128,7 @@ export function ExecutionProgress({ execution }: ExecutionProgressProps) {
           items={activity}
           // Deltas always append to the newest stream item, so while the turn
           // is live the tail is the block currently being written.
-          streamingItemId={live ? streamItems[streamItems.length - 1]?.id : undefined}
+          streamingItemId={live ? streamItems.at(-1)?.id : undefined}
           className={cn(showsSummaryRow && 'mt-3')}
         />
       )}

--- a/components/Notebook/AgentChat/ExecutionProgress.tsx
+++ b/components/Notebook/AgentChat/ExecutionProgress.tsx
@@ -7,8 +7,19 @@ import {
   isActiveExecutionStatus,
   type ChatActivityItem,
   type ChatExecution,
+  type ChatStreamItem,
 } from '@/types/notebookChat';
 import { ActivityFeed, humanizeLabel } from './ActivityFeed';
+
+/**
+ * Stream item ids are stable only within one provider iteration; namespaced
+ * with the stream identity they stay unique feed-wide, so a reused id in the
+ * next iteration mounts a fresh row instead of inheriting the old one's state.
+ */
+function namespaceStreamItems(stream: ChatExecution['stream']): ChatStreamItem[] {
+  if (stream == null) return [];
+  return stream.items.map((item) => ({ ...item, id: `${stream.id}:${item.id}` }));
+}
 
 /** "Searched the web ×2 · Read the note" — tool labels in first-appearance order. */
 function summarizeActivity(items: ChatActivityItem[]): string | null {
@@ -69,7 +80,7 @@ export function ExecutionProgress({ execution }: ExecutionProgressProps) {
   // Durable activity is followed by the current provider iteration's
   // transient preview. A lifecycle refetch replaces the preview with the
   // newly durable rows/message once the complete turn is recorded.
-  const streamItems = execution.stream?.items ?? [];
+  const streamItems = namespaceStreamItems(execution.stream);
   const activity: ChatActivityItem[] = [...(execution.activity ?? []), ...streamItems];
   const active = isActiveExecutionStatus(execution.status);
   // SUCCEEDED can precede the answer landing in `messages`; stay visually live

--- a/components/Notebook/AgentChat/ExecutionProgress.tsx
+++ b/components/Notebook/AgentChat/ExecutionProgress.tsx
@@ -69,10 +69,8 @@ export function ExecutionProgress({ execution }: ExecutionProgressProps) {
   // Durable activity is followed by the current provider iteration's
   // transient preview. A lifecycle refetch replaces the preview with the
   // newly durable rows/message once the complete turn is recorded.
-  const activity: ChatActivityItem[] = [
-    ...(execution.activity ?? []),
-    ...(execution.stream?.items ?? []),
-  ];
+  const streamItems = execution.stream?.items ?? [];
+  const activity: ChatActivityItem[] = [...(execution.activity ?? []), ...streamItems];
   const active = isActiveExecutionStatus(execution.status);
   // SUCCEEDED can precede the answer landing in `messages`; stay visually live
   // until publication so we never render "done" with no answer bubble.
@@ -125,7 +123,15 @@ export function ExecutionProgress({ execution }: ExecutionProgressProps) {
         </button>
       )}
 
-      {showsFeed && <ActivityFeed items={activity} className={cn(showsSummaryRow && 'mt-3')} />}
+      {showsFeed && (
+        <ActivityFeed
+          items={activity}
+          // Deltas always append to the newest stream item, so while the turn
+          // is live the tail is the block currently being written.
+          streamingItemId={live ? streamItems[streamItems.length - 1]?.id : undefined}
+          className={cn(showsSummaryRow && 'mt-3')}
+        />
+      )}
 
       {live && <LiveStatusLine label={statusLabel} />}
 

--- a/hooks/useNotebookChat.ts
+++ b/hooks/useNotebookChat.ts
@@ -63,10 +63,12 @@ export interface PendingSend {
 }
 
 /**
- * The cached stream when it is the same stream a REST response checkpointed
- * but at a newer sequence — a checkpoint captured just before a socket batch
- * arrived must not rewind it. Null whenever the server copy is authoritative:
- * explicit `stream: null`, a new stream id, or a terminal execution.
+ * The cached stream when it is newer than what a REST response checkpointed —
+ * a higher sequence of the same stream, or a later provider iteration the
+ * socket installed while the response was in flight. A checkpoint racing the
+ * socket must not rewind it; null whenever the server copy is authoritative:
+ * explicit `stream: null`, a same-or-newer server iteration, or a terminal
+ * execution.
  */
 function newerCachedStream(
   execution: ChatExecution,
@@ -76,7 +78,9 @@ function newerCachedStream(
   const serverStream = execution.stream;
   const cachedStream = cached?.stream;
   if (serverStream == null || cachedStream == null) return null;
-  if (cachedStream.id !== serverStream.id) return null;
+  if (cachedStream.id !== serverStream.id) {
+    return cachedStream.iteration > serverStream.iteration ? cachedStream : null;
+  }
   return cachedStream.sequence > serverStream.sequence ? cachedStream : null;
 }
 
@@ -166,6 +170,12 @@ export function applyStreamEvent(
 
   const current = execution.stream;
   const continuing = current?.id === event.stream_id;
+  // The socket can trail a REST checkpoint across an iteration boundary; a
+  // late frame from an older iteration must not rewind the preview. Drop it —
+  // the installed content is already newer, so there is nothing to repair.
+  if (!continuing && current != null && event.iteration < current.iteration) {
+    return { chat, needsRepair: false };
+  }
   if (continuing && event.sequence <= current.sequence) {
     return { chat, needsRepair: false };
   }
@@ -257,8 +267,9 @@ export function useNotebookChat({
   // Mirror of `chat` for non-reactive reads inside fetchChat.
   const chatRef = useRef<NotebookChat | null>(null);
   // A sequence gap can produce more gap frames while its recovery GET runs.
-  // Keep exactly one repair in flight rather than starting one per token.
-  const streamRepairRef = useRef(false);
+  // Keep one repair in flight; a gap seen mid-flight queues exactly one more,
+  // since the running GET may have been snapshotted before that frame.
+  const streamRepairRef = useRef<'idle' | 'running' | 'queued'>('idle');
   chatRef.current = chat;
 
   const fetchChat = useCallback(
@@ -299,7 +310,7 @@ export function useNotebookChat({
   useEffect(() => {
     seqRef.current += 1; // invalidate any in-flight response for the old chat
     epochRef.current += 1; // …and any pending send/cancel/rename continuation
-    streamRepairRef.current = false;
+    streamRepairRef.current = 'idle';
     setPendingSend(null);
     if (!enabled || noteId == null || chatId == null) {
       setChat(null);
@@ -374,11 +385,18 @@ export function useNotebookChat({
   }, [fetchChat]);
 
   const repairStream = useCallback(() => {
-    if (streamRepairRef.current) return;
-    streamRepairRef.current = true;
-    fetchChat('live').finally(() => {
-      streamRepairRef.current = false;
-    });
+    if (streamRepairRef.current !== 'idle') {
+      streamRepairRef.current = 'queued';
+      return;
+    }
+    const run = (): void => {
+      streamRepairRef.current = 'running';
+      fetchChat('live').finally(() => {
+        if (streamRepairRef.current === 'queued') run();
+        else streamRepairRef.current = 'idle';
+      });
+    };
+    run();
   }, [fetchChat]);
 
   const handleSocketEvent = useCallback(

--- a/hooks/useNotebookChat.ts
+++ b/hooks/useNotebookChat.ts
@@ -389,9 +389,14 @@ export function useNotebookChat({
       streamRepairRef.current = 'queued';
       return;
     }
+    // A chat switch resets the repair state machine; a completion from the
+    // old chat must neither touch it nor start a fetch that could adopt the
+    // newest seq and land the old chat's data in the new one.
+    const epoch = epochRef.current;
     const run = (): void => {
       streamRepairRef.current = 'running';
       fetchChat('live').finally(() => {
+        if (epochRef.current !== epoch) return;
         if (streamRepairRef.current === 'queued') run();
         else streamRepairRef.current = 'idle';
       });

--- a/hooks/useNotebookChat.ts
+++ b/hooks/useNotebookChat.ts
@@ -173,6 +173,10 @@ export function applyStreamEvent(
   // The socket can trail a REST checkpoint across an iteration boundary; a
   // late frame from an older iteration must not rewind the preview. Drop it —
   // the installed content is already newer, so there is nothing to repair.
+  // Known residual race: after a server `stream: null` there is no iteration
+  // to compare, so a late seq-1 frame from a dead iteration can briefly
+  // resurrect its preview until the next frame or refetch replaces it. Closing
+  // it needs the cleared checkpoint to carry its iteration (backend contract).
   if (!continuing && current != null && event.iteration < current.iteration) {
     return { chat, needsRepair: false };
   }

--- a/hooks/useNotebookChat.ts
+++ b/hooks/useNotebookChat.ts
@@ -12,6 +12,9 @@ import {
   isChatStreamSocketEvent,
   isActiveExecutionStatus,
   type ChatExecution,
+  type ChatExecutionStream,
+  type ChatStreamDelta,
+  type ChatStreamItem,
   type ChatStreamSocketEvent,
   type ChatSocketEvent,
   type NotebookChat,
@@ -60,14 +63,30 @@ export interface PendingSend {
 }
 
 /**
+ * The cached stream when it is the same stream a REST response checkpointed
+ * but at a newer sequence — a checkpoint captured just before a socket batch
+ * arrived must not rewind it. Null whenever the server copy is authoritative:
+ * explicit `stream: null`, a new stream id, or a terminal execution.
+ */
+function newerCachedStream(
+  execution: ChatExecution,
+  cached: ChatExecution | undefined
+): ChatExecutionStream | null {
+  if (!isActiveExecutionStatus(execution.status)) return null;
+  const serverStream = execution.stream;
+  const cachedStream = cached?.stream;
+  if (serverStream == null || cachedStream == null) return null;
+  if (cachedStream.id !== serverStream.id) return null;
+  return cachedStream.sequence > serverStream.sequence ? cachedStream : null;
+}
+
+/**
  * Merge a `?activity=live` response over the cached chat.
  *
  * `activity` follows the server's omission contract: an absent key means
  * "unchanged — keep the cached copy", while a present key (even `[]`, a turn
- * that used no tools) replaces it. A REST response can also have captured a
- * stream checkpoint just before a newer socket batch arrived; for the same
- * stream id, keep whichever sequence is newer. Explicit `stream: null`, a new
- * stream id, and terminal executions remain server-authoritative.
+ * that used no tools) replaces it. Streams keep whichever of the cached and
+ * server copies is newer, per {@link newerCachedStream}.
  */
 function mergeLiveChat(prev: NotebookChat | null, next: NotebookChat): NotebookChat {
   const cachedExecutions = new Map<number, ChatExecution>(
@@ -79,18 +98,11 @@ function mergeLiveChat(prev: NotebookChat | null, next: NotebookChat): NotebookC
     executions: next.executions.map((execution) => {
       const cached = cachedExecutions.get(execution.id);
       const activity = execution.activity ?? cached?.activity ?? [];
-      const serverStream = execution.stream;
-      const cachedStream = cached?.stream;
-      const keepNewerSocketStream =
-        isActiveExecutionStatus(execution.status) &&
-        serverStream != null &&
-        cachedStream != null &&
-        serverStream.id === cachedStream.id &&
-        cachedStream.sequence > serverStream.sequence;
+      const newerStream = newerCachedStream(execution, cached);
       return {
         ...execution,
         activity,
-        ...(keepNewerSocketStream ? { stream: cachedStream, phase: cached?.phase ?? null } : {}),
+        ...(newerStream != null ? { stream: newerStream, phase: cached?.phase ?? null } : {}),
       };
     }),
   };
@@ -101,6 +113,34 @@ interface ApplyStreamEventResult {
   needsRepair: boolean;
 }
 
+/** Append one batch's deltas to a copy of `current`; null = corrupt frame. */
+function appendStreamDeltas(
+  current: readonly ChatStreamItem[],
+  deltas: readonly ChatStreamDelta[]
+): ChatStreamItem[] | null {
+  const items = current.map((item) => ({ ...item }));
+  for (const delta of deltas) {
+    const maximum =
+      delta.type === 'thinking' ? MAX_STREAM_THINKING_CHARS : MAX_STREAM_NARRATION_CHARS;
+    const existing = items.find((item) => item.id === delta.id);
+    if (existing == null) {
+      items.push({
+        id: delta.id,
+        type: delta.type,
+        text: delta.delta.slice(0, maximum),
+        at: delta.at,
+      });
+    } else if (existing.type === delta.type) {
+      existing.text = `${existing.text}${delta.delta}`.slice(0, maximum);
+    } else {
+      // An id changing type indicates an incompatible/corrupt frame. Recover
+      // from the server checkpoint instead of combining unlike content.
+      return null;
+    }
+  }
+  return items;
+}
+
 /**
  * Append one sequenced socket batch. Duplicate/old batches are harmless; a
  * missing batch is never guessed and instead asks REST for its checkpoint.
@@ -109,7 +149,7 @@ export function applyStreamEvent(
   chat: NotebookChat | null,
   event: ChatStreamSocketEvent
 ): ApplyStreamEventResult {
-  if (chat == null || chat.conversation_id !== event.conversation_id) {
+  if (chat?.conversation_id !== event.conversation_id) {
     return { chat, needsRepair: true };
   }
 
@@ -134,29 +174,10 @@ export function applyStreamEvent(
     return { chat, needsRepair: true };
   }
 
-  const items = continuing ? current.items.map((item) => ({ ...item })) : [];
-  for (const delta of event.deltas) {
-    const existing = items.find((item) => item.id === delta.id);
-    if (existing) {
-      // An id changing type indicates an incompatible/corrupt frame. Recover
-      // from the server checkpoint instead of combining unlike content.
-      if (existing.type !== delta.type) return { chat, needsRepair: true };
-      const maximum =
-        existing.type === 'thinking' ? MAX_STREAM_THINKING_CHARS : MAX_STREAM_NARRATION_CHARS;
-      existing.text = `${existing.text}${delta.delta}`.slice(0, maximum);
-    } else {
-      const maximum =
-        delta.type === 'thinking' ? MAX_STREAM_THINKING_CHARS : MAX_STREAM_NARRATION_CHARS;
-      items.push({
-        id: delta.id,
-        type: delta.type,
-        text: delta.delta.slice(0, maximum),
-        at: delta.at,
-      });
-    }
-  }
+  const items = appendStreamDeltas(continuing ? current.items : [], event.deltas);
+  if (items == null) return { chat, needsRepair: true };
 
-  const lastDelta = event.deltas[event.deltas.length - 1];
+  const lastDelta = event.deltas.at(-1);
   const nextExecution: ChatExecution = {
     ...execution,
     stream: {

--- a/hooks/useNotebookChat.ts
+++ b/hooks/useNotebookChat.ts
@@ -9,8 +9,10 @@ import {
 } from '@/services/notebookChat.service';
 import { useNotebookChatSocket, type ChatSocketStatus } from '@/hooks/useNotebookChatSocket';
 import {
+  isChatStreamSocketEvent,
   isActiveExecutionStatus,
   type ChatExecution,
+  type ChatStreamSocketEvent,
   type ChatSocketEvent,
   type NotebookChat,
   type NotebookChatListItem,
@@ -18,8 +20,10 @@ import {
 
 /** Fallback poll cadence while a turn runs; the socket nudge usually wins. */
 const POLL_INTERVAL_MS = 5000;
-/** Socket events are advisory nudges — collapse bursts into one refetch. */
+/** Lifecycle events and stream repair requests collapse into one refetch. */
 const NUDGE_DEBOUNCE_MS = 250;
+const MAX_STREAM_NARRATION_CHARS = 100_000;
+const MAX_STREAM_THINKING_CHARS = 4_000;
 
 export type ChatAccess = 'loading' | 'ok' | 'not_found' | 'unauthorized' | 'error';
 
@@ -58,25 +62,117 @@ export interface PendingSend {
 /**
  * Merge a `?activity=live` response over the cached chat.
  *
- * Everything except `activity` is replaced wholesale. `activity` follows the
- * server's omission contract: an absent key means "unchanged — keep the cached
- * copy", while a present key (even `[]`, a turn that used no tools) replaces
- * it. After the merge every execution carries a concrete `activity` array so
- * the UI never has to reason about the omission again.
+ * `activity` follows the server's omission contract: an absent key means
+ * "unchanged — keep the cached copy", while a present key (even `[]`, a turn
+ * that used no tools) replaces it. A REST response can also have captured a
+ * stream checkpoint just before a newer socket batch arrived; for the same
+ * stream id, keep whichever sequence is newer. Explicit `stream: null`, a new
+ * stream id, and terminal executions remain server-authoritative.
  */
 function mergeLiveChat(prev: NotebookChat | null, next: NotebookChat): NotebookChat {
-  const cachedActivity = new Map<number, ChatExecution['activity']>(
-    (prev?.executions ?? []).map((execution) => [execution.id, execution.activity])
+  const cachedExecutions = new Map<number, ChatExecution>(
+    (prev?.executions ?? []).map((execution) => [execution.id, execution])
   );
 
   return {
     ...next,
-    executions: next.executions.map((execution) =>
-      execution.activity !== undefined
-        ? execution
-        : { ...execution, activity: cachedActivity.get(execution.id) ?? [] }
-    ),
+    executions: next.executions.map((execution) => {
+      const cached = cachedExecutions.get(execution.id);
+      const activity = execution.activity ?? cached?.activity ?? [];
+      const serverStream = execution.stream;
+      const cachedStream = cached?.stream;
+      const keepNewerSocketStream =
+        isActiveExecutionStatus(execution.status) &&
+        serverStream != null &&
+        cachedStream != null &&
+        serverStream.id === cachedStream.id &&
+        cachedStream.sequence > serverStream.sequence;
+      return {
+        ...execution,
+        activity,
+        ...(keepNewerSocketStream ? { stream: cachedStream, phase: cached?.phase ?? null } : {}),
+      };
+    }),
   };
+}
+
+interface ApplyStreamEventResult {
+  chat: NotebookChat | null;
+  needsRepair: boolean;
+}
+
+/**
+ * Append one sequenced socket batch. Duplicate/old batches are harmless; a
+ * missing batch is never guessed and instead asks REST for its checkpoint.
+ */
+export function applyStreamEvent(
+  chat: NotebookChat | null,
+  event: ChatStreamSocketEvent
+): ApplyStreamEventResult {
+  if (chat == null || chat.conversation_id !== event.conversation_id) {
+    return { chat, needsRepair: true };
+  }
+
+  const executionIndex = chat.executions.findIndex(
+    (execution) => execution.id === event.execution_id
+  );
+  if (executionIndex < 0) return { chat, needsRepair: true };
+
+  const execution = chat.executions[executionIndex];
+  // A late frame must not resurrect a preview after the turn settled.
+  if (!isActiveExecutionStatus(execution.status)) {
+    return { chat, needsRepair: false };
+  }
+
+  const current = execution.stream;
+  const continuing = current?.id === event.stream_id;
+  if (continuing && event.sequence <= current.sequence) {
+    return { chat, needsRepair: false };
+  }
+  const expectedSequence = continuing ? current.sequence + 1 : 1;
+  if (event.sequence !== expectedSequence) {
+    return { chat, needsRepair: true };
+  }
+
+  const items = continuing ? current.items.map((item) => ({ ...item })) : [];
+  for (const delta of event.deltas) {
+    const existing = items.find((item) => item.id === delta.id);
+    if (existing) {
+      // An id changing type indicates an incompatible/corrupt frame. Recover
+      // from the server checkpoint instead of combining unlike content.
+      if (existing.type !== delta.type) return { chat, needsRepair: true };
+      const maximum =
+        existing.type === 'thinking' ? MAX_STREAM_THINKING_CHARS : MAX_STREAM_NARRATION_CHARS;
+      existing.text = `${existing.text}${delta.delta}`.slice(0, maximum);
+    } else {
+      const maximum =
+        delta.type === 'thinking' ? MAX_STREAM_THINKING_CHARS : MAX_STREAM_NARRATION_CHARS;
+      items.push({
+        id: delta.id,
+        type: delta.type,
+        text: delta.delta.slice(0, maximum),
+        at: delta.at,
+      });
+    }
+  }
+
+  const lastDelta = event.deltas[event.deltas.length - 1];
+  const nextExecution: ChatExecution = {
+    ...execution,
+    stream: {
+      id: event.stream_id,
+      sequence: event.sequence,
+      iteration: event.iteration,
+      items,
+    },
+    phase:
+      lastDelta?.type === 'narration'
+        ? { state: 'responding', label: 'Writing a response' }
+        : { state: 'thinking', label: 'Thinking' },
+  };
+  const executions = [...chat.executions];
+  executions[executionIndex] = nextExecution;
+  return { chat: { ...chat, executions }, needsRepair: false };
 }
 
 interface UseNotebookChatOptions {
@@ -109,11 +205,10 @@ export interface UseNotebookChatResult {
 }
 
 /**
- * State machine for one open chat. REST is the source of truth: the first load
- * is a full GET, every subsequent refresh is `?activity=live` merged via
- * {@link mergeLiveChat}. The socket and the poll loop both funnel into the
- * same refetch, so dropped/duplicated/reordered events can only ever delay
- * data, never corrupt it.
+ * State machine for one open chat. REST is the durable source of truth and
+ * carries a bounded transient stream checkpoint. Lifecycle socket events
+ * trigger a live refetch; sequenced stream events append immediately. Polling,
+ * reconnects, and any detected sequence gap repair from REST.
  */
 export function useNotebookChat({
   noteId,
@@ -140,6 +235,9 @@ export function useNotebookChat({
   const seededChatIdRef = useRef<number | null>(null);
   // Mirror of `chat` for non-reactive reads inside fetchChat.
   const chatRef = useRef<NotebookChat | null>(null);
+  // A sequence gap can produce more gap frames while its recovery GET runs.
+  // Keep exactly one repair in flight rather than starting one per token.
+  const streamRepairRef = useRef(false);
   chatRef.current = chat;
 
   const fetchChat = useCallback(
@@ -152,7 +250,11 @@ export function useNotebookChat({
       try {
         const data = await NotebookChatService.getChat(noteId, chatId, { live });
         if (seq !== seqRef.current) return;
-        setChat((prev) => mergeLiveChat(live ? prev : null, data));
+        setChat((prev) => {
+          const merged = mergeLiveChat(live ? prev : null, data);
+          chatRef.current = merged;
+          return merged;
+        });
         setAccess('ok');
       } catch (err) {
         if (seq !== seqRef.current) return;
@@ -176,6 +278,7 @@ export function useNotebookChat({
   useEffect(() => {
     seqRef.current += 1; // invalidate any in-flight response for the old chat
     epochRef.current += 1; // …and any pending send/cancel/rename continuation
+    streamRepairRef.current = false;
     setPendingSend(null);
     if (!enabled || noteId == null || chatId == null) {
       setChat(null);
@@ -241,8 +344,7 @@ export function useNotebookChat({
     return () => clearInterval(timer);
   }, [enabled, access, isBusy, isFinishing, fetchChat]);
 
-  // Debounced socket nudge → live refetch. Every event kind is handled
-  // identically; the refetched status is what we trust.
+  // Debounced lifecycle nudge / stream-gap repair → live refetch.
   const nudgeRef = useRef<DebouncedFunc<() => void> | null>(null);
   useEffect(() => {
     const nudge = debounce(() => fetchChat('live'), NUDGE_DEBOUNCE_MS);
@@ -250,9 +352,36 @@ export function useNotebookChat({
     return () => nudge.cancel();
   }, [fetchChat]);
 
-  const handleSocketEvent = useCallback((_event: ChatSocketEvent) => {
-    nudgeRef.current?.();
-  }, []);
+  const repairStream = useCallback(() => {
+    if (streamRepairRef.current) return;
+    streamRepairRef.current = true;
+    fetchChat('live').finally(() => {
+      streamRepairRef.current = false;
+    });
+  }, [fetchChat]);
+
+  const handleSocketEvent = useCallback(
+    (event: ChatSocketEvent) => {
+      if (event.conversation_id !== chatId) return;
+      if (!isChatStreamSocketEvent(event)) {
+        nudgeRef.current?.();
+        return;
+      }
+
+      const current = chatRef.current;
+      const applied = applyStreamEvent(current, event);
+      if (applied.needsRepair) {
+        repairStream();
+        return;
+      }
+      if (applied.chat !== current) {
+        // Keep burst frames ordered even when React batches their renders.
+        chatRef.current = applied.chat;
+        setChat(applied.chat);
+      }
+    },
+    [chatId, repairStream]
+  );
 
   const handleSocketReconnect = useCallback(() => {
     fetchChat('live');

--- a/hooks/useNotebookChatSocket.ts
+++ b/hooks/useNotebookChatSocket.ts
@@ -2,7 +2,7 @@
 
 import { useMemo } from 'react';
 import { WS_ROUTES } from '@/services/websocket';
-import type { ChatSocketEvent } from '@/types/notebookChat';
+import { isChatSocketEvent, type ChatSocketEvent } from '@/types/notebookChat';
 import { useReconnectingSocket, type SocketStatus } from './useReconnectingSocket';
 
 /**
@@ -21,15 +21,15 @@ interface UseNotebookChatSocketOptions {
   /** Connect only while the chat exists and is open on screen. */
   enabled: boolean;
   /**
-   * An event arrived. Events carry identifiers, never state — the only correct
-   * reaction to any kind is a (debounced) refetch, which the caller owns.
+   * An event arrived. Lifecycle events are refetch nudges; stream events carry
+   * sequenced append deltas. The caller owns both paths.
    */
   onEvent: (event: ChatSocketEvent) => void;
   /** Socket re-opened after a drop — refetch immediately, events were missed. */
   onReconnect: () => void;
 }
 
-/** One WebSocket per open chat, used purely as a refetch nudge. */
+/** One WebSocket per open chat for lifecycle nudges and transient output. */
 export function useNotebookChatSocket({
   noteId,
   chatId,
@@ -46,9 +46,11 @@ export function useNotebookChatSocket({
     url,
     enabled: enabled && url != null,
     fatalCloseCodes: FATAL_CLOSE_CODES,
-    // Frames on this channel are chat events by contract; unknown `type`
-    // values pass through and the consumer treats any event as a nudge.
-    onMessage: (data) => onEvent(data as ChatSocketEvent),
+    // Frames on this channel are chat events by contract. Runtime validation
+    // of stream fields happens in the caller; unknown kinds remain nudges.
+    onMessage: (data) => {
+      if (isChatSocketEvent(data)) onEvent(data);
+    },
     onReconnect,
   });
 }

--- a/types/notebookChat.ts
+++ b/types/notebookChat.ts
@@ -64,6 +64,22 @@ export interface ChatToolCallActivity {
 
 export type ChatActivityItem = ChatNarrationActivity | ChatThinkingActivity | ChatToolCallActivity;
 
+/** A transient item assembled from WebSocket deltas while a model turn runs. */
+export type ChatStreamItem = (ChatNarrationActivity | ChatThinkingActivity) & {
+  /** Stable within one provider iteration. */
+  id: string;
+};
+
+/** Bounded server checkpoint used to recover after a dropped socket frame. */
+export interface ChatExecutionStream {
+  /** Execution + provider iteration identity (for example `42:2`). */
+  id: string;
+  /** Monotonic within this stream id. */
+  sequence: number;
+  iteration: number;
+  items: ChatStreamItem[];
+}
+
 export interface ExecutionPhase {
   /**
    * Coarse machine state — `queued` / `using_tool` / `responding` / `thinking`
@@ -109,6 +125,12 @@ export interface ChatExecution {
    * consumers can rely on the field being present.
    */
   activity?: ChatActivityItem[];
+  /**
+   * In-flight text/readable-thinking snapshot. Present for active executions;
+   * null means an old local preview must be cleared. Terminal executions omit
+   * it because their durable activity/message is authoritative.
+   */
+  stream?: ChatExecutionStream | null;
   /** Coarse live status; null once the turn is terminal. */
   phase: ExecutionPhase | null;
 }
@@ -151,11 +173,62 @@ export interface CancelTurnResponse {
   execution_id: number | null;
 }
 
-/** Socket events carry identifiers only — on any event, refetch. */
-export interface ChatSocketEvent {
+interface ChatSocketEventBase {
   conversation_id: number;
   execution_id: number | null;
   kind: string;
+}
+
+export interface ChatStreamDelta {
+  id: string;
+  type: 'narration' | 'thinking';
+  delta: string;
+  at: string;
+}
+
+export interface ChatStreamSocketEvent extends ChatSocketEventBase {
+  execution_id: number;
+  kind: 'stream_delta';
+  stream_id: string;
+  sequence: number;
+  iteration: number;
+  deltas: ChatStreamDelta[];
+}
+
+/** Lifecycle events are identifier-only refetch nudges. */
+export type ChatSocketEvent = ChatSocketEventBase | ChatStreamSocketEvent;
+
+export function isChatSocketEvent(value: unknown): value is ChatSocketEvent {
+  if (value == null || typeof value !== 'object') return false;
+  const candidate = value as Partial<ChatSocketEventBase>;
+  return (
+    typeof candidate.conversation_id === 'number' &&
+    (candidate.execution_id == null || typeof candidate.execution_id === 'number') &&
+    typeof candidate.kind === 'string'
+  );
+}
+
+/** Runtime guard: WebSocket JSON crosses no schema-validation boundary. */
+export function isChatStreamSocketEvent(event: ChatSocketEvent): event is ChatStreamSocketEvent {
+  const candidate = event as Partial<ChatStreamSocketEvent>;
+  return (
+    event.kind === 'stream_delta' &&
+    typeof event.execution_id === 'number' &&
+    typeof candidate.stream_id === 'string' &&
+    typeof candidate.sequence === 'number' &&
+    Number.isInteger(candidate.sequence) &&
+    typeof candidate.iteration === 'number' &&
+    Array.isArray(candidate.deltas) &&
+    candidate.deltas.length > 0 &&
+    candidate.deltas.every(
+      (delta) =>
+        delta != null &&
+        typeof delta.id === 'string' &&
+        (delta.type === 'narration' || delta.type === 'thinking') &&
+        typeof delta.delta === 'string' &&
+        typeof delta.at === 'string'
+    )
+  );
 }
 
 export const MAX_CHAT_MESSAGE_LENGTH = 20_000;


### PR DESCRIPTION
## What

Follow-up to #1022: the assistant's narration and readable thinking now stream into the chat panel as they're written, instead of appearing only once the turn settles.

- **`types/notebookChat.ts`** — the socket contract grows a `stream_delta` event (`stream_id`, monotonic `sequence`, per-item append deltas typed `narration`/`thinking`), and `?activity=live` executions carry a bounded `stream` checkpoint (`null` clears a stale local preview; terminal executions omit it — their durable activity is authoritative). Runtime guards for both, since WebSocket JSON crosses no schema-validation boundary.
- **`hooks/useNotebookChat.ts`** — `applyStreamEvent` appends sequenced batches to the cached execution: duplicate/old frames are dropped, and any gap, unknown execution, or type-mismatched delta falls back to a single-flight `?activity=live` repair rather than guessing. A late frame can never resurrect a preview on a settled turn. `mergeLiveChat` keeps whichever of the socket/REST stream is newer for the same stream id, so a REST checkpoint captured just before a socket batch can't rewind it. Text is capped (100k narration / 4k thinking per block). The phase line flips between "Thinking"/"Writing a response" off the last delta's type.
- **`hooks/useNotebookChatSocket.ts`** — frames are validated before dispatch; unknown kinds remain refetch nudges, so the lifecycle path is unchanged.
- **`ExecutionProgress` / `ActivityFeed`** — the durable activity rows are followed by the current iteration's transient preview; the lifecycle refetch replaces it with the recorded turn. Stream items key by their stable ids.
- **Thinking presentation** (second commit) — expanded thinking renders through `MarkdownMessage` instead of raw text, with markers stripped (memoized) from the collapsed one-line preview. The block currently receiving deltas auto-expands and collapses once the stream moves past it; a manual toggle always wins.

## Why

Long thinking or writing stretches previously rendered as a static phase label until the next refetch — the turn looked stalled exactly when the model was doing the most work. Streaming makes it readable as it happens without giving up REST as the source of truth: the socket path is purely additive, and every anomaly (gap, reconnect, unknown shape) degrades to the existing refetch, so dropped or reordered frames can delay the preview but never corrupt the record.
