### PR TITLE
Bugfix: Funded Proposal X times text fix

### DIFF
--- a/components/Activity/cards/ActivityFundingGroupCard.tsx
+++ b/components/Activity/cards/ActivityFundingGroupCard.tsx
@@ -60,19 +60,7 @@ const FunderName: FC<{ funder: AuthorProfile }> = ({ funder }) => {
   );
 };
 
-const FunderSummary: FC<{ funders: AuthorProfile[]; contributionCount: number }> = ({
-  funders,
-  contributionCount,
-}) => {
-  if (funders.length === 1) {
-    return (
-      <>
-        <FunderName funder={funders[0]} />
-        <span className="text-gray-500">{` funded this proposal ${contributionCount} times`}</span>
-      </>
-    );
-  }
-
+const FunderSummary: FC<{ funders: AuthorProfile[] }> = ({ funders }) => {
   const named = funders.slice(0, MAX_NAMED_FUNDERS);
   const remaining = funders.length - named.length;
 
@@ -92,7 +80,7 @@ const FunderSummary: FC<{ funders: AuthorProfile[]; contributionCount: number }>
       {remaining > 0 && (
         <span className="text-gray-500">{` and ${remaining} ${remaining === 1 ? 'other' : 'others'}`}</span>
       )}
-      <span className="text-gray-500"> funded this proposal for</span>
+      <span className="text-gray-500"> funded this proposal.</span>
     </>
   );
 };
@@ -102,7 +90,7 @@ const FunderSummary: FC<{ funders: AuthorProfile[]; contributionCount: number }>
  * a funder facepile, the summed contribution, and one work card.
  */
 export const ActivityFundingGroupCard: FC<ActivityFundingGroupCardProps> = ({ row }) => {
-  const { entries, latestEntry, work, funders, contributionCount, totals } = row;
+  const { entries, latestEntry, work, funders, totals } = row;
   const { showUSD } = useCurrencyPreference();
   const { exchangeRate } = useExchangeRate();
   const { updateLastClickedEntryId } = useNavigation();
@@ -141,7 +129,7 @@ export const ActivityFundingGroupCard: FC<ActivityFundingGroupCardProps> = ({ ro
         </div>
 
         <div className="min-w-0 flex-1 pt-1 text-sm leading-6">
-          <FunderSummary funders={funders} contributionCount={contributionCount} />{' '}
+          <FunderSummary funders={funders} />{' '}
           <ContributionAmount contribution={total} className="align-middle" />
         </div>
       </div>

--- a/components/Activity/lib/activityDisplay.utils.ts
+++ b/components/Activity/lib/activityDisplay.utils.ts
@@ -129,7 +129,7 @@ function getDefaultActivityMessage(entry: FeedEntry): ActivityHeaderMessage {
   }
 
   if (entry.contentType === 'USDFUNDRAISECONTRIBUTION' || entry.contentType === 'PURCHASE') {
-    return { actor, verb: 'funded proposal for' };
+    return { actor, verb: 'funded this proposal.' };
   }
 
   return {

--- a/components/Activity/lib/activityGrouping.utils.ts
+++ b/components/Activity/lib/activityGrouping.utils.ts
@@ -42,8 +42,6 @@ export interface ActivityFundingGroupRow {
   work: ActivityWork;
   /** Distinct funders, in the order they appear in the feed. */
   funders: AuthorProfile[];
-  /** Exceeds `funders.length` when someone contributed more than once. */
-  contributionCount: number;
   totals: ActivityFundingTotals;
 }
 
@@ -195,7 +193,6 @@ function toFundingGroupRow(groupMembers: GroupCandidate[]): ActivityFundingGroup
     latestEntry: latest.entry,
     work: latest.work,
     funders,
-    contributionCount: groupMembers.length,
     totals,
   };
 }


### PR DESCRIPTION
## Overview ##

This PR corrects the text for a proposal in an activity feed when a user funds a proposal mutliple times, simply stating "funded this proposal." rather than specifying how many times they have funded it.

## Screenshots ##

Before:
<img width="718" height="379" alt="image" src="https://github.com/user-attachments/assets/1d77adad-0087-49d6-adbb-ef833e42ad2f" />

After:
<img width="711" height="352" alt="image" src="https://github.com/user-attachments/assets/6852d665-3557-4e99-8f9c-4e258289a49d" />
