### PR TITLE
Removing top header on Notifications page

### DIFF
--- a/app/notifications/loading.tsx
+++ b/app/notifications/loading.tsx
@@ -1,25 +1,11 @@
 import { PageLayout } from '@/app/layouts/PageLayout';
-import { MainPageHeader } from '@/components/ui/MainPageHeader';
-import { Icon } from '@/components/ui/icons';
 import { NotificationSkeletonList } from '@/components/skeletons/NotificationSkeleton';
 
 export default function NotificationsLoading() {
   return (
-    <PageLayout>
-      <div className="w-full">
-        <div className="mb-4">
-          <MainPageHeader
-            icon={<Icon name="notification" size={24} className="text-gray-900" />}
-            title="Notifications"
-            subtitle="Stay updated with your latest activity"
-            showTitle={false}
-          />
-        </div>
-
-        <div className="py-6">
-          <NotificationSkeletonList />
-        </div>
-      </div>
+    <PageLayout contentWidth="narrow">
+      <h1 className="sr-only">Notifications</h1>
+      <NotificationSkeletonList />
     </PageLayout>
   );
 }

--- a/app/notifications/page.tsx
+++ b/app/notifications/page.tsx
@@ -3,7 +3,6 @@
 import { useEffect } from 'react';
 import { useInView } from 'react-intersection-observer';
 import { PageLayout } from '@/app/layouts/PageLayout';
-import { HeroHeader } from '@/components/ui/HeroHeader';
 import { useNotifications } from '@/contexts/NotificationContext';
 import { NotificationList } from '@/components/Notification/NotificationList';
 import { NotificationSkeletonList } from '@/components/skeletons/NotificationSkeleton';
@@ -40,25 +39,15 @@ export default function NotificationsPage() {
   });
 
   return (
-    <PageLayout
-      rightSidebar={false}
-      topBanner={
-        <HeroHeader title="Notifications" subtitle="Stay updated with your latest activity" />
-      }
-    >
-      <div className="max-w-3xl mx-auto">
-        <NotificationList
-          notifications={notificationData.results}
-          loading={loading}
-          error={error}
-        />
+    <PageLayout rightSidebar={false} contentWidth="narrow">
+      <h1 className="sr-only">Notifications</h1>
+      <NotificationList notifications={notificationData.results} loading={loading} error={error} />
 
-        {isLoadingMore && <NotificationSkeletonList count={5} />}
+      {isLoadingMore && <NotificationSkeletonList count={5} />}
 
-        {!loading && !isLoadingMore && notificationData.next && (
-          <div ref={sentinelRef} className="h-10" aria-hidden="true" />
-        )}
-      </div>
+      {!loading && !isLoadingMore && notificationData.next && (
+        <div ref={sentinelRef} className="h-10" aria-hidden="true" />
+      )}
     </PageLayout>
   );
 }

--- a/app/notifications/page.tsx
+++ b/app/notifications/page.tsx
@@ -39,7 +39,7 @@ export default function NotificationsPage() {
   });
 
   return (
-    <PageLayout rightSidebar={false} contentWidth="narrow">
+    <PageLayout rightSidebar={true} contentWidth="narrow">
       <h1 className="sr-only">Notifications</h1>
       <NotificationList notifications={notificationData.results} loading={loading} error={error} />
 


### PR DESCRIPTION
## Overview ## 

This PR removes the top header on the Notifications page, and adds the right side bar so page width is consistent with the home page.