### PR TITLE
Adding Peer Review Clickthrough for Activity Feed

### DIFF
--- a/components/Activity/lib/activityWork.utils.ts
+++ b/components/Activity/lib/activityWork.utils.ts
@@ -90,6 +90,12 @@ function resolveWorkTab(entry: FeedEntry, workContentType?: ContentType): Activi
     case 'bounty_payout':
       return 'bounties';
     case 'comment_published':
+      if (
+        entry.content.contentType === 'COMMENT' &&
+        entry.content.comment.commentType === 'REVIEW'
+      ) {
+        return 'reviews';
+      }
       return shouldLinkToUpdatesTab(entry, workContentType) ? 'updates' : 'conversation';
     default:
       return undefined;


### PR DESCRIPTION
## Overview ##

This PR fixes a regression in the activity feed where Peer Reviews, when clicked through, ended up in the Conversations tab rather than the Peer Review tab.