### PR TITLE
Let a notebook chat choose the model that answers it

### DIFF
--- a/components/Notebook/AgentChat/AgentChatPanel.tsx
+++ b/components/Notebook/AgentChat/AgentChatPanel.tsx
@@ -9,6 +9,7 @@ import { Loader } from '@/components/ui/Loader';
 import { cn } from '@/utils/styles';
 import { useNotebookContext } from '@/contexts/NotebookContext';
 import { useNotebookChat, useNotebookChatList, type SendOutcome } from '@/hooks/useNotebookChat';
+import { useAgentModels } from '@/hooks/useAgentModels';
 import { MAX_AGENT_CHAT_WIDTH, MIN_AGENT_CHAT_WIDTH } from '@/hooks/useAgentChatWidth';
 import { useNoteVersionSocket } from '@/hooks/useNoteVersionSocket';
 import { NoteService } from '@/services/note.service';
@@ -24,6 +25,7 @@ import { belowMobileTopBar } from '../mobileChromeOffsets';
 import { NoteReviewControls } from '../NoteReview/NoteReviewControls';
 import { ChatComposer, type ComposerNotice } from './ChatComposer';
 import { ChatPicker } from './ChatPicker';
+import { ModelPicker } from './ModelPicker';
 import { ChatSources, collectChatSources } from './ChatSources';
 import { ChatTranscript } from './ChatTranscript';
 import { Logo } from '@/components/ui/Logo';
@@ -247,6 +249,8 @@ export function AgentChatPanel({
     initialChat,
   });
 
+  const models = useAgentModels(open);
+
   const switchChat = useCallback((nextChatId: number | null) => {
     setSelectedChatId(nextChatId);
     setInitialChat(null);
@@ -346,6 +350,24 @@ export function AgentChatPanel({
     []
   );
 
+  // ---- model selection ----
+  // The backend pins a conversation to the model of its first turn and rejects
+  // any later switch, so a chat that has run reports its model rather than
+  // offering one. Executions arrive oldest → newest, matching how the server
+  // resolves the pin.
+  const pinnedModel = useMemo(
+    () => chatState.chat?.executions.find((execution) => execution.model)?.model ?? '',
+    [chatState.chat]
+  );
+  const activeModel = pinnedModel || models.selectedRef;
+  // Live mirror of what a send should submit. Once pinned there is nothing to
+  // choose, so the request carries no `model` at all — repeating the pinned ref
+  // would only be a chance to disagree with the server about it. Held in a ref
+  // so the queued-first-message effect reads the current value without joining
+  // its deps and re-running.
+  const submitModelRef = useRef('');
+  submitModelRef.current = pinnedModel ? '' : models.selectedRef;
+
   const handleSend = useCallback(async () => {
     const text = draft.trim();
     if (!text) return;
@@ -376,7 +398,7 @@ export function AgentChatPanel({
       return;
     }
 
-    const outcome = await chatState.send(text);
+    const outcome = await chatState.send(text, submitModelRef.current || undefined);
     if (outcome.ok) {
       if (isCurrentTarget(target)) {
         updateDraft('');
@@ -397,7 +419,7 @@ export function AgentChatPanel({
     const text = queuedMessage;
     const target = targetRef.current;
     setQueuedMessage(null);
-    sendToChat(text).then((outcome) => {
+    sendToChat(text, submitModelRef.current || undefined).then((outcome) => {
       if (outcome.ok) return;
       if (isCurrentTarget(target)) {
         setNotice(noticeFromOutcome(outcome));
@@ -1141,6 +1163,19 @@ export function AgentChatPanel({
         canStop={canStop}
         disabled={composerDisabled}
         notice={notice}
+        modelPicker={
+          // No catalog, no control: a failed or gated load leaves the composer
+          // exactly as it was, and the turn runs the server's default.
+          models.access === 'ok' && activeModel ? (
+            <ModelPicker
+              models={models.models}
+              value={activeModel}
+              onChange={models.selectModel}
+              locked={pinnedModel !== ''}
+              disabled={composerDisabled}
+            />
+          ) : null
+        }
       />
     </aside>
   );

--- a/components/Notebook/AgentChat/ChatComposer.tsx
+++ b/components/Notebook/AgentChat/ChatComposer.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useRef, type KeyboardEvent } from 'react';
+import { useEffect, useRef, type KeyboardEvent, type ReactNode } from 'react';
 import { ArrowUp, Square } from 'lucide-react';
 import { cn } from '@/utils/styles';
 import { MAX_CHAT_MESSAGE_LENGTH } from '@/types/notebookChat';
@@ -27,6 +27,12 @@ interface ChatComposerProps {
   readonly disabled: boolean;
   readonly notice: ComposerNotice | null;
   readonly placeholder?: string;
+  /**
+   * Model selector, seated on the composer's action row opposite send. A slot
+   * rather than a prop bundle so the composer stays ignorant of the catalog —
+   * it only owns where the control sits.
+   */
+  readonly modelPicker?: ReactNode;
 }
 
 const COUNTER_THRESHOLD = MAX_CHAT_MESSAGE_LENGTH - 1000;
@@ -45,6 +51,7 @@ export function ChatComposer({
   disabled,
   notice,
   placeholder = 'Ask the assistant…',
+  modelPicker,
 }: ChatComposerProps) {
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
@@ -80,7 +87,7 @@ export function ChatComposer({
       )}
       <div
         className={cn(
-          'flex items-end gap-2 rounded-lg border border-gray-200 bg-white px-3 py-2 transition-all',
+          'rounded-lg border border-gray-200 bg-white px-3 py-2 transition-all',
           'focus-within:border-primary-500 focus-within:ring-2 focus-within:ring-primary-500',
           disabled && 'opacity-60'
         )}
@@ -95,35 +102,40 @@ export function ChatComposer({
           disabled={disabled}
           placeholder={placeholder}
           aria-label="Message the assistant"
-          className="max-h-40 min-h-[24px] flex-1 resize-none bg-transparent text-sm text-gray-800 placeholder:text-gray-500 focus:outline-none disabled:cursor-not-allowed"
+          className="block max-h-40 min-h-[24px] w-full resize-none bg-transparent text-sm text-gray-800 placeholder:text-gray-500 focus:outline-none disabled:cursor-not-allowed"
         />
-        {busy && canStop ? (
-          <button
-            type="button"
-            onClick={onStop}
-            title="Stop the assistant"
-            className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full border border-gray-300 text-gray-600 transition-colors hover:border-red-300 hover:bg-red-50 hover:text-red-600"
-          >
-            <Square className="h-3.5 w-3.5 fill-current" aria-hidden="true" />
-            <span className="sr-only">Stop</span>
-          </button>
-        ) : (
-          <button
-            type="button"
-            onClick={onSend}
-            disabled={!canSend}
-            title="Send message"
-            className={cn(
-              'flex h-8 w-8 shrink-0 items-center justify-center rounded-full transition-colors',
-              canSend
-                ? 'bg-primary-500 text-white hover:bg-primary-600'
-                : 'cursor-not-allowed bg-gray-100 text-gray-400'
-            )}
-          >
-            <ArrowUp className="h-4 w-4" aria-hidden="true" />
-            <span className="sr-only">Send</span>
-          </button>
-        )}
+        {/* Action row. The model control takes the slack and truncates; send
+            keeps its size and stays pinned right where it has always been. */}
+        <div className="mt-1 flex items-center justify-between gap-2">
+          <div className="min-w-0 flex-1">{modelPicker}</div>
+          {busy && canStop ? (
+            <button
+              type="button"
+              onClick={onStop}
+              title="Stop the assistant"
+              className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full border border-gray-300 text-gray-600 transition-colors hover:border-red-300 hover:bg-red-50 hover:text-red-600"
+            >
+              <Square className="h-3.5 w-3.5 fill-current" aria-hidden="true" />
+              <span className="sr-only">Stop</span>
+            </button>
+          ) : (
+            <button
+              type="button"
+              onClick={onSend}
+              disabled={!canSend}
+              title="Send message"
+              className={cn(
+                'flex h-8 w-8 shrink-0 items-center justify-center rounded-full transition-colors',
+                canSend
+                  ? 'bg-primary-500 text-white hover:bg-primary-600'
+                  : 'cursor-not-allowed bg-gray-100 text-gray-400'
+              )}
+            >
+              <ArrowUp className="h-4 w-4" aria-hidden="true" />
+              <span className="sr-only">Send</span>
+            </button>
+          )}
+        </div>
       </div>
       {value.length >= COUNTER_THRESHOLD && (
         <p className="mt-1 text-right text-[11px] text-gray-400">

--- a/components/Notebook/AgentChat/ModelPicker.tsx
+++ b/components/Notebook/AgentChat/ModelPicker.tsx
@@ -1,0 +1,119 @@
+'use client';
+
+import { useRef, useState } from 'react';
+import { Check, ChevronDown, Cpu } from 'lucide-react';
+import { cn } from '@/utils/styles';
+import { useOutsidePointerDown } from '@/hooks/useOutsidePointerDown';
+import { modelLabel, type AgentModel } from '@/types/notebookChat';
+
+interface ModelPickerProps {
+  readonly models: AgentModel[];
+  /** Ref in effect: the user's choice, or the model a started chat is pinned to. */
+  readonly value: string;
+  readonly onChange: (ref: string) => void;
+  /**
+   * The chat already ran a turn. The backend pins a conversation to its first
+   * turn's model and rejects a switch, so the control reads out the pinned
+   * model instead of offering choices that would 400.
+   */
+  readonly locked: boolean;
+  readonly disabled?: boolean;
+}
+
+/**
+ * Model selector for the composer. Sits beside the send button because the
+ * choice belongs to the message being written — it applies to the next turn,
+ * and only to a chat's first one.
+ *
+ * A single-model catalog and a pinned chat both render as a static label: with
+ * nothing to choose, a menu would be a control that can't do anything.
+ */
+export function ModelPicker({ models, value, onChange, locked, disabled }: ModelPickerProps) {
+  const [open, setOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+  useOutsidePointerDown(containerRef, () => setOpen(false), open);
+
+  const label = modelLabel(models, value);
+  const interactive = !locked && !disabled && models.length > 1;
+
+  if (!interactive) {
+    return (
+      <span
+        title={
+          locked
+            ? `This chat is running on ${label}. Start a new chat to use a different model.`
+            : label
+        }
+        className="flex min-w-0 items-center gap-1 px-1 text-xs text-gray-500"
+      >
+        <Cpu className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+        <span className="sr-only">Model:</span>
+        <span className="truncate">{label}</span>
+      </span>
+    );
+  }
+
+  return (
+    <div ref={containerRef} className="relative min-w-0">
+      <button
+        type="button"
+        onClick={() => setOpen((current) => !current)}
+        aria-expanded={open}
+        aria-haspopup="listbox"
+        className="flex min-w-0 items-center gap-1 rounded-md px-1 py-0.5 text-xs text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-700"
+      >
+        <Cpu className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+        <span className="sr-only">Model:</span>
+        <span className="truncate">{label}</span>
+        <ChevronDown
+          className={cn('h-3 w-3 shrink-0 transition-transform', open && 'rotate-180')}
+          aria-hidden="true"
+        />
+      </button>
+
+      {open && (
+        // Opens upward: the composer is pinned to the bottom of the panel.
+        <div
+          role="listbox"
+          className="animate-in absolute bottom-full left-0 z-10 mb-1 max-h-72 w-64 overflow-y-auto rounded-lg border border-gray-200 bg-white py-1 shadow-lg"
+        >
+          {models.map((model) => {
+            const selected = model.ref === value;
+            return (
+              <button
+                key={model.ref}
+                type="button"
+                role="option"
+                aria-selected={selected}
+                onClick={() => {
+                  setOpen(false);
+                  onChange(model.ref);
+                }}
+                className={cn(
+                  'flex w-full items-start gap-2 px-3 py-2 text-left transition-colors hover:bg-gray-50',
+                  selected && 'bg-primary-50/60'
+                )}
+              >
+                <Check
+                  className={cn(
+                    'mt-0.5 h-3.5 w-3.5 shrink-0 text-primary-500',
+                    !selected && 'invisible'
+                  )}
+                  aria-hidden="true"
+                />
+                <span className="min-w-0 flex-1">
+                  <span className="block truncate text-sm font-medium text-gray-800">
+                    {model.label}
+                  </span>
+                  {model.description && (
+                    <span className="mt-0.5 block text-xs text-gray-500">{model.description}</span>
+                  )}
+                </span>
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/hooks/useAgentModels.ts
+++ b/hooks/useAgentModels.ts
@@ -1,0 +1,97 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { AgentModelService, chatErrorStatus } from '@/services/notebookChat.service';
+import type { AgentModel, AvailableModels } from '@/types/notebookChat';
+
+/** The user's standing choice for chats they start. Per browser, like the panel width. */
+const STORAGE_KEY = 'notebook:agent-chat-model';
+
+export type AgentModelsAccess = 'loading' | 'ok' | 'hidden' | 'error';
+
+/**
+ * Process-wide cache. The catalog is a server-side constant for the life of a
+ * deployment, so every mount shares one fetch. Only successes are cached — a
+ * failed load has to stay retryable on the next mount.
+ */
+let cachedCatalog: AvailableModels | null = null;
+let inFlight: Promise<AvailableModels> | null = null;
+
+function loadCatalog(): Promise<AvailableModels> {
+  if (cachedCatalog) return Promise.resolve(cachedCatalog);
+  if (!inFlight) {
+    inFlight = AgentModelService.listModels()
+      .then((catalog) => {
+        cachedCatalog = catalog;
+        return catalog;
+      })
+      .finally(() => {
+        inFlight = null;
+      });
+  }
+  return inFlight;
+}
+
+export interface UseAgentModelsResult {
+  models: AgentModel[];
+  /** Ref the backend runs for a turn carrying no selection; empty until loaded. */
+  defaultRef: string;
+  access: AgentModelsAccess;
+  /** The ref a new chat should be started with — the user's choice, else the default. */
+  selectedRef: string;
+  selectModel: (ref: string) => void;
+}
+
+/**
+ * The selectable model catalog plus the user's standing preference.
+ *
+ * The two belong together: a stored preference is only meaningful against the
+ * roster that validates it, since the catalog is credential-aware and a model
+ * can disappear between sessions. 401/403/404 collapse to `hidden` the same
+ * way the chat listing does — the server-side gate is authoritative and the
+ * picker simply doesn't appear.
+ */
+export function useAgentModels(enabled: boolean): UseAgentModelsResult {
+  const [catalog, setCatalog] = useState<AvailableModels | null>(cachedCatalog);
+  const [access, setAccess] = useState<AgentModelsAccess>(cachedCatalog ? 'ok' : 'loading');
+  const [preference, setPreference] = useState('');
+
+  // Read after mount, never during initialization: localStorage is unavailable
+  // on the server and a differing first client render would hydrate-mismatch.
+  useEffect(() => {
+    setPreference(window.localStorage.getItem(STORAGE_KEY) ?? '');
+  }, []);
+
+  useEffect(() => {
+    if (!enabled || cachedCatalog) return;
+    let active = true;
+    loadCatalog()
+      .then((data) => {
+        if (!active) return;
+        setCatalog(data);
+        setAccess('ok');
+      })
+      .catch((error: unknown) => {
+        if (!active) return;
+        const status = chatErrorStatus(error);
+        setAccess(status === 401 || status === 403 || status === 404 ? 'hidden' : 'error');
+      });
+    return () => {
+      active = false;
+    };
+  }, [enabled]);
+
+  const selectModel = useCallback((ref: string) => {
+    setPreference(ref);
+    window.localStorage.setItem(STORAGE_KEY, ref);
+  }, []);
+
+  const models = catalog?.models ?? [];
+  const defaultRef = catalog?.default ?? '';
+  // A stored ref can name a model the catalog no longer offers (retired, or
+  // its provider's credentials removed). Fall back to the server default
+  // rather than submitting a selection the API would reject.
+  const selectedRef = models.some((model) => model.ref === preference) ? preference : defaultRef;
+
+  return { models, defaultRef, access, selectedRef, selectModel };
+}

--- a/hooks/useNotebookChat.ts
+++ b/hooks/useNotebookChat.ts
@@ -255,7 +255,11 @@ export interface UseNotebookChatResult {
   isFinishing: boolean;
   pendingSend: PendingSend | null;
   socketStatus: ChatSocketStatus;
-  send: (text: string) => Promise<SendOutcome>;
+  /**
+   * `model` is honoured on a chat's first turn only — the conversation pins
+   * that model and the backend 400s a later turn naming a different one.
+   */
+  send: (text: string, model?: string) => Promise<SendOutcome>;
   cancel: () => Promise<void>;
   rename: (title: string) => Promise<boolean>;
   refetch: () => void;
@@ -467,12 +471,12 @@ export function useNotebookChat({
   });
 
   const send = useCallback(
-    async (text: string): Promise<SendOutcome> => {
+    async (text: string, model?: string): Promise<SendOutcome> => {
       if (noteId == null || chatId == null) return { ok: false, reason: 'error' };
       const epoch = epochRef.current;
       setPendingSend({ text, executionId: null });
       try {
-        const response = await NotebookChatService.sendMessage(noteId, chatId, text);
+        const response = await NotebookChatService.sendMessage(noteId, chatId, text, model);
         if (epoch === epochRef.current) {
           setPendingSend({ text, executionId: response.execution_id });
           fetchChat('live');

--- a/services/notebookChat.service.ts
+++ b/services/notebookChat.service.ts
@@ -1,6 +1,7 @@
 import { ApiClient } from './client';
 import { ApiError } from './types';
 import type {
+  AvailableModels,
   CancelTurnResponse,
   NotebookChat,
   NotebookChatListItem,
@@ -46,10 +47,21 @@ export class NotebookChatService {
    * Starts an asynchronous turn. 202 means the user message is already recorded
    * server-side. Throws ApiError with status 409 while a previous turn is still
    * running (one turn per chat), 400 for empty/oversized messages.
+   *
+   * `model` names a ref from {@link AgentModelService.listModels} and only
+   * takes effect on a chat's first turn — the conversation is pinned to that
+   * model, and a later turn naming a different one is a 400. Omit it to run
+   * the server's configured default.
    */
-  static async sendMessage(noteId: ID, chatId: ID, message: string): Promise<SendMessageResponse> {
+  static async sendMessage(
+    noteId: ID,
+    chatId: ID,
+    message: string,
+    model?: string
+  ): Promise<SendMessageResponse> {
     return ApiClient.post<SendMessageResponse>(`${this.basePath(noteId)}${chatId}/messages/`, {
       message,
+      ...(model ? { model } : {}),
     });
   }
 
@@ -67,6 +79,21 @@ export class NotebookChatService {
    */
   static async cancelTurn(noteId: ID, chatId: ID): Promise<CancelTurnResponse> {
     return ApiClient.post<CancelTurnResponse>(`${this.basePath(noteId)}${chatId}/cancel/`);
+  }
+}
+
+/**
+ * The selectable model catalog. Not note-scoped: one server-curated roster
+ * serves every research_ai workflow that takes a model selection, and a
+ * submitted `model` must name one of its refs.
+ */
+export class AgentModelService {
+  /**
+   * Gated like the workflows it feeds — 401/403/404 mean this user has no
+   * model selection to make, not that the request was malformed.
+   */
+  static async listModels(): Promise<AvailableModels> {
+    return ApiClient.get<AvailableModels>('/api/research_ai/models/');
   }
 }
 

--- a/types/notebookChat.ts
+++ b/types/notebookChat.ts
@@ -134,6 +134,13 @@ export interface ChatExecution {
   id: number;
   attempt: number;
   status: ExecutionStatus;
+  /**
+   * Model ref this turn ran on. A conversation is pinned to the model of its
+   * first turn, so this is also how the client learns which model a chat is
+   * locked to. Absent on backends predating model selection, empty on turns
+   * recorded before the chat had one.
+   */
+  model?: string;
   /** The user message that started this turn. */
   trigger_message_id: number | null;
   retry_of_id: number | null;
@@ -280,6 +287,38 @@ export function isChatStreamSocketEvent(event: ChatSocketEvent): event is ChatSt
             typeof delta.label === 'string'))
     )
   );
+}
+
+/**
+ * One selectable generator model from `GET /api/research_ai/models/`.
+ *
+ * The catalog is server-curated and credential-aware — a model whose provider
+ * has no credentials configured is simply absent from the response — so the
+ * client renders whatever comes back and never keeps a roster of its own.
+ */
+export interface AgentModel {
+  /** Canonical provider-prefixed ref (`<provider>:<model id>`); the wire value. */
+  ref: string;
+  label: string;
+  description: string;
+  provider: string;
+}
+
+export interface AvailableModels {
+  /** Ref the backend runs for a turn submitted without a selection. */
+  default: string;
+  models: AgentModel[];
+}
+
+/**
+ * Display name for a ref. A pinned ref can outlive the catalog (a model
+ * retired, or its provider's credentials removed), so fall back to the bare
+ * model id rather than rendering an empty control.
+ */
+export function modelLabel(models: readonly AgentModel[], ref: string): string {
+  const match = models.find((model) => model.ref === ref);
+  if (match) return match.label;
+  return ref.split(':').slice(1).join(':') || ref;
 }
 
 export const MAX_CHAT_MESSAGE_LENGTH = 20_000;


### PR DESCRIPTION
Backend PR #4040 opened three doors: a curated, credential-aware catalog at GET /api/research_ai/models/, an optional `model` on a chat's message POST, and the model ref on every execution. This walks through them.

The catalog and the user's stored preference live in one hook because neither is meaningful alone: the roster is credential-aware, so a ref saved last session can name a model that has since disappeared, and it falls back to the server default rather than submitting a selection the API would reject.

A conversation is pinned to its first turn's model server-side, so the picker becomes a readout once a chat has run, and later turns carry no `model` at all — repeating the pinned ref would only be a chance to disagree with the server about it.

The endpoint is gated like the workflows it feeds. A 401/403 leaves the composer exactly as it was and the turn runs the configured default, rather than offering a control that would fail on send.