### PR TITLE
Let the notebook assistant pick its model and effort

### DIFF
--- a/components/Notebook/AgentChat/AgentChatPanel.tsx
+++ b/components/Notebook/AgentChat/AgentChatPanel.tsx
@@ -925,8 +925,17 @@ export function AgentChatPanel({
   }, [chatState.chat, chatState.pendingSend, activeTab]);
 
   // ---- derived composer state ----
+  // Sending before the catalog lands would run the turn on the server default
+  // and pin the conversation to it, silently losing the user's chosen model
+  // with no way back. Busy rather than disabled: the draft stays editable, only
+  // send waits. A catalog that fails resolves to `unavailable`, which sends on
+  // the server default by design.
   const composerBusy =
-    chatState.isBusy || chatState.isFinishing || creatingChat || queuedMessage != null;
+    chatState.isBusy ||
+    chatState.isFinishing ||
+    creatingChat ||
+    queuedMessage != null ||
+    modelSelection.status === 'loading';
   // Stop is only offered once something cancellable exists server-side. While
   // the message POST is still in flight or the chat is being created, cancel
   // would no-op and the turn would start anyway.

--- a/components/Notebook/AgentChat/AgentChatPanel.tsx
+++ b/components/Notebook/AgentChat/AgentChatPanel.tsx
@@ -9,6 +9,7 @@ import { Loader } from '@/components/ui/Loader';
 import { cn } from '@/utils/styles';
 import { useNotebookContext } from '@/contexts/NotebookContext';
 import { useNotebookChat, useNotebookChatList, type SendOutcome } from '@/hooks/useNotebookChat';
+import { useAgentModelSelection } from '@/hooks/useAgentModelSelection';
 import { MAX_AGENT_CHAT_WIDTH, MIN_AGENT_CHAT_WIDTH } from '@/hooks/useAgentChatWidth';
 import { useNoteVersionSocket } from '@/hooks/useNoteVersionSocket';
 import { NoteService } from '@/services/note.service';
@@ -18,6 +19,7 @@ import {
   MAX_CHAT_TITLE_LENGTH,
   type NotebookChat,
 } from '@/types/notebookChat';
+import type { GenerationRequest } from '@/types/notebookModels';
 import { ENDOWMENT_PROMO_BANNER_FEATURE } from '@/app/layouts/components/EndowmentPromoBanner';
 import { useDismissableFeature } from '@/hooks/useDismissableFeature';
 import { useEditorIsEmpty } from '@/hooks/useEditorIsEmpty';
@@ -28,6 +30,7 @@ import { ChatPicker } from './ChatPicker';
 import { ChatPresets } from './ChatPresets';
 import { ChatSources, collectChatSources } from './ChatSources';
 import { ChatTranscript } from './ChatTranscript';
+import { ModelControls } from './ModelControls';
 import { Logo } from '@/components/ui/Logo';
 import {
   beginNoteDiffReview,
@@ -36,6 +39,15 @@ import {
 } from '../NoteReview/noteDiffOverlay';
 
 type PanelTab = 'chat' | 'sources';
+
+/**
+ * A first message waiting on the chat it will start, holding the model choice
+ * it was composed under so a later change can't retarget a send in flight.
+ */
+interface QueuedMessage {
+  readonly text: string;
+  readonly generation: GenerationRequest;
+}
 
 /** Pixels per arrow key press while the resize divider has focus. */
 const RESIZE_KEY_STEP = 24;
@@ -262,13 +274,22 @@ export function AgentChatPanel({
     setInitialChat(null);
   }, []);
 
+  // ---- model selection ----
+  // The catalog loads with the panel. A chat that has already run a turn is
+  // locked to the model it started on, and reports it here; until then the
+  // browser-level preference decides.
+  const modelSelection = useAgentModelSelection({
+    enabled: open,
+    pinnedRef: chatState.pinnedModelRef,
+  });
+
   // ---- drafts (per chat, surviving switches and failed sends) ----
   const draftsRef = useRef(new Map<string, string>());
   const draftKey = selectedChatId == null ? 'new' : String(selectedChatId);
   const [draft, setDraft] = useState('');
   const [notice, setNotice] = useState<ComposerNotice | null>(null);
   /** First message for a chat we just created, sent once the chat is live. */
-  const [queuedMessage, setQueuedMessage] = useState<string | null>(null);
+  const [queuedMessage, setQueuedMessage] = useState<QueuedMessage | null>(null);
   const [creatingChat, setCreatingChat] = useState(false);
   /** Identity of the latest creation, so a stale settle can't clear its flag. */
   const creationSeqRef = useRef(0);
@@ -366,6 +387,9 @@ export function AgentChatPanel({
     if (!text) return;
     setNotice(null);
     const target = targetRef.current;
+    // Captured before the awaits: the turn runs on what was selected when the
+    // user pressed send, not on whatever the picker says by the time it lands.
+    const generation = modelSelection.request;
 
     if (selectedChatId == null) {
       // Default flow: create untitled, send the first message; the refetch
@@ -387,11 +411,11 @@ export function AgentChatPanel({
       draftsRef.current.delete('new');
       setInitialChat(created);
       setSelectedChatId(created.conversation_id);
-      setQueuedMessage(text);
+      setQueuedMessage({ text, generation });
       return;
     }
 
-    const outcome = await chatState.send(text);
+    const outcome = await chatState.send(text, generation);
     if (outcome.ok) {
       if (isCurrentTarget(target)) {
         updateDraft('');
@@ -403,16 +427,24 @@ export function AgentChatPanel({
       // Keep the draft on any failure.
       setNotice(noticeFromOutcome(outcome));
     }
-  }, [draft, selectedChatId, list, chatState, updateDraft, isCurrentTarget]);
+  }, [
+    draft,
+    selectedChatId,
+    list,
+    chatState,
+    modelSelection.request,
+    updateDraft,
+    isCurrentTarget,
+  ]);
 
   // Fire the queued first message once the freshly created chat is live.
   const sendToChat = chatState.send;
   useEffect(() => {
     if (queuedMessage == null || selectedChatId == null || chatState.access !== 'ok') return;
-    const text = queuedMessage;
+    const { text, generation } = queuedMessage;
     const target = targetRef.current;
     setQueuedMessage(null);
-    sendToChat(text).then((outcome) => {
+    sendToChat(text, generation).then((outcome) => {
       if (outcome.ok) return;
       if (isCurrentTarget(target)) {
         setNotice(noticeFromOutcome(outcome));
@@ -1166,6 +1198,17 @@ export function AgentChatPanel({
         canStop={canStop}
         disabled={composerDisabled}
         notice={notice}
+        toolbar={
+          <ModelControls
+            models={modelSelection.models}
+            model={modelSelection.model}
+            pinned={modelSelection.pinned}
+            options={modelSelection.options}
+            onSelectModel={modelSelection.selectModel}
+            onChangeOptions={modelSelection.setOptions}
+            disabled={composerDisabled}
+          />
+        }
       />
     </aside>
   );

--- a/components/Notebook/AgentChat/ChatComposer.tsx
+++ b/components/Notebook/AgentChat/ChatComposer.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, type KeyboardEvent, type RefObject } from 'react';
+import { useEffect, type KeyboardEvent, type ReactNode, type RefObject } from 'react';
 import { ArrowUp, Square } from 'lucide-react';
 import { cn } from '@/utils/styles';
 import { MAX_CHAT_MESSAGE_LENGTH } from '@/types/notebookChat';
@@ -32,6 +32,12 @@ interface ChatComposerProps {
    * draft and then has to hand the caret over to the box the user edits.
    */
   readonly textareaRef: RefObject<HTMLTextAreaElement | null>;
+  /**
+   * Controls seated on the action row, left of the send button — the model
+   * picker today. A slot rather than props so the composer stays ignorant of
+   * what is being configured and owns only where it sits.
+   */
+  readonly toolbar?: ReactNode;
 }
 
 const COUNTER_THRESHOLD = MAX_CHAT_MESSAGE_LENGTH - 1000;
@@ -51,6 +57,7 @@ export function ChatComposer({
   notice,
   placeholder = 'Ask the assistant…',
   textareaRef,
+  toolbar,
 }: ChatComposerProps) {
   // Grow with content up to ~6 lines, then scroll.
   useEffect(() => {
@@ -82,9 +89,13 @@ export function ChatComposer({
           {notice.text}
         </output>
       )}
+      {/* Two rows rather than one: the message sits above its own controls, so
+          the toolbar can grow without the send button drifting off the text.
+          Positioned, because the toolbar's menus open against this box —
+          anchored to their own buttons they would run off a 360px panel. */}
       <div
         className={cn(
-          'flex items-end gap-2 rounded-lg border border-gray-200 bg-white px-3 py-2 transition-all',
+          'relative rounded-lg border border-gray-200 bg-white px-3 py-2 transition-all',
           'focus-within:border-primary-500 focus-within:ring-2 focus-within:ring-primary-500',
           disabled && 'opacity-60'
         )}
@@ -99,35 +110,38 @@ export function ChatComposer({
           disabled={disabled}
           placeholder={placeholder}
           aria-label="Message the assistant"
-          className="max-h-40 min-h-[24px] flex-1 resize-none bg-transparent text-sm text-gray-800 placeholder:text-gray-500 focus:outline-none disabled:cursor-not-allowed"
+          className="block max-h-40 min-h-[24px] w-full resize-none bg-transparent text-sm text-gray-800 placeholder:text-gray-500 focus:outline-none disabled:cursor-not-allowed"
         />
-        {busy && canStop ? (
-          <button
-            type="button"
-            onClick={onStop}
-            title="Stop the assistant"
-            className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full border border-gray-300 text-gray-600 transition-colors hover:border-red-300 hover:bg-red-50 hover:text-red-600"
-          >
-            <Square className="h-3.5 w-3.5 fill-current" aria-hidden="true" />
-            <span className="sr-only">Stop</span>
-          </button>
-        ) : (
-          <button
-            type="button"
-            onClick={onSend}
-            disabled={!canSend}
-            title="Send message"
-            className={cn(
-              'flex h-8 w-8 shrink-0 items-center justify-center rounded-full transition-colors',
-              canSend
-                ? 'bg-primary-500 text-white hover:bg-primary-600'
-                : 'cursor-not-allowed bg-gray-100 text-gray-400'
-            )}
-          >
-            <ArrowUp className="h-4 w-4" aria-hidden="true" />
-            <span className="sr-only">Send</span>
-          </button>
-        )}
+        <div className="mt-1.5 flex items-center gap-2">
+          <div className="min-w-0 flex-1">{toolbar}</div>
+          {busy && canStop ? (
+            <button
+              type="button"
+              onClick={onStop}
+              title="Stop the assistant"
+              className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full border border-gray-300 text-gray-600 transition-colors hover:border-red-300 hover:bg-red-50 hover:text-red-600"
+            >
+              <Square className="h-3.5 w-3.5 fill-current" aria-hidden="true" />
+              <span className="sr-only">Stop</span>
+            </button>
+          ) : (
+            <button
+              type="button"
+              onClick={onSend}
+              disabled={!canSend}
+              title="Send message"
+              className={cn(
+                'flex h-8 w-8 shrink-0 items-center justify-center rounded-full transition-colors',
+                canSend
+                  ? 'bg-primary-500 text-white hover:bg-primary-600'
+                  : 'cursor-not-allowed bg-gray-100 text-gray-400'
+              )}
+            >
+              <ArrowUp className="h-4 w-4" aria-hidden="true" />
+              <span className="sr-only">Send</span>
+            </button>
+          )}
+        </div>
       </div>
       {value.length >= COUNTER_THRESHOLD && (
         <p className="mt-1 text-right text-[11px] text-gray-400">

--- a/components/Notebook/AgentChat/ModelControls.tsx
+++ b/components/Notebook/AgentChat/ModelControls.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useRef, useState, type ReactNode } from 'react';
+import { useEffect, useRef, useState, type ReactNode } from 'react';
 import { Check, ChevronDown, Gauge, Lock, Sparkles } from 'lucide-react';
 import { cn } from '@/utils/styles';
 import { Slider } from '@/components/ui/Slider';
@@ -64,6 +64,18 @@ export function ModelControls({
   const containerRef = useRef<HTMLDivElement>(null);
   useOutsidePointerDown(containerRef, () => setOpenMenu(null), openMenu != null);
 
+  // Escape closes the open menu. Bound to the document rather than the wrapper
+  // so the wrapper stays a plain layout div — and so it still fires once focus
+  // has left the menu.
+  useEffect(() => {
+    if (openMenu == null) return;
+    const closeOnEscape = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') setOpenMenu(null);
+    };
+    document.addEventListener('keydown', closeOnEscape);
+    return () => document.removeEventListener('keydown', closeOnEscape);
+  }, [openMenu]);
+
   if (!model) return null;
 
   const effortLevels = availableEffortLevels(model, options.thinking);
@@ -84,16 +96,7 @@ export function ModelControls({
     // Deliberately not positioned: both menus open against the composer box
     // (see ChatComposer), which is wider than this row and wider still than
     // either button — anchored to a button they would run off the panel.
-    <div
-      ref={containerRef}
-      className="flex items-center gap-1"
-      onKeyDown={(event) => {
-        if (event.key === 'Escape' && openMenu != null) {
-          event.stopPropagation();
-          setOpenMenu(null);
-        }
-      }}
-    >
+    <div ref={containerRef} className="flex items-center gap-1">
       <ControlButton
         onClick={() => toggle('model')}
         open={openMenu === 'model'}

--- a/components/Notebook/AgentChat/ModelControls.tsx
+++ b/components/Notebook/AgentChat/ModelControls.tsx
@@ -1,0 +1,450 @@
+'use client';
+
+import { useRef, useState, type ReactNode } from 'react';
+import { Check, ChevronDown, Gauge, Lock, Sparkles } from 'lucide-react';
+import { cn } from '@/utils/styles';
+import { Slider } from '@/components/ui/Slider';
+import { useOutsidePointerDown } from '@/hooks/useOutsidePointerDown';
+import {
+  availableEffortLevels,
+  clampTemperature,
+  EFFORT_LABELS,
+  formatTemperature,
+  summarizeGenerationOptions,
+  TEMPERATURE_MAX,
+  TEMPERATURE_MIN,
+  TEMPERATURE_NEUTRAL,
+  TEMPERATURE_STEP,
+  temperatureAvailable,
+  THINKING_LABELS,
+  type AgentModel,
+  type EffortLevel,
+  type GenerationOptions,
+  type ThinkingMode,
+} from '@/types/notebookModels';
+
+interface ModelControlsProps {
+  readonly models: AgentModel[];
+  /** The model the next turn runs on. Nothing renders without one. */
+  readonly model: AgentModel | null;
+  /** The open chat is committed to its model — the picker locks shut. */
+  readonly pinned: boolean;
+  readonly options: GenerationOptions;
+  readonly onSelectModel: (ref: string) => void;
+  readonly onChangeOptions: (options: GenerationOptions) => void;
+  readonly disabled: boolean;
+}
+
+type OpenMenu = 'model' | 'effort' | null;
+
+/**
+ * The composer's two dropdowns: which model answers, and how hard it works.
+ *
+ * They are separate because they lock separately. A conversation keeps the
+ * model its first turn ran on, so the model picker shuts for good once a turn
+ * has run; effort, thinking and temperature are re-read on every message, so
+ * they stay open for the life of the chat.
+ *
+ * The effort menu holds all three, temperature included — they are one
+ * decision about how much work a turn does, and only the controls the model
+ * can actually honor are drawn, in combinations it will accept. The backend
+ * refuses a temperature sent to a reasoning model, so that slider is simply
+ * absent until thinking is off.
+ */
+export function ModelControls({
+  models,
+  model,
+  pinned,
+  options,
+  onSelectModel,
+  onChangeOptions,
+  disabled,
+}: ModelControlsProps) {
+  const [openMenu, setOpenMenu] = useState<OpenMenu>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+  useOutsidePointerDown(containerRef, () => setOpenMenu(null), openMenu != null);
+
+  if (!model) return null;
+
+  const effortLevels = availableEffortLevels(model, options.thinking);
+  // A single mode is not a choice: models that always reason take no toggle,
+  // they just reason.
+  const thinkingModes = model.capabilities.thinking.length > 1 ? model.capabilities.thinking : [];
+  const showTemperature = temperatureAvailable(model, options.thinking);
+  // Claude refuses sampling params to a model that is still reasoning, which
+  // would otherwise read as a control that went missing on its own.
+  const temperatureNeedsThinkingOff =
+    !showTemperature && model.capabilities.temperature && thinkingModes.includes('disabled');
+  const hasEffortMenu = effortLevels.length > 0 || thinkingModes.length > 0 || showTemperature;
+
+  const toggle = (menu: Exclude<OpenMenu, null>) =>
+    setOpenMenu((current) => (current === menu ? null : menu));
+
+  return (
+    // Deliberately not positioned: both menus open against the composer box
+    // (see ChatComposer), which is wider than this row and wider still than
+    // either button — anchored to a button they would run off the panel.
+    <div
+      ref={containerRef}
+      className="flex items-center gap-1"
+      onKeyDown={(event) => {
+        if (event.key === 'Escape' && openMenu != null) {
+          event.stopPropagation();
+          setOpenMenu(null);
+        }
+      }}
+    >
+      <ControlButton
+        onClick={() => toggle('model')}
+        open={openMenu === 'model'}
+        disabled={disabled || pinned}
+        title={
+          pinned
+            ? `${model.label} — locked for this chat. Start a new chat to switch models.`
+            : model.label
+        }
+        icon={
+          pinned ? (
+            <Lock className="h-3 w-3 shrink-0 text-gray-400" aria-hidden="true" />
+          ) : (
+            <Sparkles className="h-3.5 w-3.5 shrink-0 text-primary-500" aria-hidden="true" />
+          )
+        }
+        srLabel={pinned ? 'Assistant model, locked for this chat:' : 'Assistant model:'}
+        className="max-w-[180px]"
+      >
+        {model.label}
+      </ControlButton>
+
+      {hasEffortMenu && (
+        <ControlButton
+          onClick={() => toggle('effort')}
+          open={openMenu === 'effort'}
+          disabled={disabled}
+          title={summarizeGenerationOptions(options).join(' · ') || 'Model defaults'}
+          icon={<Gauge className="h-3.5 w-3.5 shrink-0 text-gray-400" aria-hidden="true" />}
+          srLabel="Effort:"
+          className="max-w-[140px]"
+        >
+          {effortButtonLabel(options)}
+        </ControlButton>
+      )}
+
+      {openMenu === 'model' && (
+        <Menu label="Assistant model">
+          <div className="max-h-64 overflow-y-auto p-1">
+            {models.map((option) => (
+              <ModelRow
+                key={option.ref}
+                model={option}
+                selected={option.ref === model.ref}
+                onSelect={() => {
+                  setOpenMenu(null);
+                  onSelectModel(option.ref);
+                }}
+              />
+            ))}
+            {models.length === 0 && (
+              <p className="px-3 py-2 text-sm text-gray-500">No models are available.</p>
+            )}
+          </div>
+        </Menu>
+      )}
+
+      {openMenu === 'effort' && (
+        <Menu label="Effort">
+          <div className="space-y-3 px-3 py-3">
+            {effortLevels.length > 0 && (
+              <OptionPills
+                label="Effort"
+                value={options.effort}
+                choices={effortLevels.map((level) => ({
+                  value: level,
+                  label: EFFORT_LABELS[level],
+                }))}
+                onChange={(effort) => onChangeOptions({ effort })}
+              />
+            )}
+
+            {thinkingModes.length > 0 && (
+              <OptionPills
+                label="Extended thinking"
+                value={options.thinking}
+                choices={thinkingModes.map((mode) => ({
+                  value: mode,
+                  label: THINKING_LABELS[mode],
+                }))}
+                hint={
+                  temperatureNeedsThinkingOff
+                    ? 'Temperature is only available with thinking off.'
+                    : null
+                }
+                onChange={(thinking) => onChangeOptions({ thinking })}
+              />
+            )}
+
+            {showTemperature && (
+              <TemperatureControl
+                value={options.temperature}
+                onChange={(temperature) => onChangeOptions({ temperature })}
+              />
+            )}
+          </div>
+        </Menu>
+      )}
+    </div>
+  );
+}
+
+/**
+ * What the effort button says at a glance. Effort is the control people reach
+ * for, so it wins the label; the others only surface when nothing outranks
+ * them, and the full picture is in the button's title.
+ */
+function effortButtonLabel(options: GenerationOptions): string {
+  if (options.effort) return EFFORT_LABELS[options.effort];
+  if (options.thinking) return `Thinking ${THINKING_LABELS[options.thinking].toLowerCase()}`;
+  if (options.temperature != null) return `Temp ${formatTemperature(options.temperature)}`;
+  return 'Auto';
+}
+
+function ControlButton({
+  onClick,
+  open,
+  disabled,
+  title,
+  icon,
+  srLabel,
+  className,
+  children,
+}: {
+  readonly onClick: () => void;
+  readonly open: boolean;
+  readonly disabled: boolean;
+  readonly title: string;
+  readonly icon: ReactNode;
+  readonly srLabel: string;
+  readonly className?: string;
+  readonly children: ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      aria-haspopup="dialog"
+      aria-expanded={open}
+      title={title}
+      className={cn(
+        'flex items-center gap-1 rounded-md px-1.5 py-1 text-xs font-medium',
+        'text-gray-600 transition-colors hover:bg-gray-100 hover:text-gray-900',
+        'focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-500',
+        'disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:bg-transparent',
+        open && 'bg-gray-100 text-gray-900',
+        className
+      )}
+    >
+      {icon}
+      <span className="sr-only">{srLabel}</span>
+      <span className="truncate">{children}</span>
+      <ChevronDown
+        className={cn('h-3 w-3 shrink-0 text-gray-400 transition-transform', open && 'rotate-180')}
+        aria-hidden="true"
+      />
+    </button>
+  );
+}
+
+/**
+ * Widest the menus go. Set by the widest row the catalog produces — seven
+ * effort pills — plus a little slack, since the row scrolls rather than
+ * wraps and a few pixels short would clip the last pill rather than move it.
+ */
+const MAX_MENU_WIDTH = 'max-w-[360px]';
+
+/**
+ * Opens upward against the composer box it is positioned against: the
+ * composer sits at the bottom of the panel, and the action row alone is too
+ * narrow to seat that row of pills. Never wider than the box, so a panel
+ * dragged narrower takes the menus with it.
+ */
+function Menu({ label, children }: { readonly label: string; readonly children: ReactNode }) {
+  return (
+    <div
+      role="dialog"
+      aria-label={label}
+      className={cn(
+        'animate-in absolute bottom-full left-0 z-20 mb-2 w-full overflow-hidden',
+        'rounded-xl border border-gray-200 bg-white shadow-xl',
+        MAX_MENU_WIDTH
+      )}
+    >
+      {children}
+    </div>
+  );
+}
+
+function ModelRow({
+  model,
+  selected,
+  onSelect,
+}: {
+  readonly model: AgentModel;
+  readonly selected: boolean;
+  readonly onSelect: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onSelect}
+      aria-current={selected}
+      className={cn(
+        'flex w-full items-start gap-2 rounded-lg px-2 py-2 text-left transition-colors',
+        'hover:bg-gray-50 focus:outline-none focus-visible:bg-gray-50',
+        selected && 'bg-primary-50/60 hover:bg-primary-50/60'
+      )}
+    >
+      <Check
+        className={cn(
+          'mt-0.5 h-3.5 w-3.5 shrink-0',
+          selected ? 'text-primary-500' : 'text-transparent'
+        )}
+        aria-hidden="true"
+      />
+      <span className="min-w-0 flex-1">
+        <span className="block truncate text-sm font-medium text-gray-800">{model.label}</span>
+        {model.description && (
+          <span className="mt-0.5 block text-[11px] leading-snug text-gray-500">
+            {model.description}
+          </span>
+        )}
+      </span>
+    </button>
+  );
+}
+
+/**
+ * A labelled row of single-choice pills, always led by "Auto" — leaving a
+ * control alone is the common case and has to be reachable again once set.
+ *
+ * One line, always. The widest case the catalog produces — seven effort
+ * levels — fits at the panel's default width; drag the panel narrower than
+ * that and the row scrolls rather than wrapping into an orphan.
+ */
+function OptionPills<T extends EffortLevel | ThinkingMode>({
+  label,
+  value,
+  choices,
+  hint,
+  onChange,
+}: {
+  readonly label: string;
+  readonly value: T | undefined;
+  readonly choices: ReadonlyArray<{ value: T; label: string }>;
+  readonly hint?: ReactNode;
+  readonly onChange: (value: T | undefined) => void;
+}) {
+  const items: ReadonlyArray<{ value: T | undefined; label: string }> = [
+    { value: undefined, label: 'Auto' },
+    ...choices,
+  ];
+
+  return (
+    <div>
+      <p className="mb-1.5 text-[11px] font-semibold uppercase tracking-wide text-gray-500">
+        {label}
+      </p>
+      {/* w-max so the pills keep their natural size and the row scrolls past
+          the edge rather than compressing them. */}
+      <div className="scrollbar-hide overflow-x-auto" role="group" aria-label={label}>
+        <div className="flex w-max gap-[3px]">
+          {items.map((item) => (
+            <Pill
+              key={item.label}
+              selected={value === item.value}
+              onClick={() => onChange(item.value)}
+            >
+              {item.label}
+            </Pill>
+          ))}
+        </div>
+      </div>
+      {hint && <p className="mt-1.5 text-[11px] leading-snug text-gray-500">{hint}</p>}
+    </div>
+  );
+}
+
+function Pill({
+  selected,
+  onClick,
+  children,
+}: {
+  readonly selected: boolean;
+  readonly onClick: () => void;
+  readonly children: ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-pressed={selected}
+      className={cn(
+        'shrink-0 whitespace-nowrap rounded-md border px-1.5 py-1 text-[11px] font-medium transition-colors',
+        'focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-500',
+        selected
+          ? 'border-primary-400 bg-primary-50 text-primary-700'
+          : 'border-gray-200 text-gray-600 hover:bg-gray-50'
+      )}
+    >
+      {children}
+    </button>
+  );
+}
+
+/**
+ * Temperature parks mid-range while unset, reading "Auto": the server's own
+ * default isn't published, so the slider shows a neutral position rather than
+ * claiming a number nobody chose. The first drag commits one.
+ */
+function TemperatureControl({
+  value,
+  onChange,
+}: {
+  readonly value: number | undefined;
+  readonly onChange: (value: number | undefined) => void;
+}) {
+  return (
+    <div>
+      <div className="mb-1.5 flex items-baseline justify-between gap-2">
+        <p className="text-[11px] font-semibold uppercase tracking-wide text-gray-500">
+          Temperature
+        </p>
+        {value == null ? (
+          <span className="text-[11px] text-gray-400">Auto</span>
+        ) : (
+          <span className="flex items-baseline gap-2">
+            <span className="text-[11px] tabular-nums text-gray-700">
+              {formatTemperature(value)}
+            </span>
+            <button
+              type="button"
+              onClick={() => onChange(undefined)}
+              className="text-[11px] text-gray-400 underline-offset-2 transition-colors hover:text-gray-600 hover:underline"
+            >
+              Auto
+            </button>
+          </span>
+        )}
+      </div>
+      <Slider
+        value={[value ?? TEMPERATURE_NEUTRAL]}
+        min={TEMPERATURE_MIN}
+        max={TEMPERATURE_MAX}
+        step={TEMPERATURE_STEP}
+        aria-label="Temperature"
+        onValueChange={([next]) => onChange(clampTemperature(next))}
+        className={cn(value == null && 'opacity-60')}
+      />
+    </div>
+  );
+}

--- a/hooks/useAgentModelSelection.ts
+++ b/hooks/useAgentModelSelection.ts
@@ -1,0 +1,143 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useAgentModels, type AgentModelsStatus } from '@/hooks/useAgentModels';
+import {
+  findModel,
+  normalizeGenerationOptions,
+  unknownModel,
+  type AgentModel,
+  type GenerationOptions,
+  type GenerationRequest,
+} from '@/types/notebookModels';
+
+const STORAGE_KEY = 'notebook:agent-model';
+
+/** Stable empty list so consumers can depend on `models` by identity. */
+const NO_MODELS: AgentModel[] = [];
+
+/**
+ * The user's raw choices, kept exactly as they made them. Values a given
+ * model can't take are dropped on the way out rather than on the way in, so
+ * an effort survives a detour through a model that doesn't offer it.
+ */
+interface StoredPreference extends GenerationOptions {
+  ref?: string;
+}
+
+function readPreference(): StoredPreference {
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return {};
+    const parsed: unknown = JSON.parse(raw);
+    return parsed != null && typeof parsed === 'object' ? (parsed as StoredPreference) : {};
+  } catch {
+    // Unparseable, or storage denied — fall back to the server's defaults.
+    return {};
+  }
+}
+
+export interface UseAgentModelSelectionOptions {
+  readonly enabled: boolean;
+  /**
+   * The model the open chat's first turn ran on. A conversation keeps its
+   * model for life, so this — when set — outranks the user's standing choice.
+   */
+  readonly pinnedRef: string | null;
+}
+
+export interface AgentModelSelection {
+  readonly status: AgentModelsStatus;
+  readonly models: AgentModel[];
+  /** The model the next turn runs on, or null while there is no catalog. */
+  readonly model: AgentModel | null;
+  /** The open chat has already committed to a model. */
+  readonly pinned: boolean;
+  /** The user's controls, narrowed to what {@link model} actually accepts. */
+  readonly options: GenerationOptions;
+  readonly selectModel: (ref: string) => void;
+  /** Patch: pass a field as `undefined` to hand it back to the server. */
+  readonly setOptions: (options: GenerationOptions) => void;
+  /** Generation fields for a send, ready to spread into the request body. */
+  readonly request: GenerationRequest;
+}
+
+/**
+ * Which model the next turn runs on, and how.
+ *
+ * The model choice is a browser-level preference — the last one picked is the
+ * one a new chat starts on — while a chat already under way reports its own
+ * pin, which wins. The generation controls stay per-turn either way: the
+ * server re-reads them on every message, so effort and thinking remain live
+ * even on a chat whose model is settled.
+ */
+export function useAgentModelSelection({
+  enabled,
+  pinnedRef,
+}: UseAgentModelSelectionOptions): AgentModelSelection {
+  const { status, catalog } = useAgentModels(enabled);
+  const [preference, setPreference] = useState<StoredPreference>({});
+  const [hydrated, setHydrated] = useState(false);
+
+  // Read after mount, never during initialization: localStorage is unavailable
+  // on the server and a differing first client render would hydrate-mismatch.
+  useEffect(() => {
+    setPreference(readPreference());
+    setHydrated(true);
+  }, []);
+
+  useEffect(() => {
+    if (!hydrated) return;
+    try {
+      window.localStorage.setItem(STORAGE_KEY, JSON.stringify(preference));
+    } catch {
+      // A blocked or full store just means the choice lasts this session.
+    }
+  }, [hydrated, preference]);
+
+  const models = catalog?.models ?? NO_MODELS;
+
+  const model = useMemo(() => {
+    if (catalog == null) return null;
+    // A pinned ref is named even when the catalog no longer carries it, so a
+    // chat on a retired model still says what it is running.
+    if (pinnedRef) return findModel(models, pinnedRef) ?? unknownModel(pinnedRef);
+    return (
+      findModel(models, preference.ref ?? null) ??
+      findModel(models, catalog.default) ??
+      models[0] ??
+      null
+    );
+  }, [catalog, models, pinnedRef, preference.ref]);
+
+  const options = useMemo(
+    () => (model ? normalizeGenerationOptions(model, preference) : {}),
+    [model, preference]
+  );
+
+  const selectModel = useCallback((ref: string) => {
+    setPreference((current) => ({ ...current, ref }));
+  }, []);
+
+  const setOptions = useCallback((next: GenerationOptions) => {
+    setPreference((current) => ({ ...current, ...next }));
+  }, []);
+
+  const request = useMemo<GenerationRequest>(() => {
+    if (model == null) return {};
+    // Naming the pinned model again would be accepted, but only while nothing
+    // raced us. Leaving it out lets the server answer from its own record.
+    return { ...(pinnedRef == null && { model: model.ref }), ...options };
+  }, [model, options, pinnedRef]);
+
+  return {
+    status,
+    models,
+    model,
+    pinned: pinnedRef != null,
+    options,
+    selectModel,
+    setOptions,
+    request,
+  };
+}

--- a/hooks/useAgentModels.ts
+++ b/hooks/useAgentModels.ts
@@ -1,0 +1,66 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { AgentModelService } from '@/services/agentModel.service';
+import type { AgentModelCatalog } from '@/types/notebookModels';
+
+/**
+ * `loading` until the first fetch settles; `unavailable` for every failure —
+ * the gate, a network blip, a backend without the endpoint. All of them mean
+ * the same thing to the UI: no picker, and turns run on the server's default.
+ */
+export type AgentModelsStatus = 'loading' | 'ok' | 'unavailable';
+
+export interface UseAgentModelsResult {
+  readonly status: AgentModelsStatus;
+  readonly catalog: AgentModelCatalog | null;
+}
+
+// The catalog is per-deployment, not per-note or per-user-action: one fetch
+// serves every panel this session. Only successes are cached, so a transient
+// failure is retried by the next mount rather than disabling the picker for
+// the rest of the session.
+let cachedCatalog: AgentModelCatalog | null = null;
+let inFlight: Promise<AgentModelCatalog> | null = null;
+
+function loadCatalog(): Promise<AgentModelCatalog> {
+  if (cachedCatalog) return Promise.resolve(cachedCatalog);
+  if (!inFlight) {
+    inFlight = AgentModelService.listModels()
+      .then((catalog) => {
+        cachedCatalog = catalog;
+        return catalog;
+      })
+      .finally(() => {
+        inFlight = null;
+      });
+  }
+  return inFlight;
+}
+
+/** The models this user may select. Fetched once, when something needs it. */
+export function useAgentModels(enabled: boolean): UseAgentModelsResult {
+  const [result, setResult] = useState<UseAgentModelsResult>(() =>
+    cachedCatalog ? { status: 'ok', catalog: cachedCatalog } : { status: 'loading', catalog: null }
+  );
+
+  useEffect(() => {
+    if (!enabled || result.catalog != null) return;
+    let cancelled = false;
+    loadCatalog().then(
+      (catalog) => {
+        if (!cancelled) setResult({ status: 'ok', catalog });
+      },
+      () => {
+        // Deliberately terminal for this mount: the deps can't change back, so
+        // a failing endpoint is asked once, not once per render.
+        if (!cancelled) setResult({ status: 'unavailable', catalog: null });
+      }
+    );
+    return () => {
+      cancelled = true;
+    };
+  }, [enabled, result.catalog]);
+
+  return result;
+}

--- a/hooks/useAgentModels.ts
+++ b/hooks/useAgentModels.ts
@@ -25,16 +25,14 @@ let inFlight: Promise<AgentModelCatalog> | null = null;
 
 function loadCatalog(): Promise<AgentModelCatalog> {
   if (cachedCatalog) return Promise.resolve(cachedCatalog);
-  if (!inFlight) {
-    inFlight = AgentModelService.listModels()
-      .then((catalog) => {
-        cachedCatalog = catalog;
-        return catalog;
-      })
-      .finally(() => {
-        inFlight = null;
-      });
-  }
+  inFlight ??= AgentModelService.listModels()
+    .then((catalog) => {
+      cachedCatalog = catalog;
+      return catalog;
+    })
+    .finally(() => {
+      inFlight = null;
+    });
   return inFlight;
 }
 

--- a/hooks/useNotebookChat.ts
+++ b/hooks/useNotebookChat.ts
@@ -21,6 +21,7 @@ import {
   type NotebookChat,
   type NotebookChatListItem,
 } from '@/types/notebookChat';
+import type { GenerationRequest } from '@/types/notebookModels';
 
 /** Fallback poll cadence while a turn runs; the socket nudge usually wins. */
 const POLL_INTERVAL_MS = 5000;
@@ -255,7 +256,14 @@ export interface UseNotebookChatResult {
   isFinishing: boolean;
   pendingSend: PendingSend | null;
   socketStatus: ChatSocketStatus;
-  send: (text: string) => Promise<SendOutcome>;
+  /**
+   * The model this conversation committed to on its first turn, or null while
+   * it is still free to take one. Mirrors the server's own rule: the earliest
+   * execution carrying a model owns the conversation, and a later turn naming
+   * a different one is refused.
+   */
+  pinnedModelRef: string | null;
+  send: (text: string, generation?: GenerationRequest) => Promise<SendOutcome>;
   cancel: () => Promise<void>;
   rename: (title: string) => Promise<boolean>;
   refetch: () => void;
@@ -357,6 +365,11 @@ export function useNotebookChat({
 
   const latestExecution = useMemo(
     () => (chat && chat.executions.length > 0 ? chat.executions[chat.executions.length - 1] : null),
+    [chat]
+  );
+
+  const pinnedModelRef = useMemo(
+    () => (chat?.executions ?? []).find((execution) => execution.model)?.model ?? null,
     [chat]
   );
 
@@ -467,12 +480,12 @@ export function useNotebookChat({
   });
 
   const send = useCallback(
-    async (text: string): Promise<SendOutcome> => {
+    async (text: string, generation?: GenerationRequest): Promise<SendOutcome> => {
       if (noteId == null || chatId == null) return { ok: false, reason: 'error' };
       const epoch = epochRef.current;
       setPendingSend({ text, executionId: null });
       try {
-        const response = await NotebookChatService.sendMessage(noteId, chatId, text);
+        const response = await NotebookChatService.sendMessage(noteId, chatId, text, generation);
         if (epoch === epochRef.current) {
           setPendingSend({ text, executionId: response.execution_id });
           fetchChat('live');
@@ -542,6 +555,7 @@ export function useNotebookChat({
     isFinishing,
     pendingSend,
     socketStatus,
+    pinnedModelRef,
     send,
     cancel,
     rename,

--- a/services/agentModel.service.ts
+++ b/services/agentModel.service.ts
@@ -1,0 +1,21 @@
+import { ApiClient } from './client';
+import {
+  toAgentModelCatalog,
+  type AgentModelCatalog,
+  type AgentModelCatalogResponse,
+} from '@/types/notebookModels';
+
+/**
+ * The user-selectable model catalog, shared by every agent workflow that
+ * takes a model (the notebook assistant today, proposal drafting next).
+ *
+ * Gated exactly like those workflows, so a 401/403 here means the same thing
+ * as one on the chat itself: this user has no assistant, and the picker
+ * simply isn't there.
+ */
+export class AgentModelService {
+  static async listModels(): Promise<AgentModelCatalog> {
+    const response = await ApiClient.get<AgentModelCatalogResponse>('/api/research_ai/models/');
+    return toAgentModelCatalog(response);
+  }
+}

--- a/services/notebookChat.service.ts
+++ b/services/notebookChat.service.ts
@@ -6,6 +6,7 @@ import type {
   NotebookChatListItem,
   SendMessageResponse,
 } from '@/types/notebookChat';
+import type { GenerationRequest } from '@/types/notebookModels';
 import { ID } from '@/types/root';
 
 /**
@@ -46,10 +47,21 @@ export class NotebookChatService {
    * Starts an asynchronous turn. 202 means the user message is already recorded
    * server-side. Throws ApiError with status 409 while a previous turn is still
    * running (one turn per chat), 400 for empty/oversized messages.
+   *
+   * `generation` carries the model and its controls; every field is optional
+   * and an omitted one runs the server's configured default. `model` is only
+   * honoured on a conversation's first turn — naming a different one later is
+   * a 400, so send it only while the conversation is still unpinned.
    */
-  static async sendMessage(noteId: ID, chatId: ID, message: string): Promise<SendMessageResponse> {
+  static async sendMessage(
+    noteId: ID,
+    chatId: ID,
+    message: string,
+    generation?: GenerationRequest
+  ): Promise<SendMessageResponse> {
     return ApiClient.post<SendMessageResponse>(`${this.basePath(noteId)}${chatId}/messages/`, {
       message,
+      ...generation,
     });
   }
 

--- a/types/notebookChat.ts
+++ b/types/notebookChat.ts
@@ -134,6 +134,13 @@ export interface ChatExecution {
   id: number;
   attempt: number;
   status: ExecutionStatus;
+  /**
+   * Provider-prefixed ref of the model this turn was submitted with (e.g.
+   * `claude_platform:claude-opus-5`). Empty on turns recorded before the
+   * server tracked one; a conversation's first non-empty value is the model
+   * every later turn on it runs, and cannot be changed.
+   */
+  model: string;
   /** The user message that started this turn. */
   trigger_message_id: number | null;
   retry_of_id: number | null;

--- a/types/notebookModels.ts
+++ b/types/notebookModels.ts
@@ -1,0 +1,261 @@
+/**
+ * Types for the agent model catalog (`GET /api/research_ai/models/`) and the
+ * per-turn generation controls a selected model accepts.
+ *
+ * Wire shapes stay snake_case-free but verbatim, like `types/notebookChat.ts`.
+ *
+ * The catalog says *what* each model accepts (its `capabilities`); the rules
+ * below say which *combinations* the backend will take. They mirror
+ * `research_ai.services.agent.model_capabilities.validate_generation_options`,
+ * so the picker can only ever assemble a legal request — an illegal pairing
+ * is a control that isn't offered, never a 400 on send.
+ */
+
+/** Provider names the catalog uses; the ref prefix is one of these. */
+export const CLAUDE_PLATFORM = 'claude_platform';
+export const OPENROUTER = 'openrouter';
+
+export const EFFORT_LEVELS = ['none', 'minimal', 'low', 'medium', 'high', 'xhigh', 'max'] as const;
+export type EffortLevel = (typeof EFFORT_LEVELS)[number];
+
+export const THINKING_MODES = ['adaptive', 'disabled'] as const;
+export type ThinkingMode = (typeof THINKING_MODES)[number];
+
+export const TEMPERATURE_MIN = 0;
+export const TEMPERATURE_MAX = 2;
+export const TEMPERATURE_STEP = 0.05;
+/** Where the slider parks while temperature is unset — mid-range, sent to nobody. */
+export const TEMPERATURE_NEUTRAL = 1;
+
+export const EFFORT_LABELS: Record<EffortLevel, string> = {
+  none: 'None',
+  minimal: 'Minimal',
+  low: 'Low',
+  medium: 'Medium',
+  high: 'High',
+  xhigh: 'Very high',
+  max: 'Max',
+};
+
+export const THINKING_LABELS: Record<ThinkingMode, string> = {
+  adaptive: 'On',
+  disabled: 'Off',
+};
+
+/** Optional request controls one model accepts, straight from the catalog. */
+export interface AgentModelCapabilities {
+  /** Selectable effort levels; empty means the model takes no effort at all. */
+  readonly effort: EffortLevel[];
+  /** Selectable thinking modes; empty means the model takes no thinking flag. */
+  readonly thinking: ThinkingMode[];
+  readonly temperature: boolean;
+}
+
+export interface AgentModel {
+  /** Canonical `<provider>:<model id>` ref — exactly what a request sends. */
+  readonly ref: string;
+  readonly label: string;
+  readonly description: string;
+  readonly provider: string;
+  readonly capabilities: AgentModelCapabilities;
+}
+
+export interface AgentModelCatalog {
+  /** The ref that runs when a request names no model. */
+  readonly default: string;
+  /** Server-ordered: strongest first within each family. */
+  readonly models: AgentModel[];
+}
+
+/**
+ * Per-turn model controls. Every field is optional and an omitted one means
+ * "whatever the server is configured to do", which is the resting state of
+ * the picker — nothing is sent until the user asks for it.
+ */
+export interface GenerationOptions {
+  readonly effort?: EffortLevel;
+  readonly thinking?: ThinkingMode;
+  readonly temperature?: number;
+}
+
+/** The generation fields of a send, ready to spread into the request body. */
+export interface GenerationRequest extends GenerationOptions {
+  /**
+   * Omitted once the conversation is pinned: the server keeps the model its
+   * first turn ran on and rejects an attempt to change it.
+   */
+  readonly model?: string;
+}
+
+/** Raw catalog response — `capabilities` arrives as open-ended strings. */
+export interface AgentModelCatalogResponse {
+  default?: string;
+  models?: Array<{
+    ref?: string;
+    label?: string;
+    description?: string;
+    provider?: string;
+    capabilities?: {
+      effort?: string[];
+      thinking?: string[];
+      temperature?: boolean;
+    };
+  }>;
+}
+
+function isEffortLevel(value: string): value is EffortLevel {
+  return (EFFORT_LEVELS as readonly string[]).includes(value);
+}
+
+function isThinkingMode(value: string): value is ThinkingMode {
+  return (THINKING_MODES as readonly string[]).includes(value);
+}
+
+/** The provider half of a ref; the whole ref when it carries no prefix. */
+export function providerOf(ref: string): string {
+  const separator = ref.indexOf(':');
+  return separator === -1 ? ref : ref.slice(0, separator);
+}
+
+/** The model-id half of a ref, e.g. `openai/gpt-5.6-sol`. */
+export function modelIdOf(ref: string): string {
+  const separator = ref.indexOf(':');
+  return separator === -1 ? ref : ref.slice(separator + 1);
+}
+
+/**
+ * Narrow a catalog response, dropping controls this client has no copy for.
+ * A newer backend adding an effort level shows the levels we do know rather
+ * than an unlabelled pill, and a malformed entry drops out entirely.
+ */
+export function toAgentModelCatalog(response: AgentModelCatalogResponse): AgentModelCatalog {
+  const models: AgentModel[] = [];
+  for (const model of response.models ?? []) {
+    if (!model?.ref) continue;
+    models.push({
+      ref: model.ref,
+      label: model.label?.trim() || modelIdOf(model.ref),
+      description: model.description ?? '',
+      provider: model.provider || providerOf(model.ref),
+      capabilities: {
+        effort: (model.capabilities?.effort ?? []).filter(isEffortLevel),
+        thinking: (model.capabilities?.thinking ?? []).filter(isThinkingMode),
+        temperature: model.capabilities?.temperature === true,
+      },
+    });
+  }
+  return { default: response.default ?? '', models };
+}
+
+export function findModel(models: AgentModel[], ref: string | null): AgentModel | null {
+  if (!ref) return null;
+  return models.find((model) => model.ref === ref) ?? null;
+}
+
+/**
+ * Display stand-in for a ref the catalog doesn't offer — a chat pinned to a
+ * model since retired, or one whose provider lost its credentials. Its
+ * capabilities read empty, so it is named but never configured.
+ */
+export function unknownModel(ref: string): AgentModel {
+  return {
+    ref,
+    label: modelIdOf(ref) || ref,
+    description: '',
+    provider: providerOf(ref),
+    capabilities: { effort: [], thinking: [], temperature: false },
+  };
+}
+
+/**
+ * Effort levels legal alongside `thinking`.
+ *
+ * OpenRouter maps effort onto one reasoning budget, so the two controls can
+ * contradict each other: with thinking off the only effort it will take is
+ * the one asking for none, and with thinking on that same level is the
+ * contradiction. Claude Opus 5 separately refuses its top two levels with
+ * thinking off.
+ */
+export function availableEffortLevels(
+  model: AgentModel,
+  thinking: ThinkingMode | undefined
+): EffortLevel[] {
+  let levels: EffortLevel[] = model.capabilities.effort;
+  if (model.provider === OPENROUTER) {
+    if (thinking === 'disabled') levels = levels.filter((level) => level === 'none');
+    if (thinking === 'adaptive') levels = levels.filter((level) => level !== 'none');
+  }
+  if (thinking === 'disabled' && modelIdOf(model.ref).toLowerCase().includes('opus-5')) {
+    levels = levels.filter((level) => level !== 'xhigh' && level !== 'max');
+  }
+  return levels;
+}
+
+/**
+ * Whether a temperature may accompany `thinking`. Claude Platform rejects
+ * sampling params on any model that reasons unless reasoning is explicitly
+ * turned off — leaving thinking unset is not enough for it.
+ */
+export function temperatureAvailable(
+  model: AgentModel,
+  thinking: ThinkingMode | undefined
+): boolean {
+  if (!model.capabilities.temperature) return false;
+  if (model.provider === CLAUDE_PLATFORM && model.capabilities.thinking.length > 0) {
+    return thinking === 'disabled';
+  }
+  return true;
+}
+
+/** Snap to the slider's step and the server's finite 0–2 range. */
+export function clampTemperature(value: number): number | undefined {
+  if (!Number.isFinite(value)) return undefined;
+  const clamped = Math.min(TEMPERATURE_MAX, Math.max(TEMPERATURE_MIN, value));
+  return Number((Math.round(clamped / TEMPERATURE_STEP) * TEMPERATURE_STEP).toFixed(2));
+}
+
+export function formatTemperature(value: number): string {
+  return value.toFixed(2);
+}
+
+/**
+ * Drop every option `model` cannot carry, in dependency order: thinking
+ * first, since it decides which efforts and whether a temperature survive.
+ *
+ * Callers keep the user's raw choices and normalize on the way out, so an
+ * effort a model can't take comes back when they return to one that can.
+ */
+export function normalizeGenerationOptions(
+  model: AgentModel,
+  options: GenerationOptions
+): GenerationOptions {
+  const thinking =
+    options.thinking != null && model.capabilities.thinking.includes(options.thinking)
+      ? options.thinking
+      : undefined;
+  const effort =
+    options.effort != null && availableEffortLevels(model, thinking).includes(options.effort)
+      ? options.effort
+      : undefined;
+  const temperature =
+    options.temperature != null && temperatureAvailable(model, thinking)
+      ? clampTemperature(options.temperature)
+      : undefined;
+  return {
+    ...(effort != null && { effort }),
+    ...(thinking != null && { thinking }),
+    ...(temperature != null && { temperature }),
+  };
+}
+
+/**
+ * One-line summary of what has been changed from the defaults, for the
+ * picker's button and its tooltip. Empty when nothing has.
+ */
+export function summarizeGenerationOptions(options: GenerationOptions): string[] {
+  const parts: string[] = [];
+  if (options.effort) parts.push(`${EFFORT_LABELS[options.effort]} effort`);
+  if (options.thinking) parts.push(`Thinking ${THINKING_LABELS[options.thinking].toLowerCase()}`);
+  if (options.temperature != null) parts.push(`Temp ${formatTemperature(options.temperature)}`);
+  return parts;
+}


### PR DESCRIPTION
Supersedes #1066, which took a different shape. Built against the backend in
ResearchHub/researchhub-backend#4040 (model catalog) and ResearchHub/researchhub-backend#4049
(effort, adaptive thinking, temperature).

## What this adds

Two dropdowns in the assistant composer: which model answers, and how hard it works.

They are separate controls because they lock separately. A conversation keeps the model
its first turn ran on, so the model picker shuts for good once a turn has run — greyed
out, with the model still readable and a tooltip saying why. Effort, thinking and
temperature are re-read by the server on every message, so they stay live for the life
of the chat.

The catalog comes from `GET /api/research_ai/models/`, which reports what each model
accepts. Only controls a model can honor are drawn:

| Model | Effort | Extended thinking | Temperature |
|---|---|---|---|
| Claude Opus 5 | Low → Max | Auto / On / Off | absent |
| Claude Haiku 4.5 | absent | absent | present |
| Gemini 3.1 Pro | Low / Medium / High | absent (always reasons) | present |
| GPT-5.6 Sol | None → Max | Auto / On / Off | absent |

...and only in combinations the model will accept. Claude refuses a temperature to a
model that is still reasoning; OpenRouter refuses an effort alongside disabled thinking;
Opus 5 refuses its top two effort levels with thinking off. Those controls are absent or
narrowed live rather than rejected on send — `types/notebookModels.ts` mirrors
`validate_generation_options`, so the picker can only ever assemble a legal request.

Every control leads with **Auto**, which sends nothing and lets the server decide. That
is the resting state: an untouched picker adds no fields to the request.

Model choice persists per browser as the starting point for a new chat. A chat already
under way reports its own pin, which outranks it.

## Wire behaviour

```
first turn   {"message": "…", "model": "openrouter:openai/gpt-5.6-sol", "effort": "low"}
later turns  {"message": "…", "effort": "medium", "thinking": "disabled"}
```

`model` goes out only while the conversation is unpinned — naming a different one later
is a 400, so it is omitted rather than repeated.

## Verified

Driven through the real UI against a local backend: catalog fetch, per-model control
rendering, all four cross-field constraints, both wire payloads above, and a live turn
that came back `SUCCEEDED` on `openrouter:openai/gpt-5.6-sol` with the conversation
pinned and the model dropdown locked.

Layout checked at the panel's default 420px width, where the widest case — seven effort
levels — sits on one line with 8px to spare, and at its 360px minimum, where the row
scrolls rather than wrapping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)