### PR TITLE
Remove shield control from grant Proposals tab

### DIFF
--- a/components/work/WorkHeader/WorkHeaderGrant.tsx
+++ b/components/work/WorkHeader/WorkHeaderGrant.tsx
@@ -9,8 +9,6 @@ import { Tabs } from '@/components/ui/Tabs';
 import { SubmitProposalTooltip } from '@/components/tooltips/SubmitProposalTooltip';
 import { useGrantTab, type GrantBannerTab } from '@/components/Funding/GrantPageContent';
 import { useFundraises } from '@/contexts/FundraiseContext';
-import { useUser } from '@/contexts/UserContext';
-import { IncludePrivateProposalsControl } from '@/components/Funding/IncludePrivateProposalsControl';
 import type { GrantApplicationVisibility } from '@/types/grant';
 import { WorkHeader } from './WorkHeader';
 import { WorkHeaderGrantEyebrow } from './WorkHeaderGrantEyebrow';
@@ -43,9 +41,6 @@ export function WorkHeaderGrant({
   const [isApplyModalOpen, setIsApplyModalOpen] = useState(false);
   const { activeTab, setActiveTab, activity } = useGrantTab();
   const { proposalCount } = useFundraises();
-  const { user } = useUser();
-
-  const canSeePrivateControl = !!user?.isModerator || !!user?.authorProfile?.isHubEditor;
 
   const handleTabChange = useCallback(
     (tabId: string) => setActiveTab(tabId as GrantBannerTab),
@@ -136,16 +131,7 @@ export function WorkHeaderGrant({
   ];
 
   const tabs = (
-    <Tabs
-      tabs={grantTabs}
-      activeTab={activeTab}
-      onTabChange={handleTabChange}
-      rightContent={
-        canSeePrivateControl && activeTab === 'proposals' ? (
-          <IncludePrivateProposalsControl locked />
-        ) : undefined
-      }
-    />
+    <Tabs tabs={grantTabs} activeTab={activeTab} onTabChange={handleTabChange} />
   );
 
   return (


### PR DESCRIPTION
## Summary
- Removes the locked “Show private proposals” shield icon from the RFPs page Proposals tab
