### PR TITLE
Offer opening presets on the assistant's empty chat screen

### DIFF
--- a/components/Notebook/AgentChat/AgentChatPanel.tsx
+++ b/components/Notebook/AgentChat/AgentChatPanel.tsx
@@ -12,7 +12,7 @@ import { useNotebookChat, useNotebookChatList, type SendOutcome } from '@/hooks/
 import { MAX_AGENT_CHAT_WIDTH, MIN_AGENT_CHAT_WIDTH } from '@/hooks/useAgentChatWidth';
 import { useNoteVersionSocket } from '@/hooks/useNoteVersionSocket';
 import { NoteService } from '@/services/note.service';
-import { NOTE_VERSION_CREATED } from '@/types/note';
+import { isRfpNote, NOTE_VERSION_CREATED } from '@/types/note';
 import {
   isActiveExecutionStatus,
   MAX_CHAT_TITLE_LENGTH,
@@ -20,10 +20,12 @@ import {
 } from '@/types/notebookChat';
 import { ENDOWMENT_PROMO_BANNER_FEATURE } from '@/app/layouts/components/EndowmentPromoBanner';
 import { useDismissableFeature } from '@/hooks/useDismissableFeature';
+import { useEditorIsEmpty } from '@/hooks/useEditorIsEmpty';
 import { belowMobileTopBar } from '../mobileChromeOffsets';
 import { NoteReviewControls } from '../NoteReview/NoteReviewControls';
 import { ChatComposer, type ComposerNotice } from './ChatComposer';
 import { ChatPicker } from './ChatPicker';
+import { ChatPresets } from './ChatPresets';
 import { ChatSources, collectChatSources } from './ChatSources';
 import { ChatTranscript } from './ChatTranscript';
 import { Logo } from '@/components/ui/Logo';
@@ -223,6 +225,10 @@ export function AgentChatPanel({
   onReviewChange,
 }: AgentChatPanelProps) {
   const { editor, currentNote } = useNotebookContext();
+  // Decide which writing preset the empty chat screen offers, and what it
+  // calls the document: the notebook holds RFPs as well as proposals.
+  const noteIsEmpty = useEditorIsEmpty(editor);
+  const noteIsRfp = isRfpNote(currentNote);
 
   // Mirrors PageLayout: the promo banner sits above the TopBar on mobile, and
   // this panel hangs from the bar's underside, so it has to know.
@@ -270,6 +276,26 @@ export function AgentChatPanel({
       setDraft(value);
     },
     [draftKey]
+  );
+
+  const composerRef = useRef<HTMLTextAreaElement>(null);
+
+  /**
+   * A preset loads the composer rather than sending: its message is a starting
+   * point, and the details that make it worth sending — the deadline, the
+   * section, the sub-field — are the user's to add. Focus follows the text so
+   * the caret is already waiting at the end of it.
+   */
+  const applyPreset = useCallback(
+    (message: string) => {
+      setNotice(null);
+      updateDraft(message);
+      const textarea = composerRef.current;
+      if (!textarea) return;
+      textarea.focus();
+      textarea.setSelectionRange(message.length, message.length);
+    },
+    [updateDraft]
   );
 
   const prevDraftKeyRef = useRef(draftKey);
@@ -889,13 +915,22 @@ export function AgentChatPanel({
   const composerDisabled =
     selectedChatId == null ? list.access !== 'ok' : chatState.access !== 'ok';
 
+  const emptyState = (
+    <EmptyState
+      noteIsEmpty={noteIsEmpty}
+      noteIsRfp={noteIsRfp}
+      onSelectPreset={applyPreset}
+      presetsDisabled={composerDisabled}
+    />
+  );
+
   const renderBody = () => {
     if (selectedChatId == null) {
       if (list.access === 'loading') return <CenteredLoader />;
       if (list.access === 'error') {
         return <ErrorState message="Couldn’t load your chats." onRetry={() => refreshList()} />;
       }
-      return <EmptyState />;
+      return emptyState;
     }
 
     switch (chatState.access) {
@@ -920,7 +955,7 @@ export function AgentChatPanel({
           chatState.chat.messages.length === 0 &&
           chatState.chat.executions.length === 0 &&
           !chatState.pendingSend;
-        if (isEmpty) return <EmptyState />;
+        if (isEmpty) return emptyState;
         return <ChatTranscript chat={chatState.chat} pendingSend={chatState.pendingSend} />;
       }
     }
@@ -1133,6 +1168,7 @@ export function AgentChatPanel({
       )}
 
       <ChatComposer
+        textareaRef={composerRef}
         value={draft}
         onChange={updateDraft}
         onSend={handleSend}
@@ -1208,21 +1244,39 @@ function ErrorState({
   );
 }
 
-function EmptyState() {
+function EmptyState({
+  noteIsEmpty,
+  noteIsRfp,
+  onSelectPreset,
+  presetsDisabled,
+}: {
+  readonly noteIsEmpty: boolean;
+  readonly noteIsRfp: boolean;
+  readonly onSelectPreset: (message: string) => void;
+  readonly presetsDisabled: boolean;
+}) {
   return (
-    <div className="flex h-full flex-col items-center justify-center gap-3 px-6 text-center">
-      <div className="flex h-11 w-11 items-center justify-center rounded-full bg-primary-50">
-        <Logo size={32} noText />
+    <div className="flex h-full flex-col items-center justify-center gap-5 px-6 text-center">
+      <div className="flex flex-col items-center gap-3">
+        <div className="flex h-11 w-11 items-center justify-center rounded-full bg-primary-50">
+          <Logo size={32} noText />
+        </div>
+        <div>
+          <p className="flex items-center justify-center gap-1.5 font-serif text-lg tracking-tight text-gray-800">
+            Research assistant
+          </p>
+          <p className="mt-1.5 text-xs leading-relaxed text-gray-500">
+            Ask questions about this note, search the web and scholarly literature, or have the
+            assistant edit the draft for you.
+          </p>
+        </div>
       </div>
-      <div>
-        <p className="flex items-center justify-center gap-1.5 font-serif text-lg tracking-tight text-gray-800">
-          Research assistant
-        </p>
-        <p className="mt-1.5 text-xs leading-relaxed text-gray-500">
-          Ask questions about this note, search the web and scholarly literature, or have the
-          assistant edit the draft for you.
-        </p>
-      </div>
+      <ChatPresets
+        noteIsEmpty={noteIsEmpty}
+        isRfp={noteIsRfp}
+        onSelect={onSelectPreset}
+        disabled={presetsDisabled}
+      />
     </div>
   );
 }

--- a/components/Notebook/AgentChat/AgentChatPanel.tsx
+++ b/components/Notebook/AgentChat/AgentChatPanel.tsx
@@ -238,9 +238,13 @@ export function AgentChatPanel({
   const promoBannerVisible = promoStatus === 'checked' && !promoDismissed;
 
   const list = useNotebookChatList(noteId, open);
+  // Null is the new-chat screen, and it is where a page visit starts: the
+  // assistant opens on its own opening moves rather than dropping the reader
+  // into the middle of whatever they last asked. Earlier chats stay one click
+  // away in the picker, and a selection survives closing the panel — only a
+  // fresh visit or a note switch resets it.
   const [selectedChatId, setSelectedChatId] = useState<number | null>(null);
   const [initialChat, setInitialChat] = useState<NotebookChat | null>(null);
-  const autoSelectedRef = useRef(false);
 
   // Network activity is gated on `open`. No keep-alive is needed for turns
   // that finish while the panel is closed or another chat is selected: the
@@ -313,7 +317,6 @@ export function AgentChatPanel({
     setNotice(null);
     setQueuedMessage(null);
     setCreatingChat(false);
-    autoSelectedRef.current = false;
     draftsRef.current.clear();
     setDraft('');
   }, [noteId]);
@@ -324,20 +327,6 @@ export function AgentChatPanel({
       onUnavailable();
     }
   }, [list.access, chatState.access, onUnavailable]);
-
-  // ---- auto-select the most recent chat once per panel open ----
-  useEffect(() => {
-    if (!open) {
-      autoSelectedRef.current = false;
-      return;
-    }
-    if (autoSelectedRef.current || list.access !== 'ok') return;
-    autoSelectedRef.current = true;
-    if (selectedChatId == null && list.chats.length > 0) {
-      setSelectedChatId(list.chats[0].id);
-      setInitialChat(null);
-    }
-  }, [open, list.access, list.chats, selectedChatId]);
 
   // ---- keep the listing fresh as the open chat evolves ----
   // Derived titles land after the first turn, previews/spinners change as

--- a/components/Notebook/AgentChat/ChatComposer.tsx
+++ b/components/Notebook/AgentChat/ChatComposer.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useRef, type KeyboardEvent } from 'react';
+import { useEffect, type KeyboardEvent, type RefObject } from 'react';
 import { ArrowUp, Square } from 'lucide-react';
 import { cn } from '@/utils/styles';
 import { MAX_CHAT_MESSAGE_LENGTH } from '@/types/notebookChat';
@@ -27,6 +27,11 @@ interface ChatComposerProps {
   readonly disabled: boolean;
   readonly notice: ComposerNotice | null;
   readonly placeholder?: string;
+  /**
+   * The textarea itself, owned by the parent: a preset drops its text into the
+   * draft and then has to hand the caret over to the box the user edits.
+   */
+  readonly textareaRef: RefObject<HTMLTextAreaElement | null>;
 }
 
 const COUNTER_THRESHOLD = MAX_CHAT_MESSAGE_LENGTH - 1000;
@@ -45,9 +50,8 @@ export function ChatComposer({
   disabled,
   notice,
   placeholder = 'Ask the assistant…',
+  textareaRef,
 }: ChatComposerProps) {
-  const textareaRef = useRef<HTMLTextAreaElement>(null);
-
   // Grow with content up to ~6 lines, then scroll.
   useEffect(() => {
     const textarea = textareaRef.current;

--- a/components/Notebook/AgentChat/ChatPresets.tsx
+++ b/components/Notebook/AgentChat/ChatPresets.tsx
@@ -1,0 +1,113 @@
+'use client';
+
+import type { ComponentType } from 'react';
+import { HandCoins, PenLine, SquarePen, Telescope } from 'lucide-react';
+import { cn } from '@/utils/styles';
+
+interface ChatPreset {
+  readonly id: string;
+  readonly label: string;
+  readonly icon: ComponentType<{ className?: string }>;
+  /** Loaded into the composer as an editable starting point, not sent. */
+  readonly message: string;
+}
+
+/**
+ * An RFP is the funder's own call, so it takes one writing preset in both
+ * states — worded to work whether the note is blank or half-written, since the
+ * assistant reads the note either way.
+ */
+const DRAFT_RFP: ChatPreset = {
+  id: 'draft-rfp',
+  label: 'Draft RFP',
+  icon: PenLine,
+  message:
+    'Help me draft this RFP. Ask me for anything you still need to know about the work I want to ' +
+    'fund, then write the draft into the note.',
+};
+
+const DRAFT_PROPOSAL: ChatPreset = {
+  id: 'draft-proposal',
+  label: 'Draft proposal',
+  icon: PenLine,
+  message:
+    'Help me draft this proposal. Ask me for anything you still need to know about the work, ' +
+    'then write a first draft into the note.',
+};
+
+const EDIT_PROPOSAL: ChatPreset = {
+  id: 'edit-proposal',
+  label: 'Edit proposal',
+  icon: SquarePen,
+  message:
+    'Review the proposal in this note and make it stronger — tighten the writing, fill in what ' +
+    'is missing, and flag anything a reviewer would push back on.',
+};
+
+const RESEARCH: ChatPreset = {
+  id: 'research',
+  label: 'Help me research',
+  icon: Telescope,
+  message:
+    'Help me research this. Search the web and the scholarly literature for the work most ' +
+    'relevant to this note, and summarise what I should know, with sources.',
+};
+
+const FUNDING: ChatPreset = {
+  id: 'funding',
+  label: 'Find me funding',
+  icon: HandCoins,
+  message:
+    'Find open RFPs I could apply to that fit this work, and tell me why each one is a match.',
+};
+
+/**
+ * An RFP note is written by the side handing out the money, so it gets neither
+ * the funding search nor the proposal-shaped review — only the call itself and
+ * the field it is calling into. A proposal note takes all three, its writing
+ * preset turning on whether there is a draft to improve yet.
+ */
+function presetsFor(noteIsEmpty: boolean, isRfp: boolean): ChatPreset[] {
+  if (isRfp) return [DRAFT_RFP, RESEARCH];
+  return [noteIsEmpty ? DRAFT_PROPOSAL : EDIT_PROPOSAL, RESEARCH, FUNDING];
+}
+
+interface ChatPresetsProps {
+  readonly noteIsEmpty: boolean;
+  readonly isRfp: boolean;
+  readonly onSelect: (message: string) => void;
+  readonly disabled: boolean;
+}
+
+/**
+ * Opening moves offered on the empty chat screen. Picking one writes its
+ * message into the composer for the user to edit and send, so the specifics a
+ * generic instruction can't carry go in before the assistant sees it.
+ */
+export function ChatPresets({ noteIsEmpty, isRfp, onSelect, disabled }: ChatPresetsProps) {
+  return (
+    // Stacked, not the grid this pattern usually wears: the panel is 360px at
+    // its narrowest, where side-by-side cards would wrap every label.
+    <div className="flex w-full max-w-xs flex-col gap-2">
+      {presetsFor(noteIsEmpty, isRfp).map((preset) => (
+        <button
+          key={preset.id}
+          type="button"
+          onClick={() => onSelect(preset.message)}
+          disabled={disabled}
+          className={cn(
+            'flex w-full items-center gap-2.5 rounded-xl border border-gray-200 bg-white px-3 py-2.5',
+            'text-left text-sm font-medium text-gray-700 transition-colors',
+            'hover:border-primary-200 hover:bg-primary-50 hover:text-gray-900',
+            'focus:outline-none focus-visible:border-primary-400 focus-visible:ring-2 focus-visible:ring-primary-500',
+            'disabled:cursor-not-allowed disabled:opacity-60 disabled:hover:border-gray-200',
+            'disabled:hover:bg-white disabled:hover:text-gray-700'
+          )}
+        >
+          <preset.icon className="h-4 w-4 shrink-0 text-primary-500" aria-hidden="true" />
+          {preset.label}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/components/Notebook/AgentChat/ChatPresets.tsx
+++ b/components/Notebook/AgentChat/ChatPresets.tsx
@@ -32,7 +32,7 @@ const DRAFT_PROPOSAL: ChatPreset = {
   icon: PenLine,
   message:
     'Help me draft this proposal. Ask me for anything you still need to know about the work, ' +
-    'then generate me three hypotheses.',
+    'then generate me three hypotheses to start.',
 };
 
 const EDIT_PROPOSAL: ChatPreset = {

--- a/components/Notebook/AgentChat/ChatPresets.tsx
+++ b/components/Notebook/AgentChat/ChatPresets.tsx
@@ -44,7 +44,13 @@ const EDIT_PROPOSAL: ChatPreset = {
     'is missing, and flag anything a reviewer would push back on.',
 };
 
-const RESEARCH: ChatPreset = {
+/**
+ * The two searches, each in a note-shaped and an author-shaped form. Both have
+ * to match on something: a written note is the better brief, and an empty one
+ * is no brief at all, so the search falls back to the person doing it. A pair
+ * shares its id, since the two never appear together.
+ */
+const RESEARCH_FROM_NOTE: ChatPreset = {
   id: 'research',
   label: 'Help me research',
   icon: Telescope,
@@ -53,11 +59,15 @@ const RESEARCH: ChatPreset = {
     'relevant to this note, and summarise what I should know, with sources.',
 };
 
-/**
- * The funding search, which has to match on something. A written note is the
- * better brief; an empty one is no brief at all, so it falls back to the
- * author — the same id either way, since they never appear together.
- */
+const RESEARCH_FROM_EXPERTISE: ChatPreset = {
+  id: 'research',
+  label: 'Help me research',
+  icon: Telescope,
+  message:
+    'Help me research. Search the web and the scholarly literature for the work most relevant ' +
+    'to my expertise, and summarise what I should know, with sources.',
+};
+
 const FUNDING_FROM_NOTE: ChatPreset = {
   id: 'funding',
   label: 'Find me funding',
@@ -81,10 +91,11 @@ const FUNDING_FROM_EXPERTISE: ChatPreset = {
  * preset turning on whether there is a draft to improve yet.
  */
 function presetsFor(noteIsEmpty: boolean, isRfp: boolean): ChatPreset[] {
-  if (isRfp) return [DRAFT_RFP, RESEARCH];
+  const research = noteIsEmpty ? RESEARCH_FROM_EXPERTISE : RESEARCH_FROM_NOTE;
+  if (isRfp) return [DRAFT_RFP, research];
   return [
     noteIsEmpty ? DRAFT_PROPOSAL : EDIT_PROPOSAL,
-    RESEARCH,
+    research,
     noteIsEmpty ? FUNDING_FROM_EXPERTISE : FUNDING_FROM_NOTE,
   ];
 }

--- a/components/Notebook/AgentChat/ChatPresets.tsx
+++ b/components/Notebook/AgentChat/ChatPresets.tsx
@@ -32,7 +32,7 @@ const DRAFT_PROPOSAL: ChatPreset = {
   icon: PenLine,
   message:
     'Help me draft this proposal. Ask me for anything you still need to know about the work, ' +
-    'then write a first draft into the note.',
+    'then generate me three hypotheses.',
 };
 
 const EDIT_PROPOSAL: ChatPreset = {

--- a/components/Notebook/AgentChat/ChatPresets.tsx
+++ b/components/Notebook/AgentChat/ChatPresets.tsx
@@ -53,12 +53,25 @@ const RESEARCH: ChatPreset = {
     'relevant to this note, and summarise what I should know, with sources.',
 };
 
-const FUNDING: ChatPreset = {
+/**
+ * The funding search, which has to match on something. A written note is the
+ * better brief; an empty one is no brief at all, so it falls back to the
+ * author — the same id either way, since they never appear together.
+ */
+const FUNDING_FROM_NOTE: ChatPreset = {
   id: 'funding',
   label: 'Find me funding',
   icon: HandCoins,
   message:
     'Find open RFPs I could apply to that fit this work, and tell me why each one is a match.',
+};
+
+const FUNDING_FROM_EXPERTISE: ChatPreset = {
+  id: 'funding',
+  label: 'Find me funding',
+  icon: HandCoins,
+  message:
+    'Find open RFPs I could apply to based on my expertise, and tell me why each one is a match.',
 };
 
 /**
@@ -69,7 +82,11 @@ const FUNDING: ChatPreset = {
  */
 function presetsFor(noteIsEmpty: boolean, isRfp: boolean): ChatPreset[] {
   if (isRfp) return [DRAFT_RFP, RESEARCH];
-  return [noteIsEmpty ? DRAFT_PROPOSAL : EDIT_PROPOSAL, RESEARCH, FUNDING];
+  return [
+    noteIsEmpty ? DRAFT_PROPOSAL : EDIT_PROPOSAL,
+    RESEARCH,
+    noteIsEmpty ? FUNDING_FROM_EXPERTISE : FUNDING_FROM_NOTE,
+  ];
 }
 
 interface ChatPresetsProps {

--- a/hooks/useEditorIsEmpty.ts
+++ b/hooks/useEditorIsEmpty.ts
@@ -1,0 +1,37 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import type { Editor } from '@tiptap/core';
+
+const readIsEmpty = (editor: Editor | null): boolean =>
+  !editor || editor.isDestroyed ? true : editor.isEmpty;
+
+/**
+ * Whether the editor's document is empty, kept current as the document
+ * changes.
+ *
+ * Subscribed to `transaction` rather than `update`: content applied
+ * programmatically — loading a note, applying an assistant version — is sent
+ * with `emitUpdate: false` so it doesn't trip the autosave, and so never
+ * reaches an `update` listener. Only an actual flip re-renders the caller;
+ * every other transaction just reads a cheap flag.
+ *
+ * No editor reads as empty: callers use this to choose between offering to
+ * write a draft and offering to improve one, and with no document mounted
+ * there is nothing to improve.
+ */
+export function useEditorIsEmpty(editor: Editor | null): boolean {
+  const [isEmpty, setIsEmpty] = useState(() => readIsEmpty(editor));
+
+  useEffect(() => {
+    const sync = () => setIsEmpty(readIsEmpty(editor));
+    sync();
+    if (!editor) return;
+    editor.on('transaction', sync);
+    return () => {
+      editor.off('transaction', sync);
+    };
+  }, [editor]);
+
+  return isEmpty;
+}

--- a/types/note.ts
+++ b/types/note.ts
@@ -181,6 +181,9 @@ const transformRegisteredReportPrefill = (raw: any): RegisteredReportPrefill | n
 const isRegisteredReportDocumentType = (documentType?: string | null): boolean =>
   documentType?.trim().toUpperCase() === 'REGISTERED_REPORT';
 
+const isGrantDocumentType = (documentType?: string | null): boolean =>
+  documentType?.trim().toUpperCase() === 'GRANT';
+
 const serializeNoteJson = (value: unknown): string | undefined => {
   if (typeof value === 'string') return value;
   if (!value || typeof value !== 'object') return undefined;
@@ -269,6 +272,17 @@ export const isRegisteredReportNote = (note?: ClassifiableNote | null): boolean 
 
 export const isPublishedRegisteredReportNote = (note?: ClassifiableNote | null): boolean =>
   Boolean(note?.post?.id) && isRegisteredReportNote(note);
+
+/**
+ * A Request for Proposal — the funder's call for work, as opposed to the
+ * proposals answering it. Reads the same signals as the editor's work-type
+ * label, including `contentType`, which is where a note carrying only a post
+ * records it.
+ */
+export const isRfpNote = (note?: ClassifiableNote | null): boolean =>
+  isGrantDocumentType(note?.documentType) ||
+  isGrantDocumentType(note?.post?.documentType) ||
+  note?.post?.contentType === 'funding_request';
 
 /** Uses exact legacy IDs because ordinary preprints also used DISCUSSION before rollout. */
 export const isChangelogNote = (note?: ClassifiableChangelogNote | null): boolean => {


### PR DESCRIPTION
The notebook assistant's empty chat screen gave a new user nothing to act on — the first message was theirs to invent. It now carries preset cards.

Picking one **loads an editable starting point into the composer and focuses it**; it does not send. The generic half of an instruction is the easy half, and the details only the author knows (the deadline, the section, the sub-field) go in before the assistant sees them.

### Which cards appear

| Note | Cards |
|---|---|
| Proposal, empty | Draft proposal · Help me research · Find me funding |
| Proposal, written | Edit proposal · Help me research · Find me funding |
| RFP, empty or written | Draft RFP · Help me research |

An RFP is written by the side handing out the money, so it takes neither the funding search nor the proposal-shaped review — only the call itself and the field it is calling into. Its writing card stays "Draft RFP" in both states, so its message is worded to work on a blank note or a half-written one.

The funding preset asks for open RFPs specifically, since that is the only funding opportunity the site carries.

### Opening on a new chat

The panel used to auto-select the note's most recent chat on open, which landed the reader in the middle of whatever they last asked — and made the presets the one screen they'd rarely see. That effect is gone; `null` already meant the new-chat screen, so opening is now a matter of not doing anything.

Earlier chats stay one click away in the picker, and a selection still survives closing the panel. Only a fresh visit or a note switch resets it.

### Notes for review

- **`useEditorIsEmpty` subscribes to `transaction`, not `update`.** The notebook applies content programmatically with `emitUpdate: false` so it never trips the autosave — loading a note, applying an assistant version — and every one of those would be invisible to an `update` listener. Only an actual flip re-renders; every other transaction just reads a cheap flag.
- **`isRfpNote` joins the existing note classifiers** in `types/note.ts`, reading the same signals as the editor's own work-type label.
- **The send path is untouched.** A preset's text becomes a draft like any typed one. The only plumbing is `ChatComposer`'s textarea ref moving up to the panel, so a preset can hand the caret over after filling the box.

### Verification

Driven in the browser against a mock backend covering all four note shapes (proposal/RFP × empty/written):

- each note showed exactly the cards above, agreeing with the editor's own work-type header (`Proposal` / `Request for Proposal`)
- clicking a preset produced **no network call** — only the chat-listing GET that was already in flight — confirming prefill is inert
- the prefilled text sends normally afterwards and clears the composer
- checked docked at 1440px and as a sheet at 375px

And on a note with existing chat history: first open showed the presets rather than the last chat, the picker still opened that chat, closing and reopening the panel kept it, and a page reload came back to the presets.

Typecheck, eslint and prettier clean.

### Not included

An audit turned up seven places elsewhere in the app where user-facing copy still says "grant" rather than RFP (the RFP publishing form's two validation messages, a profile tooltip, the search page title and meta, the verify-identity modal, and a feed image alt). None are in the assistant. Left for a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
