### PR TITLE
Show the notebook assistant to all signed-in users

### DIFF
--- a/components/Notebook/NoteEditorLayout.tsx
+++ b/components/Notebook/NoteEditorLayout.tsx
@@ -111,7 +111,7 @@ export function NoteEditorLayout({ onAgentChatDockedChange }: NoteEditorLayoutPr
     searchParams?.get('tab') === 'details' ? 'details' : 'document'
   );
 
-  // ---- AI assistant chat (gated to hub editors and moderators) ----
+  // ---- AI assistant chat ----
   const [isAgentChatOpen, setIsAgentChatOpen] = useState(false);
   // Flipped when the server denies access (the gate can change server-side);
   // hides the entry point while this note is open.
@@ -142,9 +142,8 @@ export function NoteEditorLayout({ onAgentChatDockedChange }: NoteEditorLayoutPr
   const isChangelog = isChangelogNote(note);
   const isChangelogAccessDenied = isChangelog && !user?.isModerator;
 
-  const isHubEditorOrModerator = Boolean(user?.moderator) || (user?.editorOfHubs?.length ?? 0) > 0;
   const showAgentChat =
-    isHubEditorOrModerator &&
+    Boolean(user) &&
     !agentChatUnavailable &&
     // Changelogs are moderator-only: the page renders Note Not Found in place
     // of the document, so the assistant must not mount over it.

--- a/hooks/useNotebookChatSocket.ts
+++ b/hooks/useNotebookChatSocket.ts
@@ -7,7 +7,7 @@ import { useReconnectingSocket, type SocketStatus } from './useReconnectingSocke
 
 /**
  * Server-defined close codes that mean reconnecting is pointless for this
- * chat: unauthenticated (4401), not editor/moderator (4403), chat/note not
+ * chat: unauthenticated (4401), Research AI access blocked (4403), chat/note not
  * found or not yours (4404). REST polling remains the fallback, and the REST
  * layer surfaces the matching access error to the UI.
  */


### PR DESCRIPTION
Show the notebook assistant entry point to all signed-in users by removing the moderator-or-hub-editor visibility requirement. Existing note loading, legacy-note, changelog access, and server-denial conditions still apply. Update the WebSocket close-code comment to reflect the remaining account access check.

Validation: Prettier and diff whitespace checks pass. Full frontend type checks and browser verification were not run because project dependencies are not installed in the clean checkout.

Companion backend PR: https://github.com/ResearchHub/researchhub-backend/pull/4111
